### PR TITLE
APT: Configurable Packages index compression (gzip/zstd/bzip2/none)

### DIFF
--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -34,7 +34,7 @@ The APT plugin consists of:
 - ✅ InRelease file preservation (GPG-signed)
 - ✅ GPG signature generation for filtered mode (InRelease, Release.gpg)
 - ✅ Multi-component and multi-architecture layouts
-- ✅ Gzip compression support
+- ✅ Configurable Packages index compression (gzip, zstandard, bzip2, none)
 - ✅ Dependency metadata (Depends, Recommends, Suggests, Conflicts, etc.)
 
 **Planned:**
@@ -157,6 +157,37 @@ The `apt` section in repository configuration supports these options:
 - **`flat_repository`** (boolean, default: false)
   - Support for flat repositories (no dists/ structure)
   - Rare, used by some very old repositories
+
+## Metadata Compression
+
+In filtered mode Chantal regenerates the `Packages` index. The uncompressed
+`Packages` file is always written, alongside one compressed variant controlled
+by the top-level `metadata.compression` option:
+
+```yaml
+repositories:
+  - id: ubuntu-jammy-filtered
+    type: apt
+    feed: http://archive.ubuntu.com/ubuntu
+    mode: filtered
+    apt:
+      distribution: jammy
+      components: [main]
+      architectures: [amd64]
+    metadata:
+      compression: zstandard   # gzip (default) | zstandard | bzip2 | none
+```
+
+| Value | Output | Notes |
+|-------|--------|-------|
+| `auto` (default) | `Packages` + `Packages.gz` | `auto` maps to gzip for APT |
+| `gzip` | `Packages` + `Packages.gz` | Universally supported |
+| `zstandard` | `Packages` + `Packages.zst` | Supported by modern apt (Ubuntu) |
+| `bzip2` | `Packages` + `Packages.bz2` | Legacy |
+| `none` | `Packages` only | Uncompressed index only |
+
+All generated variants are listed with their checksums in the `Release` file, so
+clients automatically pick a format they support.
 
 ## Publishing
 

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -6,7 +6,6 @@ APT/DEB repository publisher plugin.
 This module implements publishing for APT repositories with Debian package metadata.
 """
 
-import gzip
 import hashlib
 import shutil
 from datetime import datetime, timezone
@@ -19,6 +18,11 @@ from chantal.core.storage import StorageManager
 from chantal.db.models import ContentItem, Repository, RepositoryFile, RepositoryMode, Snapshot
 from chantal.plugins.apt.gpg import GpgSigner, GpgSigningError
 from chantal.plugins.base import PublisherPlugin
+from chantal.plugins.rpm.compression import CompressionFormat, compress_file, get_extension
+
+# Compressed Packages index variants that may exist in a component directory.
+# Used when collecting checksums for the Release file.
+_PACKAGES_VARIANTS = ("Packages", "Packages.gz", "Packages.xz", "Packages.zst", "Packages.bz2")
 
 
 class AptPublisher(PublisherPlugin):
@@ -137,6 +141,9 @@ class AptPublisher(PublisherPlugin):
         # Group packages by component and architecture
         packages_by_component_arch = self._group_packages_by_component_arch(packages)
 
+        # Resolve the compression format for generated Packages indices.
+        compression = self._resolve_compression()
+
         # Publish packages for each component/architecture combination
         published_metadata = []
         for (component, architecture), component_packages in packages_by_component_arch.items():
@@ -153,16 +160,17 @@ class AptPublisher(PublisherPlugin):
                 component_packages, component_arch_path, component, architecture
             )
 
-            # Generate Packages file
-            packages_file = self._generate_packages_file(
-                component_packages, component_arch_path, component, architecture
+            # Generate Packages file(s) (uncompressed + configured compression)
+            generated = self._generate_packages_file(
+                component_packages, component_arch_path, component, architecture, compression
             )
 
             published_metadata.append(
                 {
                     "component": component,
                     "architecture": architecture,
-                    "packages_file": packages_file,
+                    # Uncompressed Packages path; its parent is the component dir.
+                    "packages_file": generated[0],
                 }
             )
 
@@ -189,6 +197,20 @@ class AptPublisher(PublisherPlugin):
                     "    Example: deb [trusted=yes] http://mirror/ubuntu jammy main restricted universe multiverse"
                 )
                 print("    Configure a 'gpg' section to publish signed metadata instead.")
+
+    def _resolve_compression(self) -> CompressionFormat:
+        """Resolve the compression format for generated Packages indices.
+
+        Honors ``config.metadata.compression``. For APT, ``auto`` falls back to
+        gzip since Debian/Ubuntu repositories always provide a ``Packages.gz``.
+
+        Returns:
+            The compression format (gzip, zstandard, bzip2, or none).
+        """
+        setting = self.config.metadata.compression if self.config.metadata else "auto"
+        if setting == "auto":
+            return "gzip"
+        return setting
 
     def _group_packages_by_component_arch(
         self, packages: list[ContentItem]
@@ -255,17 +277,23 @@ class AptPublisher(PublisherPlugin):
         component_arch_path: Path,
         component: str,
         architecture: str,
-    ) -> Path:
-        """Generate Packages file for component/architecture.
+        compression: CompressionFormat = "gzip",
+    ) -> list[Path]:
+        """Generate Packages file(s) for component/architecture.
+
+        Writes the uncompressed ``Packages`` file plus a compressed variant
+        (unless ``compression`` is ``none``).
 
         Args:
             packages: List of content items
             component_arch_path: Path to component/architecture directory
             component: Component name
             architecture: Architecture name
+            compression: Compression format for the compressed Packages index
 
         Returns:
-            Path to generated Packages.gz file
+            List of generated paths; the uncompressed ``Packages`` first,
+            followed by the compressed variant (if any).
         """
         # Build Packages file content (RFC822 format)
         packages_content = []
@@ -382,18 +410,21 @@ class AptPublisher(PublisherPlugin):
         # Write uncompressed Packages file
         packages_file_path = component_arch_path / "Packages"
         packages_file_path.write_text(full_content, encoding="utf-8")
+        generated = [packages_file_path]
 
-        # Gzip it
-        packages_gz_path = component_arch_path / "Packages.gz"
-        with open(packages_file_path, "rb") as f_in:
-            with gzip.open(packages_gz_path, "wb") as f_out:
-                shutil.copyfileobj(f_in, f_out)
+        # Write the compressed variant (unless disabled)
+        if compression != "none":
+            ext = get_extension(compression)
+            compressed_path = component_arch_path / f"Packages{ext}"
+            compressed_path.write_bytes(compress_file(packages_file_path.read_bytes(), compression))
+            generated.append(compressed_path)
 
         print(
-            f"  ✓ Generated Packages for {component}/{architecture}: " f"{len(packages)} packages"
+            f"  ✓ Generated Packages for {component}/{architecture}: "
+            f"{len(packages)} packages ({compression})"
         )
 
-        return packages_gz_path
+        return generated
 
     def _publish_metadata_files(
         self, repository_files: list[RepositoryFile], dists_path: Path
@@ -509,44 +540,30 @@ class AptPublisher(PublisherPlugin):
         sha1sums = []
         sha256sums = []
 
-        # Collect all Packages and Packages.gz files
+        # Collect checksums for the uncompressed Packages and every compressed
+        # variant present in each component/architecture directory.
         for meta in published_metadata:
             component = meta["component"]
             architecture = meta["architecture"]
-            packages_gz_path = meta["packages_file"]
+            component_dir = meta["packages_file"].parent
 
-            # Get relative paths
             if architecture == "source":
-                packages_rel = f"{component}/source/Packages"
-                packages_gz_rel = f"{component}/source/Packages.gz"
+                rel_prefix = f"{component}/source"
             else:
-                packages_rel = f"{component}/binary-{architecture}/Packages"
-                packages_gz_rel = f"{component}/binary-{architecture}/Packages.gz"
+                rel_prefix = f"{component}/binary-{architecture}"
 
-            # Uncompressed Packages file
-            packages_path = packages_gz_path.parent / "Packages"
-            if packages_path.exists():
-                packages_data = packages_path.read_bytes()
-                packages_size = len(packages_data)
-                packages_md5 = hashlib.md5(packages_data).hexdigest()
-                packages_sha1 = hashlib.sha1(packages_data).hexdigest()
-                packages_sha256 = hashlib.sha256(packages_data).hexdigest()
+            for variant in _PACKAGES_VARIANTS:
+                variant_path = component_dir / variant
+                if not variant_path.exists():
+                    continue
 
-                md5sums.append(f" {packages_md5} {packages_size:8} {packages_rel}")
-                sha1sums.append(f" {packages_sha1} {packages_size:8} {packages_rel}")
-                sha256sums.append(f" {packages_sha256} {packages_size:8} {packages_rel}")
+                data = variant_path.read_bytes()
+                size = len(data)
+                rel = f"{rel_prefix}/{variant}"
 
-            # Compressed Packages.gz file
-            if packages_gz_path.exists():
-                packages_gz_data = packages_gz_path.read_bytes()
-                packages_gz_size = len(packages_gz_data)
-                packages_gz_md5 = hashlib.md5(packages_gz_data).hexdigest()
-                packages_gz_sha1 = hashlib.sha1(packages_gz_data).hexdigest()
-                packages_gz_sha256 = hashlib.sha256(packages_gz_data).hexdigest()
-
-                md5sums.append(f" {packages_gz_md5} {packages_gz_size:8} {packages_gz_rel}")
-                sha1sums.append(f" {packages_gz_sha1} {packages_gz_size:8} {packages_gz_rel}")
-                sha256sums.append(f" {packages_gz_sha256} {packages_gz_size:8} {packages_gz_rel}")
+                md5sums.append(f" {hashlib.md5(data).hexdigest()} {size:8} {rel}")
+                sha1sums.append(f" {hashlib.sha1(data).hexdigest()} {size:8} {rel}")
+                sha256sums.append(f" {hashlib.sha256(data).hexdigest()} {size:8} {rel}")
 
         # Add checksum sections
         if md5sums:

--- a/tests/test_apt_publisher.py
+++ b/tests/test_apt_publisher.py
@@ -12,11 +12,12 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from chantal.core.config import AptConfig, RepositoryConfig, StorageConfig
+from chantal.core.config import AptConfig, MetadataConfig, RepositoryConfig, StorageConfig
 from chantal.core.storage import StorageManager
 from chantal.db.models import Base, ContentItem, Repository
 from chantal.plugins.apt.models import DebMetadata
 from chantal.plugins.apt.publisher import AptPublisher
+from chantal.plugins.rpm.compression import decompress_file
 
 # Test fixtures
 
@@ -171,12 +172,15 @@ class TestPackagesFileGeneration:
         component_arch_path = Path(temp_storage.config.published_path) / "test_packages"
         component_arch_path.mkdir(parents=True, exist_ok=True)
 
-        # Generate Packages file
-        packages_gz = publisher._generate_packages_file(
+        # Generate Packages file (returns [Packages, Packages.gz] by default)
+        generated = publisher._generate_packages_file(
             [test_package], component_arch_path, "main", "amd64"
         )
 
         # Verify Packages.gz was created
+        assert generated[0].name == "Packages"
+        packages_gz = component_arch_path / "Packages.gz"
+        assert packages_gz in generated
         assert packages_gz.exists()
         assert packages_gz.name == "Packages.gz"
 
@@ -483,3 +487,98 @@ class TestPackageGrouping:
         # Should default to main/amd64
         assert ("main", "amd64") in grouped
         assert len(grouped[("main", "amd64")]) == 1
+
+
+class TestPackagesCompression:
+    """Tests for configurable Packages index compression."""
+
+    @staticmethod
+    def _config(compression):
+        return RepositoryConfig(
+            id="test-apt-repo",
+            name="Test APT Repository",
+            type="apt",
+            feed="https://example.com/ubuntu",
+            mode="filtered",
+            apt=AptConfig(distribution="jammy", components=["main"], architectures=["amd64"]),
+            metadata=MetadataConfig(compression=compression),
+        )
+
+    def test_default_is_gzip(self, temp_storage, test_package):
+        """Default (auto) compression produces Packages + Packages.gz only."""
+        publisher = AptPublisher(storage=temp_storage, config=self._config("auto"))
+        assert publisher._resolve_compression() == "gzip"
+
+        comp_path = Path(temp_storage.config.published_path) / "pkgs"
+        comp_path.mkdir(parents=True, exist_ok=True)
+        generated = publisher._generate_packages_file(
+            [test_package], comp_path, "main", "amd64", "gzip"
+        )
+
+        names = {p.name for p in generated}
+        assert names == {"Packages", "Packages.gz"}
+        assert not (comp_path / "Packages.zst").exists()
+
+    def test_zstandard(self, temp_storage, test_package):
+        """zstandard compression produces a valid Packages.zst."""
+        publisher = AptPublisher(storage=temp_storage, config=self._config("zstandard"))
+        comp_path = Path(temp_storage.config.published_path) / "pkgs"
+        comp_path.mkdir(parents=True, exist_ok=True)
+
+        generated = publisher._generate_packages_file(
+            [test_package], comp_path, "main", "amd64", "zstandard"
+        )
+        zst = comp_path / "Packages.zst"
+        assert zst in generated
+        assert zst.exists()
+
+        # The compressed index must round-trip to the uncompressed Packages.
+        expected = (comp_path / "Packages").read_bytes()
+        assert decompress_file(zst.read_bytes(), "zstandard") == expected
+
+    def test_bzip2(self, temp_storage, test_package):
+        """bzip2 compression produces Packages.bz2."""
+        publisher = AptPublisher(storage=temp_storage, config=self._config("bzip2"))
+        comp_path = Path(temp_storage.config.published_path) / "pkgs"
+        comp_path.mkdir(parents=True, exist_ok=True)
+
+        generated = publisher._generate_packages_file(
+            [test_package], comp_path, "main", "amd64", "bzip2"
+        )
+        assert (comp_path / "Packages.bz2") in generated
+        assert (comp_path / "Packages.bz2").exists()
+
+    def test_none_only_uncompressed(self, temp_storage, test_package):
+        """'none' compression produces only the uncompressed Packages file."""
+        publisher = AptPublisher(storage=temp_storage, config=self._config("none"))
+        comp_path = Path(temp_storage.config.published_path) / "pkgs"
+        comp_path.mkdir(parents=True, exist_ok=True)
+
+        generated = publisher._generate_packages_file(
+            [test_package], comp_path, "main", "amd64", "none"
+        )
+        assert [p.name for p in generated] == ["Packages"]
+        assert not (comp_path / "Packages.gz").exists()
+
+    def test_release_lists_compressed_variant(self, temp_storage, test_package):
+        """The Release file references the configured compressed variant."""
+        publisher = AptPublisher(storage=temp_storage, config=self._config("zstandard"))
+        dists_path = Path(temp_storage.config.published_path) / "dists" / "jammy"
+        comp_path = dists_path / "main" / "binary-amd64"
+        comp_path.mkdir(parents=True, exist_ok=True)
+
+        generated = publisher._generate_packages_file(
+            [test_package], comp_path, "main", "amd64", "zstandard"
+        )
+        published_metadata = [
+            {"component": "main", "architecture": "amd64", "packages_file": generated[0]}
+        ]
+
+        release_file = publisher._generate_release_file(
+            dists_path, published_metadata, [], "filtered"
+        )
+        content = release_file.read_text()
+
+        assert "main/binary-amd64/Packages" in content
+        assert "main/binary-amd64/Packages.zst" in content
+        assert "main/binary-amd64/Packages.gz" not in content


### PR DESCRIPTION
## Summary

The APT publisher always wrote `Packages` + `Packages.gz` and ignored the `metadata.compression` setting (which the RPM publisher already honors). This PR makes the regenerated APT `Packages` index compression configurable, reusing the shared compression module.

## Behaviour

- The uncompressed `Packages` is always written, plus **one** compressed variant per `metadata.compression`:

| `metadata.compression` | Output |
|---|---|
| `auto` (default) | `Packages` + `Packages.gz` (auto → gzip for APT) |
| `gzip` | `Packages` + `Packages.gz` |
| `zstandard` | `Packages` + `Packages.zst` (modern apt / Ubuntu) |
| `bzip2` | `Packages` + `Packages.bz2` |
| `none` | `Packages` only |

- The `Release` file now checksums the uncompressed `Packages` **and every compressed variant present** (`gz`/`xz`/`zst`/`bz2`), so clients automatically pick a format they support.
- **Default behaviour is unchanged** (gzip → `Packages.gz`), so existing repos are unaffected.

## Notes

- Reuses `chantal.plugins.rpm.compression` (a generic compression util that happens to live under the rpm plugin). Moving it to `core/` would be a reasonable follow-up refactor but is out of scope here.

## Tests

- `tests/test_apt_publisher.py::TestPackagesCompression`: gzip default, zstandard (round-trip decompress), bzip2, none, and a Release-references-the-variant test.
- Full suite green; `black`, `ruff`, `mypy` all clean.
