### PR TITLE
chore: Resolve all deprecation warnings (Pydantic ConfigDict, datetime.utcnow, alembic)

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -11,6 +11,9 @@ file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)
 # defaults to the current working directory.
 prepend_sys_path = .
 
+# separator used to split prepend_sys_path / version_locations (os = os.pathsep)
+path_separator = os
+
 # timezone to use when rendering the date within the migration file
 # as well as the filename.
 # If specified, requires the python-dateutil library that can be

--- a/src/chantal/cli/publish_commands.py
+++ b/src/chantal/cli/publish_commands.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import click
@@ -687,7 +687,7 @@ def _publish_view_snapshot(
 
             # Update view snapshot metadata
             view_snapshot.is_published = True
-            view_snapshot.published_at = datetime.utcnow()
+            view_snapshot.published_at = datetime.now(timezone.utc).replace(tzinfo=None)
             view_snapshot.published_path = str(target_path)
             session.commit()
 

--- a/src/chantal/db/models.py
+++ b/src/chantal/db/models.py
@@ -8,7 +8,7 @@ snapshots, and their relationships.
 """
 
 import enum
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     JSON,
@@ -46,6 +46,15 @@ class Base(DeclarativeBase):
     pass
 
 
+def _utcnow() -> datetime:
+    """Current UTC time as a naive datetime.
+
+    Replaces the deprecated ``datetime.utcnow`` while preserving the existing
+    naive-UTC semantics used by all timestamp columns.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 # Association table for many-to-many relationship between repositories and content items
 # This tracks which content items are currently in a repository (the "latest" state)
 repository_content_items = Table(
@@ -53,7 +62,7 @@ repository_content_items = Table(
     Base.metadata,
     Column("repository_id", Integer, ForeignKey("repositories.id"), primary_key=True),
     Column("content_item_id", Integer, ForeignKey("content_items.id"), primary_key=True),
-    Column("added_at", DateTime, default=datetime.utcnow, nullable=False),
+    Column("added_at", DateTime, default=_utcnow, nullable=False),
 )
 
 # Association table for many-to-many relationship between snapshots and content items
@@ -72,7 +81,7 @@ repository_repository_files = Table(
     Base.metadata,
     Column("repository_id", Integer, ForeignKey("repositories.id"), primary_key=True),
     Column("repository_file_id", Integer, ForeignKey("repository_files.id"), primary_key=True),
-    Column("added_at", DateTime, default=datetime.utcnow, nullable=False),
+    Column("added_at", DateTime, default=_utcnow, nullable=False),
 )
 
 # Association table for many-to-many relationship between snapshots and repository files
@@ -105,9 +114,9 @@ class Repository(Base):
     snapshots_path: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Metadata
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+        DateTime, default=_utcnow, onupdate=_utcnow, nullable=False
     )
 
     # Sync state
@@ -173,7 +182,7 @@ class ContentItem(Base):
     content_metadata: Mapped[dict] = mapped_column(JSON, nullable=False)
 
     # Timestamps
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, nullable=False)
 
     # Reference counting (for garbage collection)
     reference_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
@@ -253,7 +262,7 @@ class Snapshot(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # State
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, nullable=False)
     is_published: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     published_path: Mapped[str | None] = mapped_column(Text, nullable=True)
 
@@ -341,9 +350,9 @@ class View(Base):
     repo_type: Mapped[str] = mapped_column(String(50), nullable=False)  # rpm, apt
 
     # Timestamps
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+        DateTime, default=_utcnow, onupdate=_utcnow, nullable=False
     )
 
     # Publishing status (for "latest" publish)
@@ -381,7 +390,7 @@ class ViewRepository(Base):
     order: Mapped[int] = mapped_column(Integer, nullable=False)
 
     # Timestamps
-    added_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    added_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, nullable=False)
 
     # Relationships
     view: Mapped[View] = relationship("View", back_populates="view_repositories")
@@ -411,7 +420,7 @@ class ViewSnapshot(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # State
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, nullable=False)
 
     # Which repository snapshots are included (JSON array of snapshot IDs)
     # Example: [12, 45, 67] - references Snapshot.id
@@ -485,9 +494,9 @@ class RepositoryFile(Base):
     #   {"kernel_version": "5.14.0-362.8.1.el9_3"}
 
     # Timestamps
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+        DateTime, default=_utcnow, onupdate=_utcnow, nullable=False
     )
 
     # Relationships (many-to-many like ContentItem)

--- a/src/chantal/plugins/apt/models.py
+++ b/src/chantal/plugins/apt/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 Pydantic models for APT/DEB repository metadata.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DebMetadata(BaseModel):
@@ -74,10 +74,8 @@ class DebMetadata(BaseModel):
         default_factory=dict, description="Additional fields not explicitly modeled"
     )
 
-    class Config:
-        """Pydantic configuration."""
-
-        extra = "allow"  # Allow additional fields for forward compatibility
+    # Allow additional fields for forward compatibility
+    model_config = ConfigDict(extra="allow")
 
 
 class ReleaseMetadata(BaseModel):
@@ -120,10 +118,7 @@ class ReleaseMetadata(BaseModel):
     # Additional fields
     extra_fields: dict[str, str] = Field(default_factory=dict, description="Additional fields")
 
-    class Config:
-        """Pydantic configuration."""
-
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 class SourcesMetadata(BaseModel):
@@ -179,7 +174,4 @@ class SourcesMetadata(BaseModel):
     # Additional fields
     extra_fields: dict[str, str] = Field(default_factory=dict, description="Additional fields")
 
-    class Config:
-        """Pydantic configuration."""
-
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")

--- a/src/chantal/plugins/helm/models.py
+++ b/src/chantal/plugins/helm/models.py
@@ -9,7 +9,7 @@ The metadata is stored as JSON in the ContentItem.content_metadata field.
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class HelmMaintainer(BaseModel):
@@ -77,10 +77,8 @@ class HelmMetadata(BaseModel):
     kube_version: str | None = Field(None, alias="kubeVersion")
     app_version_field: str | None = Field(None, alias="appVersion")
 
-    class Config:
-        """Pydantic config."""
-
-        populate_by_name = True  # Allow both 'appVersion' and 'app_version'
+    # Allow both 'appVersion' and 'app_version'
+    model_config = ConfigDict(populate_by_name=True)
 
     def to_index_entry(self) -> dict[str, Any]:
         """Convert to Helm index.yaml entry format.

--- a/src/chantal/plugins/helm/publisher.py
+++ b/src/chantal/plugins/helm/publisher.py
@@ -9,7 +9,7 @@ This module implements publishing for Helm chart repositories.
 import logging
 import os
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -201,7 +201,7 @@ class HelmPublisher(PublisherPlugin):
         index: dict[str, Any] = {
             "apiVersion": "v1",
             "entries": {},
-            "generated": datetime.utcnow().isoformat() + "Z",
+            "generated": datetime.now(timezone.utc).replace(tzinfo=None).isoformat() + "Z",
         }
         entries: dict[str, list[dict[str, Any]]] = index["entries"]
 

--- a/src/chantal/plugins/rpm/models.py
+++ b/src/chantal/plugins/rpm/models.py
@@ -7,7 +7,7 @@ These models define the metadata schema for RPM packages stored in the generic
 ContentItem model.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RpmMetadata(BaseModel):
@@ -32,11 +32,8 @@ class RpmMetadata(BaseModel):
     conflicts: list[str] | None = Field(None, description="List of conflicts")
     obsoletes: list[str] | None = Field(None, description="List of obsoletes")
 
-    class Config:
-        """Pydantic configuration."""
-
-        # Allow extra fields for forward compatibility
-        extra = "allow"
+    # Allow extra fields for forward compatibility
+    model_config = ConfigDict(extra="allow")
 
     def get_nevra(self, name: str, version: str) -> str:
         """Get NEVRA string (Name-Epoch:Version-Release.Arch).

--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -11,7 +11,7 @@ import gzip
 import hashlib
 import shutil
 import xml.etree.ElementTree as ET
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from sqlalchemy.orm import Session
@@ -310,7 +310,7 @@ class RpmPublisher(PublisherPlugin):
 
             # Time (use current time for now)
             time_elem = ET.SubElement(pkg_elem, "time")
-            time_elem.set("file", str(int(datetime.utcnow().timestamp())))
+            time_elem.set("file", str(int(datetime.now(timezone.utc).timestamp())))
 
         # Write XML
         tree = ET.ElementTree(metadata)
@@ -437,7 +437,7 @@ class RpmPublisher(PublisherPlugin):
 
         # Revision (timestamp)
         revision = ET.SubElement(repomd, "revision")
-        revision.text = str(int(datetime.utcnow().timestamp()))
+        revision.text = str(int(datetime.now(timezone.utc).timestamp()))
 
         # Add data entry for each metadata file
         for file_type, file_path in metadata_files:
@@ -490,7 +490,7 @@ class RpmPublisher(PublisherPlugin):
             location.set("href", f"repodata/{file_path.name}")
 
             timestamp = ET.SubElement(data, "timestamp")
-            timestamp.text = str(int(datetime.utcnow().timestamp()))
+            timestamp.text = str(int(datetime.now(timezone.utc).timestamp()))
 
             size = ET.SubElement(data, "size")
             size.text = str(file_size)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,6 @@
 """Tests for Views functionality."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine
@@ -351,17 +351,16 @@ def test_view_snapshot_retrieves_packages(db_session, test_repositories, test_pa
         package_count=2,
         total_size_bytes=3500000,
     )
-    snap1.content_items = [test_packages[0], test_packages[1]]  # vim, bash
-
     snap2 = Snapshot(
         repository_id=test_repositories[1].id,
         name="snap-2",
         package_count=2,
         total_size_bytes=4000000,
     )
-    snap2.content_items = [test_packages[2], test_packages[3]]  # nginx, httpd
-
+    # Add to the session before linking content items so autoflush has them.
     db_session.add_all([snap1, snap2])
+    snap1.content_items = [test_packages[0], test_packages[1]]  # vim, bash
+    snap2.content_items = [test_packages[2], test_packages[3]]  # nginx, httpd
     db_session.commit()
 
     # Create view snapshot
@@ -401,7 +400,7 @@ def test_view_publish_state(db_session):
 
     # Mark as published
     view.is_published = True
-    view.published_at = datetime.utcnow()
+    view.published_at = datetime.now(timezone.utc).replace(tzinfo=None)
     view.published_path = "/var/www/repos/views/test-view/latest"
     db_session.commit()
 
@@ -431,7 +430,7 @@ def test_view_snapshot_publish_state(db_session):
 
     # Mark as published
     view_snapshot.is_published = True
-    view_snapshot.published_at = datetime.utcnow()
+    view_snapshot.published_at = datetime.now(timezone.utc).replace(tzinfo=None)
     view_snapshot.published_path = "/var/www/repos/views/test-view/snapshots/snapshot-1"
     db_session.commit()
 


### PR DESCRIPTION
## Summary

Clears all deprecation warnings from the test suite (~300 → 0). Addresses the **Code Quality → Fix all deprecation warnings** item from the 1.0 roadmap (#32). No behavioural change.

## Changes

**Pydantic v2 `class Config` → `ConfigDict`**
- `apt/models.py`, `rpm/models.py`, `helm/models.py`: migrate the deprecated inner `class Config` to `model_config = ConfigDict(...)`.

**`datetime.utcnow()` (deprecated in 3.12)**
- `db/models.py`: add a naive-UTC `_utcnow()` helper and use it for every timestamp column `default`/`onupdate`. **Naive-UTC semantics are preserved** (values are still naive), so DB roundtrips and comparisons are unchanged.
- `rpm/publisher.py`: `datetime.now(timezone.utc)` for repomd timestamps (also fixes the latent `utcnow().timestamp()` local-time bug).
- `helm/publisher.py`: naive-UTC ISO + `Z` for the index `generated` field (output format unchanged).
- `cli/publish_commands.py` and `tests/test_views.py`: naive-UTC for `published_at`.

**Alembic**
- `alembic.ini`: add `path_separator = os` (removes the alembic `prepend_sys_path` deprecation warning hit by `test_cli` and `test_migrations`).

**Test hygiene**
- `tests/test_views.py`: add snapshots to the session before linking content items, silencing a SQLAlchemy autoflush `SAWarning`.

## Verification

- Full suite green with **0 warnings** (was ~311).
- `black`, `ruff`, `mypy` all clean.
