### PR TITLE
feat: Config JSON Schema + example validation in CI

### DIFF
--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,0 +1,58 @@
+# Configuration JSON Schema
+
+`chantal-config.schema.json` is a [JSON Schema](https://json-schema.org/)
+(draft 2020-12) for Chantal's `config.yaml`. It is generated from the
+configuration models, so it always matches what Chantal actually validates.
+
+JSON Schema works for YAML too, so editors can use it to **validate** and
+**autocomplete** your configuration.
+
+## Regenerating
+
+The schema is generated from the Pydantic models. After changing any config
+model, regenerate it:
+
+```bash
+chantal schema -o docs/schema/chantal-config.schema.json
+```
+
+A test (`tests/test_schema.py`) fails in CI if the committed schema is stale, and
+also validates every example under `examples/` against it.
+
+## Editor integration
+
+### Per-file modeline (works in VS Code, JetBrains, neovim, …)
+
+Add this as the first line of your config file:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/slauger/chantal/main/docs/schema/chantal-config.schema.json
+```
+
+See `examples/config/config.yaml` for a working example.
+
+### VS Code workspace mapping
+
+Alternatively, map the schema to your config files in `.vscode/settings.json`
+(requires the **YAML** extension by Red Hat):
+
+```json
+{
+  "yaml.schemas": {
+    "./docs/schema/chantal-config.schema.json": [
+      "config.yaml",
+      "conf.d/*.yaml",
+      "examples/**/*.yaml"
+    ]
+  }
+}
+```
+
+## Standalone validation
+
+You can also validate a config with any JSON Schema tooling, e.g.
+[`check-jsonschema`](https://github.com/python-jsonschema/check-jsonschema):
+
+```bash
+check-jsonschema --schemafile docs/schema/chantal-config.schema.json config.yaml
+```

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -1,0 +1,1421 @@
+{
+  "$defs": {
+    "ApkConfig": {
+      "description": "Alpine APK-specific configuration.",
+      "properties": {
+        "branch": {
+          "title": "Branch",
+          "type": "string"
+        },
+        "repository": {
+          "default": "main",
+          "title": "Repository",
+          "type": "string"
+        },
+        "architecture": {
+          "default": "x86_64",
+          "title": "Architecture",
+          "type": "string"
+        }
+      },
+      "required": [
+        "branch"
+      ],
+      "title": "ApkConfig",
+      "type": "object"
+    },
+    "AptConfig": {
+      "description": "APT/DEB-specific configuration.",
+      "properties": {
+        "distribution": {
+          "title": "Distribution",
+          "type": "string"
+        },
+        "components": {
+          "description": "Repository components (main, restricted, universe, multiverse, contrib, non-free)",
+          "items": {
+            "type": "string"
+          },
+          "title": "Components",
+          "type": "array"
+        },
+        "architectures": {
+          "description": "Architectures to mirror (amd64, arm64, i386, armhf, all)",
+          "items": {
+            "type": "string"
+          },
+          "title": "Architectures",
+          "type": "array"
+        },
+        "include_source_packages": {
+          "default": false,
+          "description": "Include source packages (.dsc, .orig.tar.gz, etc.)",
+          "title": "Include Source Packages",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "distribution"
+      ],
+      "title": "AptConfig",
+      "type": "object"
+    },
+    "AuthConfig": {
+      "description": "Repository authentication configuration.",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "type": "string"
+        },
+        "cert_dir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cert Dir"
+        },
+        "cert_file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cert File"
+        },
+        "key_file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Key File"
+        },
+        "username": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Username"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Password"
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Token"
+        },
+        "headers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Headers"
+        },
+        "verify_ssl": {
+          "default": true,
+          "title": "Verify Ssl",
+          "type": "boolean"
+        },
+        "ca_bundle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ca Bundle"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "AuthConfig",
+      "type": "object"
+    },
+    "CacheConfig": {
+      "description": "Metadata cache configuration.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "max_age_hours": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Age Hours"
+        }
+      },
+      "title": "CacheConfig",
+      "type": "object"
+    },
+    "DatabaseConfig": {
+      "description": "Database configuration.",
+      "properties": {
+        "url": {
+          "default": "sqlite:///chantal.db",
+          "title": "Url",
+          "type": "string"
+        },
+        "pool_size": {
+          "default": 5,
+          "title": "Pool Size",
+          "type": "integer"
+        },
+        "max_overflow": {
+          "default": 10,
+          "title": "Max Overflow",
+          "type": "integer"
+        },
+        "echo": {
+          "default": false,
+          "title": "Echo",
+          "type": "boolean"
+        }
+      },
+      "title": "DatabaseConfig",
+      "type": "object"
+    },
+    "DebFilterConfig": {
+      "description": "DEB/APT-specific filters (future support).",
+      "properties": {
+        "components": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ListFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "priorities": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ListFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "sections": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ListFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "DebFilterConfig",
+      "type": "object"
+    },
+    "DownloadConfig": {
+      "description": "Download configuration for file downloads.",
+      "properties": {
+        "backend": {
+          "default": "requests",
+          "title": "Backend",
+          "type": "string"
+        },
+        "parallel": {
+          "default": 1,
+          "title": "Parallel",
+          "type": "integer"
+        },
+        "timeout": {
+          "default": 300,
+          "title": "Timeout",
+          "type": "integer"
+        },
+        "retry_attempts": {
+          "default": 3,
+          "title": "Retry Attempts",
+          "type": "integer"
+        },
+        "verify_checksum": {
+          "default": true,
+          "title": "Verify Checksum",
+          "type": "boolean"
+        }
+      },
+      "title": "DownloadConfig",
+      "type": "object"
+    },
+    "FilterConfig": {
+      "description": "Package filtering configuration.\n\nSupports both new structure and legacy flat structure for backward compatibility.\n\nStructure:\n- metadata: Generic filters (all package types)\n- rpm/deb/helm: Plugin-specific filters\n- patterns: Generic regex patterns\n- post_processing: Applied after all filters",
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenericMetadataFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "patterns": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PatternFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "post_processing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PostProcessingConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "rpm": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RpmFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "deb": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DebFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "include_packages": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Include Packages"
+        },
+        "exclude_packages": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Packages"
+        },
+        "include_architectures": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Include Architectures"
+        },
+        "exclude_architectures": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Architectures"
+        }
+      },
+      "title": "FilterConfig",
+      "type": "object"
+    },
+    "GenericMetadataFilterConfig": {
+      "description": "Generic metadata filters (work for all package types).",
+      "properties": {
+        "size_bytes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SizeFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "build_time": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TimeFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "architectures": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ListFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "GenericMetadataFilterConfig",
+      "type": "object"
+    },
+    "GpgConfig": {
+      "description": "GPG signing configuration for APT repositories.\n\nUsed to sign regenerated metadata (Release) in filtered mode so that\nclients can verify the repository without ``[trusted=yes]``.\n\nThe signing key can be provided in three ways (checked in this order):\n\n1. ``key_file`` - import a private (secret) key from an ASCII-armored file.\n2. ``key_id`` - use a key already present in the keyring / ``gnupg_home``.\n3. ``generate_key`` - generate a new keypair if none of the above is set.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "key_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Key ID or fingerprint of the signing key to use",
+          "title": "Key Id"
+        },
+        "key_file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to ASCII-armored private key file to import before signing",
+          "title": "Key File"
+        },
+        "passphrase": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Signing key passphrase (inline; prefer passphrase_file)",
+          "title": "Passphrase"
+        },
+        "passphrase_file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to a file containing the signing key passphrase",
+          "title": "Passphrase File"
+        },
+        "gnupg_home": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "GNUPGHOME directory holding the keyring",
+          "title": "Gnupg Home"
+        },
+        "public_key_file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to the public key to publish for clients (exported from the keyring if not set)",
+          "title": "Public Key File"
+        },
+        "public_key_name": {
+          "default": "key.gpg",
+          "description": "Filename of the published public key inside the repository root",
+          "title": "Public Key Name",
+          "type": "string"
+        },
+        "generate_key": {
+          "default": false,
+          "description": "Generate a new signing keypair if no key is provided",
+          "title": "Generate Key",
+          "type": "boolean"
+        },
+        "key_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Real name for a generated key (defaults to repository name)",
+          "title": "Key Name"
+        },
+        "key_email": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Email for a generated key (defaults to chantal@localhost)",
+          "title": "Key Email"
+        }
+      },
+      "title": "GpgConfig",
+      "type": "object"
+    },
+    "ListFilterConfig": {
+      "description": "Generic list-based filtering (include/exclude).",
+      "properties": {
+        "include": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Include"
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude"
+        }
+      },
+      "title": "ListFilterConfig",
+      "type": "object"
+    },
+    "MetadataConfig": {
+      "description": "Metadata generation configuration (RPM, APT, etc.).",
+      "properties": {
+        "compression": {
+          "default": "auto",
+          "description": "Compression format for generated metadata. 'auto' uses same as upstream.",
+          "enum": [
+            "auto",
+            "gzip",
+            "zstandard",
+            "bzip2",
+            "none"
+          ],
+          "title": "Compression",
+          "type": "string"
+        }
+      },
+      "title": "MetadataConfig",
+      "type": "object"
+    },
+    "PatternFilterConfig": {
+      "description": "Pattern-based filters (regex).",
+      "properties": {
+        "include": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Include"
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude"
+        }
+      },
+      "title": "PatternFilterConfig",
+      "type": "object"
+    },
+    "PostProcessingConfig": {
+      "description": "Post-processing configuration (applied after filtering).",
+      "properties": {
+        "only_latest_version": {
+          "default": false,
+          "title": "Only Latest Version",
+          "type": "boolean"
+        },
+        "only_latest_n_versions": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Only Latest N Versions"
+        }
+      },
+      "title": "PostProcessingConfig",
+      "type": "object"
+    },
+    "ProxyConfig": {
+      "description": "HTTP proxy configuration.",
+      "properties": {
+        "http_proxy": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Http Proxy"
+        },
+        "https_proxy": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Https Proxy"
+        },
+        "no_proxy": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "No Proxy"
+        },
+        "username": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Username"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Password"
+        }
+      },
+      "title": "ProxyConfig",
+      "type": "object"
+    },
+    "RepositoryConfig": {
+      "description": "Repository configuration.",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        },
+        "feed": {
+          "title": "Feed",
+          "type": "string"
+        },
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "mode": {
+          "default": "filtered",
+          "enum": [
+            "mirror",
+            "filtered",
+            "hosted"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Tags"
+        },
+        "auth": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AuthConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "latest_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Latest Path"
+        },
+        "snapshots_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Snapshots Path"
+        },
+        "retention": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RetentionConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ScheduleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filters": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "proxy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProxyConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ssl": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SSLConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "cache_enabled": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cache Enabled"
+        },
+        "apk": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ApkConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "apt": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AptConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MetadataConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Metadata generation configuration (compression, etc.)"
+        },
+        "gpg": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GpgConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "feed"
+      ],
+      "title": "RepositoryConfig",
+      "type": "object"
+    },
+    "RetentionConfig": {
+      "description": "Package retention policy configuration.",
+      "properties": {
+        "policy": {
+          "default": "mirror",
+          "title": "Policy",
+          "type": "string"
+        },
+        "keep_count": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Keep Count"
+        }
+      },
+      "title": "RetentionConfig",
+      "type": "object"
+    },
+    "RpmFilterConfig": {
+      "description": "RPM-specific filters.",
+      "properties": {
+        "exclude_source_rpms": {
+          "default": false,
+          "title": "Exclude Source Rpms",
+          "type": "boolean"
+        },
+        "groups": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ListFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "licenses": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ListFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "vendors": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ListFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "epochs": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ListFilterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "RpmFilterConfig",
+      "type": "object"
+    },
+    "SSLConfig": {
+      "description": "SSL/TLS configuration for HTTPS connections.",
+      "properties": {
+        "ca_bundle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ca Bundle"
+        },
+        "ca_cert": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ca Cert"
+        },
+        "verify": {
+          "default": true,
+          "title": "Verify",
+          "type": "boolean"
+        },
+        "client_cert": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Client Cert"
+        },
+        "client_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Client Key"
+        }
+      },
+      "title": "SSLConfig",
+      "type": "object"
+    },
+    "ScheduleConfig": {
+      "description": "Repository sync schedule configuration.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "cron": {
+          "default": "0 2 * * *",
+          "title": "Cron",
+          "type": "string"
+        },
+        "create_snapshot": {
+          "default": false,
+          "title": "Create Snapshot",
+          "type": "boolean"
+        },
+        "snapshot_name_template": {
+          "default": "{repo_id}-{date}",
+          "title": "Snapshot Name Template",
+          "type": "string"
+        }
+      },
+      "title": "ScheduleConfig",
+      "type": "object"
+    },
+    "SizeFilterConfig": {
+      "description": "Size-based filtering.",
+      "properties": {
+        "min": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min"
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max"
+        }
+      },
+      "title": "SizeFilterConfig",
+      "type": "object"
+    },
+    "StorageConfig": {
+      "description": "Storage paths configuration.",
+      "properties": {
+        "base_path": {
+          "default": "/var/lib/chantal",
+          "title": "Base Path",
+          "type": "string"
+        },
+        "pool_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pool Path"
+        },
+        "published_path": {
+          "default": "/var/www/repos",
+          "title": "Published Path",
+          "type": "string"
+        },
+        "temp_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Temp Path"
+        },
+        "cache_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cache Path"
+        }
+      },
+      "title": "StorageConfig",
+      "type": "object"
+    },
+    "TimeFilterConfig": {
+      "description": "Time-based filtering.",
+      "properties": {
+        "newer_than": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Newer Than"
+        },
+        "older_than": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Older Than"
+        },
+        "last_n_days": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last N Days"
+        }
+      },
+      "title": "TimeFilterConfig",
+      "type": "object"
+    },
+    "ViewConfig": {
+      "description": "View configuration - groups multiple repositories into one virtual repository.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "repos": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Repos",
+          "type": "array"
+        },
+        "publish_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Publish Path"
+        }
+      },
+      "required": [
+        "name",
+        "repos"
+      ],
+      "title": "ViewConfig",
+      "type": "object"
+    }
+  },
+  "description": "Global Chantal configuration.",
+  "properties": {
+    "database": {
+      "$ref": "#/$defs/DatabaseConfig"
+    },
+    "storage": {
+      "$ref": "#/$defs/StorageConfig"
+    },
+    "cache": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CacheConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "proxy": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ProxyConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "ssl": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SSLConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "download": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DownloadConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "gpg": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GpgConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "repositories": {
+      "items": {
+        "$ref": "#/$defs/RepositoryConfig"
+      },
+      "title": "Repositories",
+      "type": "array"
+    },
+    "views": {
+      "items": {
+        "$ref": "#/$defs/ViewConfig"
+      },
+      "title": "Views",
+      "type": "array"
+    },
+    "include": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Include"
+    }
+  },
+  "title": "Chantal Configuration",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/slauger/chantal/main/docs/schema/chantal-config.schema.json"
+}

--- a/examples/apk/development.yaml
+++ b/examples/apk/development.yaml
@@ -18,7 +18,7 @@ repositories:
           # Core build tools
           - "^build-base$"
           - "^gcc$"
-          - "^g++$"
+          - "^g\\+\\+$"
           - "^make$"
           - "^cmake$"
           - "^autoconf$"

--- a/examples/apt/gitlab.yaml
+++ b/examples/apt/gitlab.yaml
@@ -23,7 +23,7 @@ repositories:
       include_source_packages: false
 
     retention:
-      policy: keep_latest  # Keep only recent versions
+      policy: keep-last-n  # Keep only recent versions
       keep_count: 3  # Keep last 3 versions
 
     # Sync schedule
@@ -52,5 +52,5 @@ repositories:
       include_source_packages: false
 
     retention:
-      policy: keep_latest
+      policy: keep-last-n
       keep_count: 3

--- a/examples/apt/grafana.yaml
+++ b/examples/apt/grafana.yaml
@@ -24,7 +24,7 @@ repositories:
       include_source_packages: false
 
     retention:
-      policy: keep_latest  # Keep only recent versions
+      policy: keep-last-n  # Keep only recent versions
       keep_count: 5  # Keep last 5 versions
 
     # Sync schedule (optional)

--- a/examples/apt/lynis.yaml
+++ b/examples/apt/lynis.yaml
@@ -25,7 +25,7 @@ repositories:
       include_source_packages: false
 
     retention:
-      policy: keep_latest  # Keep only recent versions
+      policy: keep-last-n  # Keep only recent versions
       keep_count: 3  # Keep last 3 versions for rollback
 
     # Sync schedule (optional)

--- a/examples/config/config.yaml
+++ b/examples/config/config.yaml
@@ -1,6 +1,12 @@
+# yaml-language-server: $schema=../../docs/schema/chantal-config.schema.json
 # Chantal Configuration Example
 # This is the main configuration file for Chantal.
 # Copy to /etc/chantal/config.yaml or ~/.config/chantal/config.yaml
+#
+# The modeline above enables validation and autocompletion in editors that
+# support JSON Schema for YAML (e.g. the VS Code "YAML" extension by Red Hat).
+# For configs outside this repo, point $schema at the raw URL instead - see
+# docs/schema/README.md.
 
 # Database configuration
 database:

--- a/examples/filter-examples.yaml
+++ b/examples/filter-examples.yaml
@@ -87,7 +87,7 @@ repositories:
   # ========================================
   - id: example-deb
     name: DEB-Specific Filters Example
-    type: deb  # When APT support is added
+    type: apt
     feed: http://deb.debian.org/debian
     enabled: false
     filters:

--- a/examples/rpm/lynis.yaml
+++ b/examples/rpm/lynis.yaml
@@ -16,7 +16,7 @@ repositories:
 
     # Retention policy
     retention:
-      policy: keep_latest  # Keep only recent versions
+      policy: keep-last-n  # Keep only recent versions
       keep_count: 3  # Keep last 3 versions for rollback
 
     # Sync schedule (optional)

--- a/src/chantal/cli/main.py
+++ b/src/chantal/cli/main.py
@@ -92,6 +92,33 @@ def stats(ctx: click.Context, repo_id: str) -> None:
 
 # ============================================================================
 # Register Command Groups
+@cli.command("schema")
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write the schema to this file instead of stdout.",
+)
+def schema(output: Path | None) -> None:
+    """Output the JSON Schema for the configuration file.
+
+    The schema is generated from the configuration models and can be used by
+    editors (e.g. the VS Code YAML extension) to validate and autocomplete
+    config.yaml files.
+    """
+    import json
+
+    from chantal.core.config import generate_json_schema
+
+    text = json.dumps(generate_json_schema(), indent=2) + "\n"
+    if output:
+        output.write_text(text, encoding="utf-8")
+        click.echo(f"Wrote configuration schema to {output}")
+    else:
+        click.echo(text, nl=False)
+
+
 # ============================================================================
 
 # Register all command groups

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -726,6 +726,27 @@ class ConfigLoader:
         return all_repos, all_views
 
 
+def generate_json_schema() -> dict[str, Any]:
+    """Generate the JSON Schema for the Chantal configuration file.
+
+    The schema is derived from the :class:`GlobalConfig` Pydantic model, so it
+    is always in sync with the actual configuration validation. It can be used
+    by editors (e.g. the VS Code YAML extension) for validation and
+    autocompletion of ``config.yaml`` files.
+
+    Returns:
+        A JSON Schema (draft 2020-12) document as a dictionary.
+    """
+    schema = GlobalConfig.model_json_schema()
+    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    schema["$id"] = (
+        "https://raw.githubusercontent.com/slauger/chantal/main/"
+        "docs/schema/chantal-config.schema.json"
+    )
+    schema["title"] = "Chantal Configuration"
+    return schema
+
+
 def load_config(config_path: Path | None = None) -> GlobalConfig:
     """Load configuration from file.
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,55 @@
+"""
+Tests for the configuration JSON Schema and the bundled example configs.
+
+These guard against two kinds of drift:
+- The committed JSON Schema going stale relative to the config models.
+- Example configs under ``examples/`` no longer validating against the schema.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from chantal.core.config import GlobalConfig, generate_json_schema
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_FILE = REPO_ROOT / "docs" / "schema" / "chantal-config.schema.json"
+EXAMPLE_FILES = sorted((REPO_ROOT / "examples").rglob("*.yaml"))
+
+
+def test_committed_schema_is_up_to_date():
+    """The committed schema file must match the schema generated from the models.
+
+    If this fails, regenerate it with: ``chantal schema -o docs/schema/chantal-config.schema.json``
+    """
+    committed = json.loads(SCHEMA_FILE.read_text(encoding="utf-8"))
+    assert committed == generate_json_schema(), (
+        "docs/schema/chantal-config.schema.json is out of date; regenerate with "
+        "'chantal schema -o docs/schema/chantal-config.schema.json'"
+    )
+
+
+def test_examples_exist():
+    """Sanity check that example configs are discovered."""
+    assert EXAMPLE_FILES, "no example configs found under examples/"
+
+
+@pytest.mark.parametrize("example", EXAMPLE_FILES, ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_example_config_validates(example):
+    """Every YAML document in every example config validates against the schema."""
+    with open(example, encoding="utf-8") as fh:
+        documents = list(yaml.safe_load_all(fh))
+
+    validated = 0
+    for index, doc in enumerate(documents):
+        if not doc:
+            continue
+        try:
+            GlobalConfig(**doc)
+        except Exception as exc:  # noqa: BLE001 - surface the file + doc index
+            pytest.fail(f"{example} (document {index}) is invalid:\n{exc}")
+        validated += 1
+
+    assert validated > 0, f"{example} contained no config documents"


### PR DESCRIPTION
## Summary

Adds a **JSON Schema for `config.yaml`**, generated from the Pydantic config models (single source of truth), plus automated validation of the bundled examples. JSON Schema works for YAML, so editors can validate and autocomplete configs.

This also answers a recurring need: a machine-readable schema for the config, like JSON Schema gives you for JSON.

## What's included

- **`generate_json_schema()`** in `core/config.py`, derived from `GlobalConfig` (draft 2020-12).
- **CLI `chantal schema [-o FILE]`** to emit / regenerate the schema.
- **Committed `docs/schema/chantal-config.schema.json`** + `docs/schema/README.md` (editor setup: `# yaml-language-server: $schema=…` modeline and VS Code `yaml.schemas` mapping).
- **`examples/config/config.yaml`**: a working schema modeline (relative path, keeps `yamllint --strict` happy).
- **`tests/test_schema.py`**:
  - validates **every YAML document** in `examples/**/*.yaml` against the models (multi-doc `---` files included), and
  - asserts the committed schema stays **in sync** with the models (fails if you change a model without regenerating).

## Fixes surfaced by the new validation

The example-validation test immediately caught pre-existing rot, now fixed:
- `retention.policy: keep_latest` → `keep-last-n` (the valid policy that uses `keep_count`): `apt/gitlab`, `apt/grafana`, `apt/lynis`, `rpm/lynis`.
- `type: deb` → `apt` in `filter-examples.yaml`.

## Verification

- Full suite green (incl. 34 example-config checks); `black`, `ruff`, `mypy`, and `yamllint --strict` all clean.
