### PR TITLE
feat: RSA index signing for APK filtered mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Python-based CLI tool for offline repository mirroring, inspired by pulp-admin
 - 🔐 **RHEL CDN Support** - Client certificate authentication for Red Hat repos
 - 🎯 **Smart Filtering** - Pattern-based package filtering with post-processing
 - 🪞 **Mirror & Filtered Modes** - Full metadata mirroring or filtered repos with regenerated metadata
-- 🔏 **GPG Metadata Signing** - Sign regenerated metadata in filtered mode: APT (InRelease/Release.gpg) and RPM (repomd.xml.asc) so clients can verify the repo
+- 🔏 **Metadata Signing** - Sign regenerated metadata in filtered mode: APT (InRelease/Release.gpg), RPM (repomd.xml.asc) and APK (RSA-signed APKINDEX) so clients can verify the repo
 - ⚡ **Fast Updates** - Check for updates without downloading (like `dnf check-update`)
 - 🚀 **Metadata Caching** - SHA256-based cache for RPM metadata (90-95% faster syncs for RHEL)
 

--- a/docs/plugins/apk-plugin.md
+++ b/docs/plugins/apk-plugin.md
@@ -23,7 +23,72 @@ The APK plugin consists of:
 - ✅ Snapshot support
 - ✅ Multi-architecture support (x86_64, aarch64, armhf, armv7, x86)
 - ✅ **Mirror Mode** - Byte-for-byte identical repositories with snapshot versioning
-- 🚧 Package signing/verification - Planned
+- ✅ RSA signing of the regenerated APKINDEX.tar.gz in filtered mode
+- 🚧 Package (.apk) signing/verification - Planned
+
+## Index Signing (Filtered Mode)
+
+**Status:** ✅ Available
+
+In filtered mode the published package set differs from upstream, so Chantal
+**regenerates** `APKINDEX.tar.gz`. That invalidates any upstream signature, so
+configure a `gpg` section to have Chantal sign the regenerated index with an
+**RSA key** (APK's own signing scheme - *not* GPG).
+
+When signing is enabled, publishing produces:
+
+- a signed `APKINDEX.tar.gz` (a `.SIGN.RSA256.<name>` signature segment prepended
+  to the index), and
+- `<repo-root>/<name>.rsa.pub` - the public key for client distribution.
+
+> APK uses RSA index signing (like `abuild-sign`), independent of the GPG signing
+> used by the APT/RPM plugins. The `gpg` config block is reused as the generic
+> "signing" section; for APK its `key_file` is an **RSA private key (PEM)**.
+
+### Configuration
+
+```yaml
+repositories:
+  - id: alpine-edge-filtered
+    type: apk
+    feed: https://dl-cdn.alpinelinux.org/alpine/edge/main
+    mode: filtered
+    apk:
+      branch: edge
+      repository: main
+      architecture: x86_64
+    filters:
+      patterns:
+        include: ["^nginx.*"]
+    gpg:
+      # RSA private key (PEM); or set generate_key: true to create one
+      key_file: /etc/chantal/keys/alpine.rsa
+      passphrase_file: /etc/chantal/keys/passphrase.txt
+      public_key_name: chantal.rsa.pub   # published at the repo root
+```
+
+| Option | Meaning for APK |
+|--------|-----------------|
+| `enabled` | Enable/disable signing (default: `true`) |
+| `key_file` | RSA **private** key (PEM) to sign with |
+| `generate_key` | Generate an RSA keypair on demand |
+| `passphrase` / `passphrase_file` | Private key passphrase |
+| `public_key_name` | Published public key filename (default: `<key_name>.rsa.pub`) |
+
+### Client configuration
+
+Install the public key into the apk keyring, then use the repo normally:
+
+```bash
+wget -O /etc/apk/keys/chantal.rsa.pub \
+  http://mirror.example.com/repos/alpine-edge-filtered/chantal.rsa.pub
+echo "http://mirror.example.com/repos/alpine-edge-filtered/edge/main" \
+  >> /etc/apk/repositories
+apk update
+```
+
+(Without a configured key, the index is published unsigned and clients need
+`apk --allow-untrusted`.)
 
 ## Repository Modes
 

--- a/examples/apk/filtered-signed.yaml
+++ b/examples/apk/filtered-signed.yaml
@@ -1,0 +1,49 @@
+# Filtered Alpine APK repository with RSA index signing
+#
+# In filtered mode Chantal regenerates APKINDEX.tar.gz for the filtered package
+# set, which invalidates any upstream signature. A `gpg` section makes Chantal
+# sign the regenerated index with an RSA key (APK's own scheme, like
+# abuild-sign - NOT GnuPG) so clients can verify it without --allow-untrusted.
+#
+# Signing is OPTIONAL: without a `gpg` section the index is published unsigned
+# (clients then need `apk --allow-untrusted`).
+#
+# Publishing produces:
+#   <branch>/<repo>/<arch>/APKINDEX.tar.gz   - signed (.SIGN.RSA256.<name> prepended)
+#   <name>.rsa.pub                           - public key for client distribution
+#
+# Client:
+#   wget -O /etc/apk/keys/chantal.rsa.pub \
+#     http://mirror.example.com/repos/alpine-edge-web/chantal.rsa.pub
+#   echo "http://mirror.example.com/repos/alpine-edge-web/edge/main" \
+#     >> /etc/apk/repositories
+#   apk update
+
+repositories:
+  - id: alpine-edge-web
+    name: "Alpine edge - Web (signed, filtered)"
+    type: apk
+    feed: "https://dl-cdn.alpinelinux.org/alpine/edge/main"
+    enabled: true
+    mode: filtered
+
+    apk:
+      branch: edge
+      repository: main
+      architecture: x86_64
+
+    filters:
+      patterns:
+        include:
+          - "^nginx.*"
+
+    # --- RSA index signing (optional) ---------------------------------------
+    gpg:
+      # RSA private key in PEM form
+      key_file: /etc/chantal/keys/alpine.rsa
+      passphrase_file: /etc/chantal/keys/passphrase.txt
+      public_key_name: chantal.rsa.pub   # published at the repo root
+
+      # Alternative: let Chantal generate an RSA keypair on first publish
+      # generate_key: true
+      # key_name: chantal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,11 @@ dependencies = [
     # Compression
     "zstandard>=0.23.0",  # >=0.23.0 includes type stubs
 
-    # GPG signing (APT filtered mode)
+    # GPG signing (APT/RPM filtered mode)
     "python-gnupg>=0.5.0",
+
+    # RSA signing of APK indexes (APKINDEX.tar.gz)
+    "cryptography>=42.0",
 
     # Progress & UI
     "tqdm>=4.66.0",

--- a/src/chantal/cli/publish_commands.py
+++ b/src/chantal/cli/publish_commands.py
@@ -429,6 +429,9 @@ def _publish_single_repository(
             click.echo(f"\n✗ Publishing failed: {e}", err=True)
             raise
     elif repo_config.type == "apk":
+        # Fall back to the global GPG/signing config if the repo has none.
+        if repo_config.gpg is None and global_config.gpg is not None:
+            repo_config.gpg = global_config.gpg
         apk_publisher = ApkPublisher(storage=storage)
         # Publish repository
         try:

--- a/src/chantal/plugins/apk/publisher.py
+++ b/src/chantal/plugins/apk/publisher.py
@@ -17,8 +17,9 @@ from sqlalchemy.orm import Session
 
 from chantal.core.config import RepositoryConfig
 from chantal.core.storage import StorageManager
-from chantal.db.models import ContentItem, Repository, Snapshot
+from chantal.db.models import ContentItem, Repository, RepositoryMode, Snapshot
 from chantal.plugins.apk.models import ApkMetadata
+from chantal.plugins.apk.signing import ApkSigner, ApkSigningError
 from chantal.plugins.base import PublisherPlugin
 
 logger = logging.getLogger(__name__)
@@ -140,7 +141,34 @@ class ApkPublisher(PublisherPlugin):
             session, repository, arch_path, config, packages, snapshot=snapshot
         )
 
+        # In filtered mode the regenerated APKINDEX invalidates any upstream
+        # signature. Sign it with our RSA key when configured so clients can
+        # verify it without --allow-untrusted. Mirror mode keeps upstream as-is.
+        if repository.mode == RepositoryMode.FILTERED:
+            gpg_config = config.gpg
+            if gpg_config is not None and gpg_config.enabled:
+                self._sign_index(arch_path / "APKINDEX.tar.gz", target_path, config)
+
         logger.info(f"Published {len(packages)} packages to {arch_path}")
+
+    def _sign_index(self, index_path: Path, target_path: Path, config: RepositoryConfig) -> None:
+        """Sign the APKINDEX.tar.gz with RSA and publish the public key.
+
+        Args:
+            index_path: Path to the generated APKINDEX.tar.gz.
+            target_path: Repository root where the public key is published.
+            config: Repository configuration (gpg section + display name).
+        """
+        gpg_config = config.gpg
+        assert gpg_config is not None
+        try:
+            signer = ApkSigner(gpg_config, default_name=config.display_name)
+            outputs = signer.sign_index_file(index_path, repo_root=target_path)
+            logger.info(f"Signed APKINDEX.tar.gz with RSA key '{signer.key_name}'")
+            for name in outputs:
+                logger.info(f"Published {name}")
+        except ApkSigningError as exc:
+            raise RuntimeError(f"APK signing failed for repo '{config.id}': {exc}") from exc
 
     def _publish_metadata_files(
         self,
@@ -164,6 +192,13 @@ class ApkPublisher(PublisherPlugin):
             packages: List of packages (for fallback generation)
             snapshot: Optional snapshot model instance
         """
+        # In filtered mode the published package set differs from upstream, so
+        # always regenerate the index (never hardlink the upstream APKINDEX -
+        # that would also be unsafe to sign, since it shares the pool inode).
+        if repository.mode == RepositoryMode.FILTERED:
+            self._generate_apkindex(packages, arch_path)
+            return
+
         # Find APKINDEX.tar.gz RepositoryFile
         apkindex_file = None
 

--- a/src/chantal/plugins/apk/signing.py
+++ b/src/chantal/plugins/apk/signing.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+"""
+RSA signing for APK repository indexes (``APKINDEX.tar.gz``).
+
+APK does not use GPG. A signed ``APKINDEX.tar.gz`` is the concatenation of two
+gzip members (apk reads them as one continuous tar stream):
+
+1. A *cut* tar (no trailing zero blocks) holding a single file
+   ``.SIGN.RSA256.<keyname>`` whose content is the RSA signature.
+2. The unsigned ``APKINDEX.tar.gz`` (the index segment).
+
+The signature is an RSA PKCS#1 v1.5 signature (SHA-256) over the raw bytes of
+the unsigned index segment - exactly what ``abuild-sign`` produces. The public
+key is published in PEM form; clients install it into ``/etc/apk/keys/``.
+
+Configuration reuses :class:`chantal.core.config.GpgConfig`:
+- ``key_file``        - path to an RSA private key (PEM)
+- ``generate_key``    - generate an RSA keypair on demand
+- ``passphrase`` / ``passphrase_file`` - private key passphrase
+- ``public_key_name`` - published public key filename (defaults to
+  ``<key_name>.rsa.pub``)
+"""
+
+import gzip
+import io
+import math
+import tarfile
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+from chantal.core.config import GpgConfig
+
+_TAR_BLOCK = 512
+
+
+class ApkSigningError(Exception):
+    """Raised when an APK signing operation fails."""
+
+
+class ApkSigner:
+    """Sign ``APKINDEX.tar.gz`` with an RSA key (abuild-compatible)."""
+
+    def __init__(self, config: GpgConfig, *, default_name: str | None = None):
+        """Initialize the signer.
+
+        Args:
+            config: Signing configuration (GpgConfig, reused for APK).
+            default_name: Fallback base name for a generated key / public key
+                filename (typically the repository id).
+        """
+        self.config = config
+        self._default_name = default_name
+        self._passphrase = config.read_passphrase()
+        self._private_key: RSAPrivateKey | None = None
+        self._key_name: str | None = None
+
+    @property
+    def key_name(self) -> str:
+        """Public key filename used in the ``.SIGN.RSA256.<name>`` entry."""
+        if self._key_name is None:
+            self._load_key()
+        assert self._key_name is not None
+        return self._key_name
+
+    def _private(self) -> RSAPrivateKey:
+        if self._private_key is None:
+            self._load_key()
+        assert self._private_key is not None
+        return self._private_key
+
+    def _load_key(self) -> None:
+        """Load the RSA private key (from file) or generate one."""
+        if self.config.key_file:
+            key_path = Path(self.config.key_file)
+            if not key_path.exists():
+                raise ApkSigningError(f"APK signing key file not found: {key_path}")
+            password = self._passphrase.encode("utf-8") if self._passphrase else None
+            try:
+                loaded = load_pem_private_key(key_path.read_bytes(), password=password)
+            except Exception as exc:  # noqa: BLE001
+                raise ApkSigningError(f"Failed to load RSA key from {key_path}: {exc}") from exc
+            if not isinstance(loaded, RSAPrivateKey):
+                raise ApkSigningError(f"Key in {key_path} is not an RSA private key")
+            self._private_key = loaded
+            self._key_name = self._resolve_public_name(default_base=key_path.stem)
+        elif self.config.generate_key:
+            self._private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            self._key_name = self._resolve_public_name(default_base=None)
+        else:
+            raise ApkSigningError("No APK signing key configured (set key_file or generate_key).")
+
+    def _resolve_public_name(self, *, default_base: str | None) -> str:
+        """Resolve the published public key filename.
+
+        ``GpgConfig.public_key_name`` defaults to ``key.gpg`` (the GPG default),
+        which is meaningless for APK; treat that as unset and derive a
+        ``<base>.rsa.pub`` name instead.
+        """
+        configured = self.config.public_key_name
+        if configured and configured != "key.gpg":
+            return configured
+        base = default_base or self.config.key_name or self._default_name or "chantal"
+        # Keep the filename safe and apk-friendly.
+        base = "".join(c if c.isalnum() or c in "-._" else "-" for c in base)
+        return f"{base}.rsa.pub"
+
+    def sign_index(self, unsigned_index: bytes) -> bytes:
+        """Sign an unsigned ``APKINDEX.tar.gz`` byte string.
+
+        Args:
+            unsigned_index: The bytes of the unsigned ``APKINDEX.tar.gz``.
+
+        Returns:
+            The signed ``APKINDEX.tar.gz`` bytes (signature segment + index).
+        """
+        signature = self._private().sign(unsigned_index, padding.PKCS1v15(), hashes.SHA256())
+        entry_name = f".SIGN.RSA256.{self.key_name}"
+        signature_segment = self._cut_tar_gz(entry_name, signature)
+        return signature_segment + unsigned_index
+
+    @staticmethod
+    def _cut_tar_gz(name: str, data: bytes) -> bytes:
+        """Build a gzip member holding a single *cut* tar entry.
+
+        "Cut" means the trailing zero blocks are removed so apk reads the next
+        gzip member as a continuation of the same tar stream (cf.
+        ``abuild-tar --cut``).
+        """
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tar:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(data))
+
+        # Keep only header (one block) + data padded to the block size.
+        padded = math.ceil(len(data) / _TAR_BLOCK) * _TAR_BLOCK
+        cut = buf.getvalue()[: _TAR_BLOCK + padded]
+
+        out = io.BytesIO()
+        with gzip.GzipFile(fileobj=out, mode="wb", mtime=0) as gz:
+            gz.write(cut)
+        return out.getvalue()
+
+    def export_public_key(self) -> bytes:
+        """Export the RSA public key in PEM form for client distribution."""
+        if self.config.public_key_file:
+            return Path(self.config.public_key_file).read_bytes()
+        return (
+            self._private()
+            .public_key()
+            .public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+        )
+
+    def sign_index_file(self, index_path: Path, repo_root: Path | None = None) -> dict[str, Path]:
+        """Sign an ``APKINDEX.tar.gz`` in place and publish the public key.
+
+        Args:
+            index_path: Path to the unsigned ``APKINDEX.tar.gz`` (overwritten).
+            repo_root: Repository root where the public key is published. If
+                None, the public key is not exported.
+
+        Returns:
+            Mapping of output name to the written path.
+        """
+        signed = self.sign_index(index_path.read_bytes())
+        index_path.write_bytes(signed)
+        outputs: dict[str, Path] = {"APKINDEX.tar.gz": index_path}
+
+        if repo_root is not None:
+            pubkey_path = repo_root / self.key_name
+            pubkey_path.write_bytes(self.export_public_key())
+            outputs[self.key_name] = pubkey_path
+
+        return outputs

--- a/tests/test_apk_signing.py
+++ b/tests/test_apk_signing.py
@@ -1,0 +1,253 @@
+"""
+Tests for APK repository index (APKINDEX.tar.gz) RSA signing.
+
+APK uses its own signing scheme (not GPG): the signed APKINDEX.tar.gz is a
+signature gzip segment (a cut tar holding ``.SIGN.RSA256.<name>``) concatenated
+with the unsigned index segment. The signature is RSA PKCS#1 v1.5 over SHA-256
+of the index segment bytes.
+"""
+
+import gzip
+import io
+import tarfile
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from chantal.core.config import ApkConfig, GpgConfig, RepositoryConfig, StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.models import Base, ContentItem, Repository, RepositoryMode
+from chantal.plugins.apk.models import ApkMetadata
+from chantal.plugins.apk.publisher import ApkPublisher
+from chantal.plugins.apk.signing import ApkSigner, ApkSigningError
+
+
+def _unsigned_index(content: bytes = b"C:Q1xxx\nP:test\nV:1.0\n\n") -> bytes:
+    """Build an unsigned APKINDEX.tar.gz (gzip(tar(APKINDEX)))."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo("APKINDEX")
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _extract_signature(signed: bytes, unsigned: bytes) -> tuple[str, bytes]:
+    """Return (sign-entry-name, signature bytes) from a signed index."""
+    segment = signed[: len(signed) - len(unsigned)]
+    raw = gzip.decompress(segment)  # the cut tar (no end blocks)
+    tar = tarfile.open(fileobj=io.BytesIO(raw + b"\0" * 1024), mode="r")
+    name = tar.getnames()[0]
+    extracted = tar.extractfile(name)
+    assert extracted is not None
+    return name, extracted.read()
+
+
+# --------------------------------------------------------------------------- #
+# ApkSigner
+# --------------------------------------------------------------------------- #
+
+
+class TestApkSigner:
+    def test_sign_index_structure_and_validity(self):
+        """A signed index prepends a valid RSA signature segment."""
+        config = GpgConfig(generate_key=True, key_name="chantal-test")
+        signer = ApkSigner(config)
+
+        unsigned = _unsigned_index()
+        signed = signer.sign_index(unsigned)
+
+        # The index segment is preserved at the end.
+        assert signed.endswith(unsigned)
+        assert signed != unsigned
+
+        name, signature = _extract_signature(signed, unsigned)
+        assert name == f".SIGN.RSA256.{signer.key_name}"
+
+        # The signature verifies against the public key over the index bytes.
+        pub = load_pem_public_key(signer.export_public_key())
+        pub.verify(signature, unsigned, padding.PKCS1v15(), hashes.SHA256())  # no raise
+
+    def test_key_name_defaults_to_rsa_pub(self):
+        config = GpgConfig(generate_key=True, key_name="mymirror")
+        signer = ApkSigner(config)
+        assert signer.key_name == "mymirror.rsa.pub"
+
+    def test_custom_public_key_name(self):
+        config = GpgConfig(generate_key=True, public_key_name="alpine-mirror.rsa.pub")
+        signer = ApkSigner(config)
+        assert signer.key_name == "alpine-mirror.rsa.pub"
+
+    def test_export_public_key_is_pem(self):
+        signer = ApkSigner(GpgConfig(generate_key=True))
+        pem = signer.export_public_key()
+        assert pem.startswith(b"-----BEGIN PUBLIC KEY-----")
+
+    def test_sign_with_key_file(self, tmp_path):
+        """An RSA private key from a file can be used to sign."""
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        key_pem = key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+        key_file = tmp_path / "signing.pem"
+        key_file.write_bytes(key_pem)
+
+        signer = ApkSigner(GpgConfig(key_file=str(key_file)))
+        unsigned = _unsigned_index()
+        signed = signer.sign_index(unsigned)
+
+        _, signature = _extract_signature(signed, unsigned)
+        key.public_key().verify(signature, unsigned, padding.PKCS1v15(), hashes.SHA256())
+        assert signer.key_name == "signing.rsa.pub"
+
+    def test_missing_key_file_raises(self, tmp_path):
+        signer = ApkSigner(GpgConfig(key_file=str(tmp_path / "nope.pem")))
+        with pytest.raises(ApkSigningError, match="key file not found"):
+            signer.sign_index(_unsigned_index())
+
+    def test_no_key_source_raises(self):
+        # enabled=False bypasses GpgConfig's own validation; the signer then
+        # refuses because no key source is configured.
+        signer = ApkSigner(GpgConfig(enabled=False))
+        with pytest.raises(ApkSigningError, match="No APK signing key"):
+            signer.sign_index(_unsigned_index())
+
+    def test_sign_index_file_writes_outputs(self, tmp_path):
+        signer = ApkSigner(GpgConfig(generate_key=True, key_name="repo"))
+        index = tmp_path / "APKINDEX.tar.gz"
+        unsigned = _unsigned_index()
+        index.write_bytes(unsigned)
+
+        outputs = signer.sign_index_file(index, repo_root=tmp_path)
+        assert index.read_bytes().endswith(unsigned)
+        assert (tmp_path / "repo.rsa.pub").exists()
+        assert set(outputs) == {"APKINDEX.tar.gz", "repo.rsa.pub"}
+
+
+# --------------------------------------------------------------------------- #
+# Publisher integration
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def temp_storage(tmp_path):
+    pool_path = tmp_path / "pool"
+    pool_path.mkdir()
+    return StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(pool_path),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+
+
+def _make_apk_repo(db_session, temp_storage, tmp_path, mode):
+    repo = Repository(
+        repo_id="test-apk",
+        name="Test APK",
+        type="apk",
+        feed="https://example.com/alpine",
+        enabled=True,
+        mode=mode,
+    )
+    db_session.add(repo)
+    db_session.commit()
+
+    apk_file = tmp_path / "test-1.0-r0.apk"
+    apk_file.write_bytes(b"fake apk" * 32)
+    sha256, pool_path, size_bytes = temp_storage.add_package(apk_file, "test-1.0-r0.apk")
+
+    metadata = ApkMetadata(
+        name="test",
+        version="1.0-r0",
+        architecture="x86_64",
+        checksum="Q1abc",
+        size=size_bytes,
+    )
+    item = ContentItem(
+        content_type="apk",
+        name="test",
+        version="1.0-r0",
+        sha256=sha256,
+        size_bytes=size_bytes,
+        pool_path=pool_path,
+        filename="test-1.0-r0.apk",
+        content_metadata=metadata.model_dump(),
+    )
+    item.repositories.append(repo)
+    db_session.add(item)
+    db_session.commit()
+    return repo
+
+
+def _apk_config(mode, gpg):
+    return RepositoryConfig(
+        id="test-apk",
+        name="Test APK",
+        type="apk",
+        feed="https://example.com/alpine",
+        mode=mode,
+        apk=ApkConfig(branch="v3.19", repository="main", architecture="x86_64"),
+        gpg=gpg,
+    )
+
+
+def _index_path(target):
+    return target / "v3.19" / "main" / "x86_64" / "APKINDEX.tar.gz"
+
+
+class TestApkPublisherSigning:
+    def test_filtered_mode_signs_index(self, db_session, temp_storage, tmp_path):
+        repo = _make_apk_repo(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED)
+        config = _apk_config("filtered", GpgConfig(generate_key=True, key_name="chantal"))
+        target = tmp_path / "published" / "test-apk"
+
+        ApkPublisher(storage=temp_storage).publish_repository(
+            session=db_session, repository=repo, config=config, target_path=target
+        )
+
+        index = _index_path(target)
+        assert index.exists()
+        # Signed index contains the RSA signature marker.
+        assert b".SIGN.RSA256.chantal.rsa.pub" in gzip.decompress(index.read_bytes())
+        assert (target / "chantal.rsa.pub").exists()
+
+    def test_filtered_mode_without_gpg_is_unsigned(self, db_session, temp_storage, tmp_path):
+        repo = _make_apk_repo(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED)
+        config = _apk_config("filtered", None)
+        target = tmp_path / "published" / "test-apk"
+
+        ApkPublisher(storage=temp_storage).publish_repository(
+            session=db_session, repository=repo, config=config, target_path=target
+        )
+
+        index = _index_path(target)
+        assert index.exists()
+        assert b".SIGN.RSA" not in gzip.decompress(index.read_bytes())
+
+    def test_disabled_gpg_is_unsigned(self, db_session, temp_storage, tmp_path):
+        repo = _make_apk_repo(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED)
+        config = _apk_config("filtered", GpgConfig(enabled=False))
+        target = tmp_path / "published" / "test-apk"
+
+        ApkPublisher(storage=temp_storage).publish_repository(
+            session=db_session, repository=repo, config=config, target_path=target
+        )
+
+        assert b".SIGN.RSA" not in gzip.decompress(_index_path(target).read_bytes())


### PR DESCRIPTION
## Summary

Brings signing parity to the APK plugin so all four formats can sign their regenerated metadata in filtered mode.

**APK does not use GPG.** A signed `APKINDEX.tar.gz` is a `.SIGN.RSA256.<name>` signature segment (a *cut* tar) prepended to the unsigned index, with an RSA PKCS#1 v1.5 / SHA-256 signature over the index bytes — exactly what `abuild-sign` produces. The RSA public key is published for clients (`/etc/apk/keys/`).

## What's included

- **`ApkSigner`** (`plugins/apk/signing.py`, using `cryptography`): builds the abuild-compatible signed index and exports the RSA public key. Reuses `GpgConfig` (`key_file` = RSA private PEM, `generate_key`, `passphrase`/`passphrase_file`, `public_key_name`).
- **`ApkPublisher`**: signs in **filtered mode** only; mirror mode keeps the upstream index untouched. Global signing-config fallback wired into the APK publish path.
- **Filtered-mode fix**: the index is now always *regenerated* in filtered mode. Previously it could hardlink the pooled upstream `APKINDEX` — signing that in place would corrupt the shared inode. Regenerating is also the correct behaviour for a filtered package set.
- Optional + disabled unless a `gpg` section is set. The `.apk` packages themselves are never re-signed.

## Scope notes

- This signs the repository **index** (`APKINDEX.tar.gz`). Signing individual `.apk` packages remains a separate, planned feature.
- The `gpg:` config block is reused as the generic "signing" section; for APK its key is RSA (not GnuPG).

## Tests & docs

- `tests/test_apk_signing.py`: signer (structure, RSA verification against the exported public key, key-from-file, custom names, error paths) and publisher integration (filtered signs / mirror & no-gpg & disabled stay unsigned).
- Docs (`apk-plugin.md`), README, and `examples/apk/filtered-signed.yaml` (validated by the schema/example test).
- `black`, `ruff`, `mypy`, `yamllint --strict`, full suite all green.

## Dependency

- Adds `cryptography>=42.0` (joins the existing compiled deps; ships wheels for 3.12–3.14).
