### PR TITLE
ci: Bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -78,7 +78,7 @@ jobs:
 
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -45,7 +45,7 @@ jobs:
           make html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/lint-and-type-check.yml
+++ b/.github/workflows/lint-and-type-check.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}


### PR DESCRIPTION
Resolves the CI deprecation warning that actions/checkout, actions/setup-python and actions/cache were being forced onto Node.js 24.

Bump all Node-based GitHub Actions to their current major (Node 24 native):

- actions/checkout v4 -> v7
- actions/setup-python v5 -> v6
- actions/cache v4 -> v5
- actions/upload-pages-artifact v3 -> v5
- actions/deploy-pages v4 -> v5
- actions/attest-build-provenance v1 -> v4

The docker/* actions are container-based (not Node) and are unaffected. Usage of each action is the default/basic form, so the major bumps are drop-in.