### PR TITLE
docs: Correct plugin signing/verification status

### DIFF
--- a/docs/plugins/apk-plugin.md
+++ b/docs/plugins/apk-plugin.md
@@ -24,7 +24,7 @@ The APK plugin consists of:
 - ✅ Multi-architecture support (x86_64, aarch64, armhf, armv7, x86)
 - ✅ **Mirror Mode** - Byte-for-byte identical repositories with snapshot versioning
 - ✅ RSA signing of the regenerated APKINDEX.tar.gz in filtered mode
-- 🚧 Package (.apk) signing/verification - Planned
+- ℹ️ Individual `.apk` packages are served unmodified and keep their upstream signatures (Chantal does not re-sign packages)
 
 ## Index Signing (Filtered Mode)
 

--- a/docs/plugins/helm-plugin.md
+++ b/docs/plugins/helm-plugin.md
@@ -21,8 +21,8 @@ The Helm plugin consists of:
 - ✅ Chart deduplication via content-addressed storage
 - ✅ Snapshot support
 - ✅ **Mirror Mode** - Byte-for-byte identical repositories with snapshot versioning
-- 🚧 Chart signing/verification - Planned
-- 🚧 OCI registry support - Planned
+- ✅ OCI registry support (`oci://` chart repositories)
+- ℹ️ Charts are served unmodified; Chantal does not sign or re-sign charts (upstream Helm provenance `.prov` files are preserved if present)
 
 ## Repository Modes
 

--- a/docs/plugins/rpm-plugin.md
+++ b/docs/plugins/rpm-plugin.md
@@ -45,7 +45,10 @@ The RPM plugin consists of:
 
 **Planned:**
 - 🚧 Delta RPMs
-- 🚧 GPG signature verification of upstream packages during sync
+
+**Note:** RPM packages are served unmodified and keep their upstream signatures
+(verified client-side with `gpgcheck=1`). Chantal signs only the repository
+metadata (`repomd.xml.asc`) in filtered mode and does not re-sign packages.
 
 ## Configuration
 


### PR DESCRIPTION
The plugin docs listed untracked "Planned" signing/verification features (no issues) and a stale "Planned" entry for Helm OCI (actually implemented via #34).

- APK/RPM/Helm: replace the speculative "signing/verification - Planned" bullets with factual notes - packages/charts are served unmodified and keep their upstream signatures; Chantal signs only the repository *metadata* (APT InRelease/Release.gpg, RPM repomd.xml.asc, APK APKINDEX) in filtered mode.
- Helm: mark OCI registry support as available (checked) instead of planned.