### PR TITLE
docs: Remove unimplemented formats, fix stale plugin status

### DIFF
--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -51,7 +51,7 @@ Configured repositories from YAML.
 class Repository(Base):
     id: str               # Primary key (from config)
     name: str             # Human-readable name
-    type: str             # Repository type (rpm, apt, pypi)
+    type: str             # Repository type (rpm, apt, helm, apk)
     feed_url: str         # Upstream URL
     enabled: bool         # Whether enabled
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -27,7 +27,7 @@ Chantal follows a clean, modular architecture designed for simplicity and extens
                      │
 ┌────────────────────▼────────────────────────────────────┐
 │                 Plugin Layer                            │
-│  • Sync Plugins (RPM, APT, PyPI)                        │
+│  • Sync Plugins (RPM, APT, Helm, APK)                   │
 │  • Publisher Plugins (metadata generation)              │
 └────────────────────┬────────────────────────────────────┘
                      │
@@ -139,8 +139,9 @@ pool/
 
 **Plugins:**
 - `RpmSyncPlugin` - RPM/DNF/YUM repositories
-- `DebSyncPlugin` - APT repositories (future)
-- `PypiSyncPlugin` - Python Package Index (future)
+- `AptSyncPlugin` - Debian/Ubuntu APT repositories
+- `HelmSyncPlugin` - Helm chart repositories (HTTP and OCI)
+- `ApkSyncPlugin` - Alpine APK repositories
 
 **Key Files:**
 - `src/chantal/plugins/base.py` - Base plugin interface

--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -1,6 +1,6 @@
 # Plugin System
 
-Chantal uses a plugin architecture to support different repository types (RPM, DEB/APT, PyPI, etc.).
+Chantal uses a plugin architecture to support different repository types (RPM, DEB/APT, Helm, Alpine APK).
 
 ## Overview
 
@@ -96,39 +96,29 @@ class PublisherPlugin(ABC):
 - Creates hardlinks to pool
 - Compresses metadata with gzip
 
-**File:** `src/chantal/plugins/rpm.py`, `src/chantal/plugins/rpm_sync.py`
+**File:** `src/chantal/plugins/rpm/sync.py`, `src/chantal/plugins/rpm/publisher.py`
 
-### DEB/APT Plugin
+### APT/DEB Plugin
 
-**Status:** 🚧 Planned
+**Status:** ✅ Available
 
-**Sync Plugin:** `DebSyncPlugin` (planned)
-- Fetch `InRelease` / `Release`
-- Parse `Packages.gz`
-- Download DEB packages
+**Sync Plugin:** `AptSyncPlugin`
+- Fetches `InRelease` / `Release`
+- Parses `Packages(.gz)`
+- Downloads DEB packages
 
-**Publisher Plugin:** `DebPublisher` (planned)
-- Generate `InRelease` / `Release`
-- Generate `Packages.gz`
-- Sign with GPG
+**Publisher Plugin:** `AptPublisher`
+- Generates `Packages` indices and the `Release` file
+- Signs metadata with GPG in filtered mode (`InRelease`, `Release.gpg`)
 
-**Challenges:**
-- APT signatures must remain valid
-- Complex metadata structure
-- Multiple compression formats
+**File:** `src/chantal/plugins/apt/sync.py`, `src/chantal/plugins/apt/publisher.py`
 
-### PyPI Plugin
+### Helm & Alpine APK Plugins
 
-**Status:** 🚧 Planned
+**Status:** ✅ Available
 
-**Sync Plugin:** `PypiSyncPlugin` (planned)
-- Fetch simple index (HTML)
-- Parse package links
-- Download wheels and source distributions
-
-**Publisher Plugin:** `PypiPublisher` (planned)
-- Generate simple index HTML
-- Generate JSON API (optional)
+- **Helm:** `HelmSyncPlugin` / `HelmPublisher` - HTTP and OCI registries, `index.yaml`
+- **APK:** `ApkSyncPlugin` / `ApkPublisher` - `APKINDEX.tar.gz`, RSA index signing
 
 ## Plugin Registration
 
@@ -139,14 +129,16 @@ Plugins are registered in the plugin registry:
 
 SYNC_PLUGINS = {
     'rpm': RpmSyncPlugin,
-    'apt': DebSyncPlugin,  # Future
-    'pypi': PypiSyncPlugin,  # Future
+    'apt': AptSyncPlugin,
+    'helm': HelmSyncPlugin,
+    'apk': ApkSyncPlugin,
 }
 
 PUBLISHER_PLUGINS = {
     'rpm': RpmPublisher,
-    'apt': DebPublisher,  # Future
-    'pypi': PypiPublisher,  # Future
+    'apt': AptPublisher,
+    'helm': HelmPublisher,
+    'apk': ApkPublisher,
 }
 ```
 
@@ -207,7 +199,7 @@ PUBLISHER_PLUGINS['my_type'] = MyPublisher
 ```python
 # In src/chantal/core/config.py
 class RepositoryConfig(BaseModel):
-    type: Literal['rpm', 'apt', 'pypi', 'my_type']
+    type: Literal['rpm', 'apt', 'helm', 'apk', 'my_type']
 ```
 
 ## Plugin Lifecycle

--- a/docs/configuration/repositories.md
+++ b/docs/configuration/repositories.md
@@ -18,7 +18,7 @@ repositories:
 **Required Fields:**
 - `id`: Unique identifier (alphanumeric, hyphens, underscores)
 - `name`: Human-readable name
-- `type`: Repository type (`rpm`, `apt`, `helm`, `apk`, future: `pypi`, `npm`)
+- `type`: Repository type (`rpm`, `apt`, `helm`, `apk`)
 - `feed`: Upstream repository URL
 - `enabled`: Whether to include in `--all` operations
 
@@ -144,28 +144,13 @@ repositories:
 
 **Optional APT Configuration:**
 - `apt.include_source_packages`: Whether to sync source packages (default: false)
-- `mode`: Repository mode (currently only `mirror` supported, `filtered` planned for Phase 2)
+- `mode`: Repository mode (`mirror`, `filtered`, or `hosted`; defaults to `filtered`)
 
 **Feed URL Requirements:**
 - Must point to APT repository base URL
 - Distribution Release file location: `{feed}/dists/{distribution}/Release`
 
 See [APT Plugin Documentation](../plugins/apt-plugin.md) for detailed examples and configuration options.
-
-### PyPI Repositories (Future)
-
-For Python package mirroring:
-
-```yaml
-repositories:
-  - id: pypi-mirror
-    name: PyPI Mirror
-    type: pypi
-    feed: https://pypi.org/simple/
-    enabled: true
-```
-
-**Note:** PyPI support is planned for v2.0.
 
 ## Advanced Options
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Chantal is a Python-based CLI tool for offline repository mirroring, inspired by
 
 - Version control (snapshots for rollback)
 - Efficient storage (deduplication across repos)
-- Support for multiple ecosystems (RPM, DEB/APT, PyPI)
+- Support for multiple ecosystems (RPM, DEB/APT, Helm, Alpine APK)
 - RHEL subscription support
 - Simple management
 
@@ -39,22 +39,9 @@ Chantal is a Python-based CLI tool for offline repository mirroring, inspired by
 +---------------------+----------------------------------+-------------------+
 | Alpine APK          | Alpine Linux packages            | ✅ **Available**  |
 +---------------------+----------------------------------+-------------------+
-| PyPI                | Python Package Index             | 🚧 Planned        |
-+---------------------+----------------------------------+-------------------+
-| npm/yarn            | Node.js package registries       | 🚧 Planned        |
-+---------------------+----------------------------------+-------------------+
-| RubyGems            | Ruby package registry            | 🔬 Research       |
-+---------------------+----------------------------------+-------------------+
-| NuGet               | .NET package registry            | 🔬 Research       |
-+---------------------+----------------------------------+-------------------+
-| Go Modules          | Go package repositories          | 🔬 Research       |
-+---------------------+----------------------------------+-------------------+
-| Terraform Provider  | Terraform provider registry      | 🔬 Research       |
-+---------------------+----------------------------------+-------------------+
 
-**Legend:** ✅ Available | 🚧 Planned | 🔬 Research Phase
-
-See `GitHub Issues <https://github.com/slauger/chantal/issues>`_ for details and progress.
+Additional package ecosystems are tracked on the
+`GitHub Issues <https://github.com/slauger/chantal/issues>`_ tracker.
 
 Features
 --------
@@ -65,8 +52,6 @@ Features
   - ✅ **DEB/APT** (Debian, Ubuntu) - *Available now*
   - ✅ **Helm Charts** (Kubernetes chart repositories) - *Available now*
   - ✅ **Alpine APK** (Alpine Linux packages) - *Available now*
-  - 🚧 **PyPI, npm** - *Planned*
-  - 🔬 **RubyGems, NuGet, Go Modules, Terraform** - *Research phase*
 
 - 📦 **Deduplication** - Content-addressed storage (SHA256), packages stored once
 - 📸 **Snapshots** - Immutable point-in-time repository states for patch management

--- a/docs/plugins/custom-plugins.md
+++ b/docs/plugins/custom-plugins.md
@@ -262,7 +262,7 @@ Update `src/chantal/core/config.py`:
 class RepositoryConfig(BaseModel):
     id: str
     name: str
-    type: Literal['rpm', 'apt', 'pypi', 'my_type']  # Add your type
+    type: Literal['rpm', 'apt', 'helm', 'apk', 'my_type']  # Add your type
     feed: str
     enabled: bool = True
     # ... other fields

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -4,7 +4,7 @@ Chantal's plugin architecture enables support for different repository types.
 
 ## What are Plugins?
 
-Plugins extend Chantal to support different repository types like RPM, DEB/APT, PyPI, etc. Each repository type requires two types of plugins:
+Plugins extend Chantal to support different repository types: RPM, DEB/APT, Helm, and Alpine APK. Each repository type requires two types of plugins:
 
 1. **Sync Plugin** - Downloads and stores packages from upstream
 2. **Publisher Plugin** - Creates publishable repositories with correct metadata
@@ -17,8 +17,8 @@ Plugins extend Chantal to support different repository types like RPM, DEB/APT, 
 | [APT/DEB](apt-plugin.md) | Sync + Publisher | ✅ Available | Debian/Ubuntu APT repositories |
 | [Helm](helm-plugin.md) | Sync + Publisher | ✅ Available | Kubernetes Helm chart repositories |
 | [Alpine APK](apk-plugin.md) | Sync + Publisher | ✅ Available | Alpine Linux package repositories |
-| PyPI | Sync + Publisher | 🚧 Planned | Python Package Index |
-| npm | Sync + Publisher | 🚧 Planned | Node.js package repositories |
+
+Additional package ecosystems are tracked on the [GitHub Issues](https://github.com/slauger/chantal/issues) tracker.
 
 ## Plugin Architecture
 
@@ -93,15 +93,17 @@ For Debian/Ubuntu-based distributions.
 
 **See:** [APT Plugin Documentation](apt-plugin.md)
 
-### PyPI Plugin (Planned)
+### Helm Plugin
 
-For Python Package Index mirroring.
+For Kubernetes Helm chart repositories (HTTP and OCI registries).
 
-**Planned features:**
-- Simple Index API (PEP 503)
-- Wheel and source distribution support
-- JSON API generation
-- Requirements.txt filtering
+**See:** [Helm Plugin Documentation](helm-plugin.md)
+
+### Alpine APK Plugin
+
+For Alpine Linux package repositories.
+
+**See:** [Alpine APK Plugin Documentation](apk-plugin.md)
 
 ## Creating Custom Plugins
 


### PR DESCRIPTION
The docs advertised package ecosystems that are not implemented (only tracked as issues) and carried several stale/incorrect status claims.

**Removed unimplemented formats** from index, plugin overview, configuration, architecture and custom-plugins docs: PyPI, npm/yarn, RubyGems, NuGet, Go Modules, Terraform. They remain tracked on the issue tracker (#5-#10).

**Fixed incorrect statuses:**
- APT/DEB was marked "Planned" in plugin-system.md - it is available.
- repositories.md claimed "only mirror supported, filtered planned for Phase 2" - filtered is the default mode.
- Helm OCI registry support was "Planned" - implemented in #34.

**Other accuracy fixes:**
- Corrected stale module paths (src/chantal/plugins/rpm/...).
- Updated plugin registry / Literal examples to the real types (rpm, apt, helm, apk).
- Added the missing Helm/APK plugin entries to the architecture/overview docs.