### PR TITLE
test: End-to-end sync→publish tests for all plugins

### DIFF
--- a/.github/workflows/lint-and-type-check.yml
+++ b/.github/workflows/lint-and-type-check.yml
@@ -66,8 +66,36 @@ jobs:
         # Type checking is now enforced - all code must pass mypy
         # See CONTRIBUTING.md for type annotation guidelines
 
-      - name: Run pytest
+      - name: Run pytest (unit tests)
         run: |
           echo "Running pytest..."
-          pytest tests/ -v --tb=short
+          pytest tests/ -v --tb=short -m "not e2e"
         continue-on-error: false
+
+  e2e:
+    name: E2E (${{ matrix.plugin }})
+    needs: lint-and-type-check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        plugin: [rpm, apt, helm, apk]
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run end-to-end sync->publish test
+        run: |
+          echo "Running E2E sync->publish for ${{ matrix.plugin }}..."
+          pytest tests/e2e -v -m e2e -k ${{ matrix.plugin }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,9 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
+markers = [
+    "e2e: end-to-end sync->publish tests (build a fixture repo, sync, publish)",
+]
 
 # Coverage configuration
 [tool.coverage.run]

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -226,8 +226,9 @@ class AptPublisher(PublisherPlugin):
         grouped: dict[tuple[str, str], list[ContentItem]] = {}
 
         for package in packages:
-            component = package.content_metadata.get("component", "main")
-            architecture = package.content_metadata.get("architecture", "amd64")
+            # Use `or` so an explicit None in the metadata still falls back.
+            component = package.content_metadata.get("component") or "main"
+            architecture = package.content_metadata.get("architecture") or "amd64"
 
             key = (component, architecture)
             if key not in grouped:

--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -189,6 +189,12 @@ class AptSyncPlugin:
                     logger.error(f"Failed to parse Packages file: {e}")
                     continue
 
+                # Component comes from the repository layout, not the Packages
+                # stanza - propagate it onto each package.
+                for pkg in packages:
+                    if not pkg.component:
+                        pkg.component = metadata_info.component
+
                 self.output.verbose(f"  Found {len(packages)} packages")
                 all_packages.extend(packages)
 

--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -166,7 +166,7 @@ class HelmSyncer:
                     sha256=sha256,
                     filename=Path(chart_url).name,
                     size_bytes=size,
-                    pool_path=pool_path,
+                    pool_path=str(pool_path),
                     content_type="helm",
                     content_metadata=metadata.model_dump(mode="json"),
                 )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,110 @@
+"""
+Shared harness for end-to-end sync->publish tests.
+
+These tests build a minimal upstream repository (one package) with pure Python,
+serve it over a local HTTP server, then drive the real `chantal` CLI through
+`db init` -> `repo sync` -> `publish repo` against a temporary SQLite database,
+and assert on the published output.
+
+No native build tools and no committed binaries are required: the "package"
+files are dummy byte strings whose checksums are computed and embedded in the
+generated metadata, which is exactly what Chantal verifies during sync.
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import socketserver
+import subprocess
+import sys
+import threading
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def serve() -> Callable[[Path], str]:
+    """Serve a directory over HTTP on localhost; returns the base URL.
+
+    Multiple directories can be served; all servers are shut down on teardown.
+    """
+    servers: list[socketserver.TCPServer] = []
+
+    def _serve(directory: Path) -> str:
+        handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+        httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        servers.append(httpd)
+        return f"http://127.0.0.1:{port}"
+
+    yield _serve
+
+    for httpd in servers:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+@pytest.fixture
+def chantal_env(tmp_path: Path):
+    """Provide a configured Chantal environment driver.
+
+    Returns a helper object with:
+    - ``write_config(repo)``: write a config.yaml with sqlite + temp storage
+      and a single repository definition, then run ``db init``.
+    - ``run(*args)``: run the chantal CLI with ``--config`` and return the
+      CompletedProcess (asserting success).
+    - ``published`` / ``pool``: the published and pool target paths.
+    """
+
+    class _Env:
+        def __init__(self) -> None:
+            self.config_path = tmp_path / "config.yaml"
+            self.db_path = tmp_path / "chantal.db"
+            self.base = tmp_path / "data"
+            self.pool = self.base / "pool"
+            self.published = tmp_path / "published"
+
+        def run(self, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+            cmd = [
+                sys.executable,
+                "-m",
+                "chantal.cli.main",
+                "--config",
+                str(self.config_path),
+                *args,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if check and result.returncode != 0:
+                raise AssertionError(
+                    f"command failed ({' '.join(args)}): rc={result.returncode}\n"
+                    f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+                )
+            return result
+
+        def write_config(self, repo: dict) -> None:
+            config = {
+                "database": {"url": f"sqlite:///{self.db_path}"},
+                "storage": {
+                    "base_path": str(self.base),
+                    "pool_path": str(self.pool),
+                    "published_path": str(self.published),
+                },
+                "repositories": [repo],
+            }
+            self.config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+            self.run("db", "init")
+
+        def sync_and_publish(self, repo_id: str) -> Path:
+            """Run sync + publish for repo_id; return the published target dir."""
+            self.run("repo", "sync", "--repo-id", repo_id)
+            target = self.published / repo_id
+            self.run("publish", "repo", "--repo-id", repo_id, "--target", str(target))
+            return target
+
+    return _Env()

--- a/tests/e2e/test_apk_e2e.py
+++ b/tests/e2e/test_apk_e2e.py
@@ -1,0 +1,79 @@
+"""End-to-end sync->publish test for the Alpine APK plugin."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+BRANCH = "v3.19"
+REPO = "main"
+ARCH = "x86_64"
+
+
+def _build_apk_upstream(root: Path) -> None:
+    """Create a minimal Alpine repo (APKINDEX.tar.gz + one .apk)."""
+    arch_dir = root / BRANCH / REPO / ARCH
+    arch_dir.mkdir(parents=True, exist_ok=True)
+
+    apk = b"dummy apk payload" * 16
+    (arch_dir / "demo-1.0-r0.apk").write_bytes(apk)
+    # APK checksum field: "Q1" + base64(sha1(file))
+    q1 = "Q1" + base64.b64encode(hashlib.sha1(apk).digest()).decode("ascii")
+
+    apkindex = (
+        f"C:{q1}\n"
+        "P:demo\n"
+        "V:1.0-r0\n"
+        f"A:{ARCH}\n"
+        f"S:{len(apk)}\n"
+        f"I:{len(apk)}\n"
+        "T:demo package\n"
+        "U:http://example.com\n"
+        "L:MIT\n"
+        "o:demo\n"
+        "m:Test <test@example.com>\n"
+        "t:1\n"
+        "\n"
+    ).encode()
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo("APKINDEX")
+        info.size = len(apkindex)
+        tar.addfile(info, io.BytesIO(apkindex))
+    (arch_dir / "APKINDEX.tar.gz").write_bytes(buf.getvalue())
+
+
+def test_apk_sync_and_publish(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apk_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apk",
+            "name": "Demo APK",
+            "type": "apk",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apk": {
+                "branch": BRANCH,
+                "repository": REPO,
+                "architecture": ARCH,
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apk")
+
+    # APKINDEX.tar.gz was regenerated and the .apk was published.
+    assert list(target.rglob("APKINDEX.tar.gz")), "published APKINDEX not found"
+    assert list(target.rglob("demo-1.0-r0.apk")), "published .apk not found"

--- a/tests/e2e/test_apt_e2e.py
+++ b/tests/e2e/test_apt_e2e.py
@@ -1,0 +1,87 @@
+"""End-to-end sync->publish test for the APT/DEB plugin."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _build_apt_upstream(root: Path) -> None:
+    """Create a minimal APT repo (Release + Packages(.gz) + one .deb)."""
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    deb_path = root / deb_rel
+    deb_path.parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    deb_path.write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        "Maintainer: Test <test@example.com>\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo package\n"
+        "\n"
+    ).encode()
+
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    rel_pkgs = f"{COMP}/binary-{ARCH}/Packages"
+    sha = hashlib.sha256
+    release = (
+        "Origin: Test\n"
+        "Label: Test\n"
+        f"Suite: {DIST}\n"
+        f"Codename: {DIST}\n"
+        f"Components: {COMP}\n"
+        f"Architectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\n"
+        "SHA256:\n"
+        f" {sha(packages).hexdigest()} {len(packages)} {rel_pkgs}\n"
+        f" {sha(packages_gz).hexdigest()} {len(packages_gz)} {rel_pkgs}.gz\n"
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def test_apt_sync_and_publish(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt",
+            "name": "Demo APT",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {
+                "distribution": DIST,
+                "components": [COMP],
+                "architectures": [ARCH],
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt")
+
+    # Release + Packages were regenerated and the .deb was published.
+    assert (target / "dists" / DIST / "Release").exists()
+    assert list(target.rglob("Packages")), "published Packages index not found"
+    assert list(target.rglob("demo_1.0_amd64.deb")), "published .deb not found"

--- a/tests/e2e/test_helm_e2e.py
+++ b/tests/e2e/test_helm_e2e.py
@@ -1,0 +1,61 @@
+"""End-to-end sync->publish test for the Helm plugin."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.e2e
+
+
+def _build_helm_upstream(root: Path) -> None:
+    """Create a minimal Helm chart repository (index.yaml + one chart)."""
+    root.mkdir(parents=True, exist_ok=True)
+    chart = b"dummy helm chart tgz payload" * 8
+    (root / "demo-0.1.0.tgz").write_bytes(chart)
+    index = {
+        "apiVersion": "v1",
+        "entries": {
+            "demo": [
+                {
+                    "name": "demo",
+                    "version": "0.1.0",
+                    "digest": hashlib.sha256(chart).hexdigest(),
+                    "urls": ["demo-0.1.0.tgz"],
+                }
+            ]
+        },
+        "generated": "2026-01-01T00:00:00Z",
+    }
+    (root / "index.yaml").write_text(yaml.safe_dump(index), encoding="utf-8")
+
+
+def test_helm_sync_and_publish(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_helm_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-helm",
+            "name": "Demo Helm",
+            "type": "helm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-helm")
+
+    # The chart was downloaded into the pool and published.
+    assert list(target.rglob("demo-0.1.0.tgz")), "published chart .tgz not found"
+
+    # A regenerated index.yaml lists the chart.
+    indexes = list(target.rglob("index.yaml"))
+    assert indexes, "published index.yaml not found"
+    index = yaml.safe_load(indexes[0].read_text())
+    assert "demo" in index.get("entries", {})

--- a/tests/e2e/test_rpm_e2e.py
+++ b/tests/e2e/test_rpm_e2e.py
@@ -1,0 +1,89 @@
+"""End-to-end sync->publish test for the RPM plugin."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+def _build_rpm_upstream(root: Path) -> None:
+    """Create a minimal yum/dnf repo (repomd.xml + primary.xml.gz + one rpm)."""
+    repodata = root / "repodata"
+    repodata.mkdir(parents=True, exist_ok=True)
+
+    rpm = b"dummy rpm payload" * 16
+    rpm_name = "demo-1.0-1.el9.x86_64.rpm"
+    (root / rpm_name).write_bytes(rpm)
+    rpm_sha = hashlib.sha256(rpm).hexdigest()
+
+    primary = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<metadata xmlns="http://linux.duke.edu/metadata/common"'
+        ' xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="1">\n'
+        '<package type="rpm">\n'
+        "  <name>demo</name>\n"
+        "  <arch>x86_64</arch>\n"
+        '  <version epoch="0" ver="1.0" rel="1.el9"/>\n'
+        f'  <checksum type="sha256" pkgid="YES">{rpm_sha}</checksum>\n'
+        "  <summary>demo</summary>\n"
+        "  <description>demo package</description>\n"
+        '  <time file="1" build="1"/>\n'
+        f'  <size package="{len(rpm)}" installed="{len(rpm)}" archive="{len(rpm)}"/>\n'
+        f'  <location href="{rpm_name}"/>\n'
+        "  <format>\n"
+        "    <rpm:license>MIT</rpm:license>\n"
+        "    <rpm:group>Unspecified</rpm:group>\n"
+        "    <rpm:sourcerpm>demo-1.0-1.el9.src.rpm</rpm:sourcerpm>\n"
+        '    <rpm:header-range start="0" end="0"/>\n'
+        "  </format>\n"
+        "</package>\n"
+        "</metadata>\n"
+    ).encode()
+
+    gz = gzip.compress(primary)
+    (repodata / "primary.xml.gz").write_bytes(gz)
+
+    repomd = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<repomd xmlns="http://linux.duke.edu/metadata/repo"'
+        ' xmlns:rpm="http://linux.duke.edu/metadata/rpm">\n'
+        "  <revision>1</revision>\n"
+        '  <data type="primary">\n'
+        f'    <checksum type="sha256">{hashlib.sha256(gz).hexdigest()}</checksum>\n'
+        f'    <open-checksum type="sha256">{hashlib.sha256(primary).hexdigest()}</open-checksum>\n'
+        '    <location href="repodata/primary.xml.gz"/>\n'
+        "    <timestamp>1</timestamp>\n"
+        f"    <size>{len(gz)}</size>\n"
+        f"    <open-size>{len(primary)}</open-size>\n"
+        "  </data>\n"
+        "</repomd>\n"
+    )
+    (repodata / "repomd.xml").write_text(repomd, encoding="utf-8")
+
+
+def test_rpm_sync_and_publish(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_rpm_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-rpm",
+            "name": "Demo RPM",
+            "type": "rpm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-rpm")
+
+    # repomd.xml was regenerated and the package was published.
+    assert (target / "repodata" / "repomd.xml").exists()
+    assert list(target.rglob("demo-1.0-1.el9.x86_64.rpm")), "published rpm not found"


### PR DESCRIPTION
Adds a separate CI **e2e** stage (after lint/type-check, matrix per plugin: rpm/apt/helm/apk) that exercises the full pipeline per format.

## How it works
- Build a minimal upstream repo (one package) with **pure Python**: valid metadata (repomd/primary, Release/Packages, APKINDEX, index.yaml) plus a dummy package whose checksum matches what the metadata declares.
- Serve it over a local HTTP server.
- Run `chantal db init` -> `repo sync` -> `publish repo` against a temporary SQLite DB.
- Assert the published metadata/layout.

No native build tools (rpmbuild/abuild/...) and no committed binaries. Client-side verification (dnf/apt/apk/helm install) is intentionally deferred to a later phase.

## Bugs found & fixed
The e2e tests immediately caught two real SQLite-only bugs:
- **helm/sync.py** stored `pool_path` as a `PosixPath` (Path-wrapped) -> `type "PosixPath" is not supported` on insert. Now stored as `str`.
- **apt** filtered publish crashed when a package `component` was `None` (component comes from the repo layout, not the Packages stanza). The sync now propagates the component, and the publisher grouping is hardened against `None`.

## CI wiring
- e2e tests are marked `e2e` and excluded from the unit job (`-m "not e2e"`).
- New `e2e` job runs `-m e2e` per plugin, `needs: lint-and-type-check`.

Closes #55. Part of #32.