### PR TITLE
feat(rpm): Verify upstream repomd.xml signature on sync (repo_gpgcheck)

### DIFF
--- a/docs/plugins/rpm-plugin.md
+++ b/docs/plugins/rpm-plugin.md
@@ -276,6 +276,50 @@ repositories:
 
 **Status:** Planned feature for uploading custom-built RPMs.
 
+## Upstream Signature Verification
+
+**Status:** ✅ Available (repository metadata) · 🚧 package signatures (follow-up)
+
+Chantal always verifies **integrity** (SHA256 of every metadata file and package
+against `repomd.xml`/`primary.xml`). A `verify` section additionally checks
+**authenticity** — that the upstream was signed by a key you trust — analogous
+to dnf's `repo_gpgcheck`.
+
+When enabled, the upstream `repodata/repomd.xml.asc` is fetched and verified
+against the configured trusted key(s). Because `repomd.xml` contains the
+checksums of every other metadata file, a valid signature there transitively
+authenticates the whole repository.
+
+```yaml
+repositories:
+  - id: rocky9-baseos
+    type: rpm
+    feed: https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os
+    verify:
+      enabled: true
+      repo_gpgcheck: true            # verify repomd.xml.asc
+      key_files:
+        - /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
+      # keys: ["-----BEGIN PGP PUBLIC KEY BLOCK----- ..."]   # inline alternative
+      # trusted_fingerprints: ["<fpr>"]                       # optional pinning
+      on_missing_signature: fail     # fail | warn | skip
+      on_invalid_signature: fail
+```
+
+The `verify` section can also be set globally (as a fallback for all
+repositories without their own). Options:
+
+| Option | Meaning |
+|--------|---------|
+| `enabled` | Turn verification on (default `false`) |
+| `repo_gpgcheck` | Verify the repository metadata signature (`repomd.xml.asc`) |
+| `gpgcheck` | Verify individual package signatures — **not yet implemented** (must be `false`; a follow-up) |
+| `key_files` / `keys` | Trusted public keys (file paths / inline ASCII-armored) |
+| `trusted_fingerprints` | Optional allow-list of key fingerprints (pinning) |
+| `on_missing_signature` / `on_invalid_signature` | `fail` (default), `warn`, or `skip` |
+
+At least one of `key_files` or `keys` is required when `enabled: true`.
+
 ## How It Works
 
 ### Sync Process

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -975,6 +975,17 @@
             }
           ],
           "default": null
+        },
+        "verify": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SignatureVerificationConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
@@ -1150,6 +1161,84 @@
         }
       },
       "title": "ScheduleConfig",
+      "type": "object"
+    },
+    "SignatureVerificationConfig": {
+      "description": "Verify the authenticity of an upstream repository via GPG.\n\nThis is independent of :class:`GpgConfig` (which holds the *private* signing\nkey used to re-sign regenerated metadata). Verification needs *public* trust\nanchors - the upstream vendor's public key(s).\n\nIntegrity (SHA256) is always checked during sync; this adds *authenticity*\n(the metadata/packages were signed by a trusted key), analogous to dnf's\n``repo_gpgcheck`` / ``gpgcheck`` and apt's Release signature check.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "repo_gpgcheck": {
+          "default": true,
+          "title": "Repo Gpgcheck",
+          "type": "boolean"
+        },
+        "gpgcheck": {
+          "default": false,
+          "title": "Gpgcheck",
+          "type": "boolean"
+        },
+        "key_files": {
+          "description": "Paths to ASCII-armored public key files",
+          "items": {
+            "type": "string"
+          },
+          "title": "Key Files",
+          "type": "array"
+        },
+        "keys": {
+          "description": "Inline ASCII-armored public keys",
+          "items": {
+            "type": "string"
+          },
+          "title": "Keys",
+          "type": "array"
+        },
+        "trusted_fingerprints": {
+          "description": "Optional allow-list of full key fingerprints (pinning)",
+          "items": {
+            "type": "string"
+          },
+          "title": "Trusted Fingerprints",
+          "type": "array"
+        },
+        "gnupg_home": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Gnupg Home"
+        },
+        "on_missing_signature": {
+          "default": "fail",
+          "enum": [
+            "fail",
+            "warn",
+            "skip"
+          ],
+          "title": "On Missing Signature",
+          "type": "string"
+        },
+        "on_invalid_signature": {
+          "default": "fail",
+          "enum": [
+            "fail",
+            "warn",
+            "skip"
+          ],
+          "title": "On Invalid Signature",
+          "type": "string"
+        }
+      },
+      "title": "SignatureVerificationConfig",
       "type": "object"
     },
     "SizeFilterConfig": {
@@ -1380,6 +1469,17 @@
       "anyOf": [
         {
           "$ref": "#/$defs/GpgConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "verify": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SignatureVerificationConfig"
         },
         {
           "type": "null"

--- a/examples/rpm/verified.yaml
+++ b/examples/rpm/verified.yaml
@@ -1,0 +1,27 @@
+# RPM repository with upstream signature verification
+#
+# Chantal always checks integrity (SHA256). The `verify` section adds
+# authenticity: the upstream repomd.xml.asc is verified against a trusted key
+# (like dnf's repo_gpgcheck). Since repomd.xml carries the checksums of all
+# other metadata, a valid signature there authenticates the whole repository.
+#
+# `verify` can be set per-repository (below) or globally as a fallback.
+
+repositories:
+  - id: rocky9-baseos
+    name: "Rocky Linux 9 - BaseOS (verified)"
+    type: rpm
+    feed: "https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os"
+    enabled: true
+    mode: mirror
+
+    verify:
+      enabled: true
+      repo_gpgcheck: true
+      key_files:
+        - /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
+      # Optional key pinning by fingerprint:
+      # trusted_fingerprints:
+      #   - "350D275D51953AAC1788576C70A7050025DB3973"
+      on_missing_signature: fail   # fail | warn | skip
+      on_invalid_signature: fail

--- a/src/chantal/cli/repo_commands.py
+++ b/src/chantal/cli/repo_commands.py
@@ -1061,6 +1061,10 @@ def _sync_single_repository(
     effective_proxy = repo_config.proxy if repo_config.proxy is not None else global_config.proxy
     effective_ssl = repo_config.ssl if repo_config.ssl is not None else global_config.ssl
 
+    # Upstream signature verification: repo-specific overrides global fallback
+    if repo_config.verify is None and global_config.verify is not None:
+        repo_config.verify = global_config.verify
+
     # Setup metadata cache (if enabled)
     cache = None
     cache_path = global_config.storage.get_cache_path()

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -242,6 +242,64 @@ class GpgConfig(BaseModel):
         return self.passphrase
 
 
+class SignatureVerificationConfig(BaseModel):
+    """Verify the authenticity of an upstream repository via GPG.
+
+    This is independent of :class:`GpgConfig` (which holds the *private* signing
+    key used to re-sign regenerated metadata). Verification needs *public* trust
+    anchors - the upstream vendor's public key(s).
+
+    Integrity (SHA256) is always checked during sync; this adds *authenticity*
+    (the metadata/packages were signed by a trusted key), analogous to dnf's
+    ``repo_gpgcheck`` / ``gpgcheck`` and apt's Release signature check.
+    """
+
+    enabled: bool = False
+
+    # What to verify
+    repo_gpgcheck: bool = True  # verify repository metadata signature (repomd.xml.asc)
+    # Verify individual package signatures. Not yet implemented; enabling it is
+    # rejected by the validator so it can never be a silent no-op.
+    gpgcheck: bool = False
+
+    # Trust anchors (public keys)
+    key_files: list[str] = Field(
+        default_factory=list, description="Paths to ASCII-armored public key files"
+    )
+    keys: list[str] = Field(default_factory=list, description="Inline ASCII-armored public keys")
+    trusted_fingerprints: list[str] = Field(
+        default_factory=list,
+        description="Optional allow-list of full key fingerprints (pinning)",
+    )
+
+    # Keyring location (a private temporary one is used if unset)
+    gnupg_home: str | None = None
+
+    # Behavior policy
+    on_missing_signature: Literal["fail", "warn", "skip"] = "fail"
+    on_invalid_signature: Literal["fail", "warn", "skip"] = "fail"
+
+    @model_validator(mode="after")
+    def validate_config(self) -> SignatureVerificationConfig:
+        """Validate the verification configuration when enabled."""
+        if not self.enabled:
+            return self
+        if not (self.key_files or self.keys):
+            raise ValueError(
+                "Signature verification is enabled but no trusted key is configured. "
+                "Provide 'key_files' or 'keys'."
+            )
+        if self.gpgcheck:
+            raise ValueError(
+                "Package signature verification (gpgcheck) is not yet implemented; "
+                "set gpgcheck: false. Repository metadata verification (repo_gpgcheck) "
+                "is supported."
+            )
+        if any(not fpr.strip() for fpr in self.trusted_fingerprints):
+            raise ValueError("trusted_fingerprints must not contain empty entries")
+        return self
+
+
 class MetadataConfig(BaseModel):
     """Metadata generation configuration (RPM, APT, etc.)."""
 
@@ -413,6 +471,9 @@ class RepositoryConfig(BaseModel):
 
     # GPG signing (APT filtered mode); falls back to global gpg config if unset
     gpg: GpgConfig | None = None
+
+    # Upstream signature verification; falls back to global verify config if unset
+    verify: SignatureVerificationConfig | None = None
 
     @field_validator("type")
     @classmethod
@@ -588,6 +649,8 @@ class GlobalConfig(BaseModel):
     download: DownloadConfig | None = Field(default_factory=DownloadConfig)
     # Global GPG signing fallback for repositories without their own gpg config
     gpg: GpgConfig | None = None
+    # Global upstream-verification fallback for repositories without their own
+    verify: SignatureVerificationConfig | None = None
     repositories: list[RepositoryConfig] = Field(default_factory=list)
     views: list[ViewConfig] = Field(default_factory=list)
 

--- a/src/chantal/core/gpg_verify.py
+++ b/src/chantal/core/gpg_verify.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+"""
+GPG verification of upstream repository authenticity.
+
+This is the counterpart to :class:`chantal.core.gpg.GpgSigner`: instead of a
+*private* key used to re-sign regenerated metadata, the verifier imports the
+upstream vendor's *public* key(s) into an isolated keyring and checks detached
+OpenPGP signatures (e.g. RPM ``repomd.xml.asc``, APT ``Release.gpg``, and RPM
+package header signatures).
+
+Wraps the ``gpg`` binary via ``python-gnupg`` (already a dependency).
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from types import TracebackType
+
+import gnupg
+
+from chantal.core.config import SignatureVerificationConfig
+
+
+class GpgVerificationError(Exception):
+    """Raised when verification cannot be performed (setup/import problems)."""
+
+
+class GpgVerifier:
+    """Verify detached OpenPGP signatures against configured trusted keys.
+
+    The trusted public keys are imported into an isolated keyring on first use.
+    A temporary keyring is created (and removed on close) unless ``gnupg_home``
+    is configured.
+    """
+
+    def __init__(self, config: SignatureVerificationConfig):
+        self.config = config
+        self._imported = False
+
+        self._tempdir: tempfile.TemporaryDirectory[str] | None = None
+        if config.gnupg_home:
+            self._gnupg_home = Path(config.gnupg_home)
+            self._gnupg_home.mkdir(parents=True, exist_ok=True)
+        else:
+            self._tempdir = tempfile.TemporaryDirectory(prefix="chantal-verify-")
+            self._gnupg_home = Path(self._tempdir.name)
+
+        os.chmod(self._gnupg_home, 0o700)
+        self.gpg = gnupg.GPG(gnupghome=str(self._gnupg_home))
+        self.gpg.encoding = "utf-8"
+
+    def __enter__(self) -> GpgVerifier:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Remove the temporary keyring, if one was created."""
+        if self._tempdir is not None:
+            self._tempdir.cleanup()
+            self._tempdir = None
+
+    def import_trusted_keys(self) -> list[str]:
+        """Import all configured trust anchors into the keyring.
+
+        Returns:
+            The fingerprints of the imported keys.
+
+        Raises:
+            GpgVerificationError: If a key file is missing or no key imported.
+        """
+        fingerprints: list[str] = []
+
+        for key_file in self.config.key_files:
+            path = Path(key_file)
+            if not path.exists():
+                raise GpgVerificationError(f"Trusted key file not found: {path}")
+            result = self.gpg.import_keys(path.read_text(encoding="utf-8"))
+            fingerprints.extend(result.fingerprints)
+
+        for key in self.config.keys:
+            result = self.gpg.import_keys(key)
+            fingerprints.extend(result.fingerprints)
+
+        if not fingerprints:
+            raise GpgVerificationError("No trusted keys could be imported for verification")
+
+        self._imported = True
+        return fingerprints
+
+    def _ensure_keys(self) -> None:
+        if not self._imported:
+            self.import_trusted_keys()
+
+    def verify_detached(self, data: bytes, signature: bytes) -> bool:
+        """Verify a detached OpenPGP signature over ``data``.
+
+        Args:
+            data: The signed payload (e.g. the raw ``repomd.xml`` bytes).
+            signature: The detached signature (ASCII-armored or binary).
+
+        Returns:
+            True if the signature is valid AND made by a trusted key (and, when
+            ``trusted_fingerprints`` is set, by a pinned key); False otherwise.
+        """
+        self._ensure_keys()
+
+        # python-gnupg verifies a detached signature from a file against data.
+        sig_file = Path(
+            tempfile.mkstemp(prefix="sig-", suffix=".asc", dir=str(self._gnupg_home))[1]
+        )
+        try:
+            sig_file.write_bytes(signature)
+            verified = self.gpg.verify_data(str(sig_file), data)
+        finally:
+            sig_file.unlink(missing_ok=True)
+
+        if not verified.valid:
+            return False
+
+        if self.config.trusted_fingerprints:
+            return self._fingerprint_pinned(verified.fingerprint)
+        return True
+
+    def _fingerprint_pinned(self, fingerprint: str | None) -> bool:
+        """Check the signing key fingerprint against the pin allow-list.
+
+        Matches the full fingerprint exactly, or a long key-id suffix (>= 16
+        hex chars). Short (32-bit) key ids are not accepted as they are trivial
+        to forge. Empty pin entries are ignored.
+        """
+        if not fingerprint:
+            return False
+        actual = fingerprint.replace(" ", "").upper()
+        for pinned in self.config.trusted_fingerprints:
+            wanted = pinned.replace(" ", "").upper()
+            if not wanted:
+                continue
+            if actual == wanted:
+                return True
+            if len(wanted) >= 16 and actual.endswith(wanted):
+                return True
+        return False

--- a/src/chantal/plugins/rpm/parsers.py
+++ b/src/chantal/plugins/rpm/parsers.py
@@ -22,6 +22,29 @@ from chantal.core.cache import MetadataCache
 logger = logging.getLogger(__name__)
 
 
+def fetch_repomd_content(session: requests.Session, base_url: str) -> bytes:
+    """Fetch the raw ``repomd.xml`` bytes.
+
+    Returning the raw bytes lets callers verify the exact bytes they then parse
+    (the detached ``repomd.xml.asc`` signature is over these bytes).
+
+    Args:
+        session: Requests session (with auth/SSL configured)
+        base_url: Base URL of repository
+
+    Returns:
+        The raw ``repomd.xml`` content.
+
+    Raises:
+        requests.RequestException: On HTTP errors
+    """
+    repomd_url = urljoin(base_url + "/", "repodata/repomd.xml")
+    response = session.get(repomd_url, timeout=30)
+    response.raise_for_status()
+    content: bytes = response.content
+    return content
+
+
 def fetch_repomd_xml(session: requests.Session, base_url: str) -> ET.Element:
     """Fetch and parse repomd.xml.
 
@@ -36,10 +59,7 @@ def fetch_repomd_xml(session: requests.Session, base_url: str) -> ET.Element:
         requests.RequestException: On HTTP errors
         ET.ParseError: On XML parse errors
     """
-    repomd_url = urljoin(base_url + "/", "repodata/repomd.xml")
-    response = session.get(repomd_url, timeout=30)
-    response.raise_for_status()
-    return ET.fromstring(response.content)
+    return ET.fromstring(fetch_repomd_content(session, base_url))
 
 
 def extract_all_metadata(repomd_root: ET.Element) -> list[dict]:

--- a/src/chantal/plugins/rpm/sync.py
+++ b/src/chantal/plugins/rpm/sync.py
@@ -9,6 +9,7 @@ This module implements syncing RPM repositories from upstream sources.
 import hashlib
 import os
 import tempfile
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urljoin
@@ -174,10 +175,16 @@ class RpmSyncPlugin:
         try:
             self.output.header(repository.repo_id, "rpm", self.config.feed)
 
-            # Step 1: Fetch repomd.xml (always fresh, contains checksums)
+            # Step 1: Fetch repomd.xml ONCE (raw bytes), verify the signature on
+            # exactly those bytes, then parse the same bytes. repomd.xml carries
+            # the checksums of all other metadata, so a valid signature here
+            # transitively authenticates the whole repository - but only if the
+            # verified bytes are the bytes we actually parse (no re-fetch).
             self.output.phase("Fetching package list", number=1)
             self.output.info("Fetching repomd.xml...")
-            repomd_root = parsers.fetch_repomd_xml(self.session, self.config.feed)
+            repomd_content = parsers.fetch_repomd_content(self.session, self.config.feed)
+            self._verify_repomd_signature(repomd_content)
+            repomd_root = ET.fromstring(repomd_content)
 
             # Step 2: Extract ALL metadata info (including primary.xml.gz)
             metadata_files = parsers.extract_all_metadata(repomd_root)
@@ -584,6 +591,51 @@ class RpmSyncPlugin:
                 success=False,
                 error_message=str(e),
             )
+
+    def _verify_repomd_signature(self, repomd_content: bytes) -> None:
+        """Verify the upstream ``repomd.xml`` signature (repo_gpgcheck).
+
+        No-op unless verification is enabled for this repository. Verifies the
+        detached ``repomd.xml.asc`` against ``repomd_content`` (the exact bytes
+        that will be parsed) using the configured trusted keys, then applies the
+        configured behavior policy.
+
+        Args:
+            repomd_content: The raw ``repomd.xml`` bytes that will be parsed.
+        """
+        verify = self.config.verify
+        if not verify or not verify.enabled or not verify.repo_gpgcheck:
+            return
+
+        from chantal.core.gpg_verify import GpgVerifier
+
+        asc_url = urljoin(self.config.feed + "/", "repodata/repomd.xml.asc")
+        asc_response = self.session.get(asc_url, timeout=30)
+        if not asc_response.ok:
+            self._handle_verify_policy(
+                verify.on_missing_signature,
+                f"upstream repomd.xml.asc not found ({asc_response.status_code})",
+            )
+            return
+
+        with GpgVerifier(verify) as verifier:
+            valid = verifier.verify_detached(repomd_content, asc_response.content)
+
+        if valid:
+            self.output.info("✓ Verified upstream repomd.xml signature")
+        else:
+            self._handle_verify_policy(
+                verify.on_invalid_signature,
+                "upstream repomd.xml signature is invalid or not from a trusted key",
+            )
+
+    def _handle_verify_policy(self, policy: str, message: str) -> None:
+        """Apply a signature-verification behavior policy (fail/warn/skip)."""
+        if policy == "fail":
+            raise ValueError(f"Signature verification failed: {message}")
+        if policy == "warn":
+            self.output.warning(f"Signature verification: {message}")
+        # "skip": silently continue
 
     def _get_existing_packages(self, session: Session) -> dict[str, ContentItem]:
         """Get existing content items from database.

--- a/tests/test_rpm_verify.py
+++ b/tests/test_rpm_verify.py
@@ -1,0 +1,151 @@
+"""
+Tests for upstream signature verification config + GpgVerifier.
+
+Covers the repository-metadata signature path (RPM ``repomd.xml.asc`` and, more
+generally, any detached OpenPGP signature). Uses an ephemeral "upstream" key to
+sign data, then verifies with a fresh keyring holding only the public key.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from chantal.core.config import GpgConfig, SignatureVerificationConfig
+from chantal.core.gpg import GpgSigner
+from chantal.core.gpg_verify import GpgVerificationError, GpgVerifier
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("gpg") is None and shutil.which("gpg2") is None,
+    reason="gpg binary not available",
+)
+
+
+def _short_home() -> str:
+    base = "/tmp" if Path("/tmp").is_dir() else None
+    return tempfile.mkdtemp(prefix="cg-", dir=base)
+
+
+@pytest.fixture
+def upstream_signer():
+    """An ephemeral 'upstream vendor' signer (private key in its own keyring)."""
+    home = _short_home()
+    signer = GpgSigner(GpgConfig(generate_key=True, gnupg_home=home, key_email="vendor@upstream"))
+    # Force key creation up front.
+    _ = signer.key_id
+    yield signer
+    signer.close()
+    shutil.rmtree(home, ignore_errors=True)
+
+
+@pytest.fixture
+def verifier_home():
+    home = _short_home()
+    yield home
+    shutil.rmtree(home, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+
+
+class TestSignatureVerificationConfig:
+    def test_enabled_requires_a_key(self):
+        with pytest.raises(ValueError, match="no trusted key"):
+            SignatureVerificationConfig(enabled=True)
+
+    def test_disabled_needs_no_key(self):
+        assert SignatureVerificationConfig(enabled=False).enabled is False
+
+    def test_enabled_with_inline_key(self):
+        cfg = SignatureVerificationConfig(enabled=True, keys=["-----BEGIN PGP PUBLIC KEY-----"])
+        assert cfg.enabled is True
+
+    def test_gpgcheck_rejected_until_implemented(self):
+        with pytest.raises(ValueError, match="not yet implemented"):
+            SignatureVerificationConfig(enabled=True, keys=["k"], gpgcheck=True)
+
+    def test_empty_fingerprint_rejected(self):
+        with pytest.raises(ValueError, match="empty entries"):
+            SignatureVerificationConfig(enabled=True, keys=["k"], trusted_fingerprints=[""])
+
+
+# --------------------------------------------------------------------------- #
+# GpgVerifier
+# --------------------------------------------------------------------------- #
+
+
+def _verify_config(public_key: str, home: str, **kw) -> SignatureVerificationConfig:
+    return SignatureVerificationConfig(enabled=True, keys=[public_key], gnupg_home=home, **kw)
+
+
+class TestGpgVerifier:
+    def test_valid_signature_passes(self, upstream_signer, verifier_home):
+        data = b"<repomd><revision>1</revision></repomd>"
+        sig = upstream_signer.detach_sign(data)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+
+        with GpgVerifier(_verify_config(pub, verifier_home)) as verifier:
+            assert verifier.verify_detached(data, sig) is True
+
+    def test_tampered_data_fails(self, upstream_signer, verifier_home):
+        data = b"<repomd><revision>1</revision></repomd>"
+        sig = upstream_signer.detach_sign(data)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+
+        with GpgVerifier(_verify_config(pub, verifier_home)) as verifier:
+            assert verifier.verify_detached(data + b"tampered", sig) is False
+
+    def test_untrusted_key_fails(self, upstream_signer, verifier_home):
+        # Verifier trusts a DIFFERENT key than the one that signed.
+        data = b"payload"
+        sig = upstream_signer.detach_sign(data)
+
+        other_home = _short_home()
+        other = GpgSigner(GpgConfig(generate_key=True, gnupg_home=other_home, key_email="x@y"))
+        try:
+            other_pub = other.export_public_key().decode("utf-8")
+            with GpgVerifier(_verify_config(other_pub, verifier_home)) as verifier:
+                assert verifier.verify_detached(data, sig) is False
+        finally:
+            other.close()
+            shutil.rmtree(other_home, ignore_errors=True)
+
+    def test_fingerprint_pin_match(self, upstream_signer, verifier_home):
+        data = b"payload"
+        sig = upstream_signer.detach_sign(data)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+        cfg = _verify_config(pub, verifier_home, trusted_fingerprints=[upstream_signer.key_id])
+
+        with GpgVerifier(cfg) as verifier:
+            assert verifier.verify_detached(data, sig) is True
+
+    def test_fingerprint_pin_long_keyid_suffix(self, upstream_signer, verifier_home):
+        # A long key-id (last 16 hex of the fingerprint) is accepted.
+        data = b"payload"
+        sig = upstream_signer.detach_sign(data)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+        long_keyid = upstream_signer.key_id[-16:]
+        cfg = _verify_config(pub, verifier_home, trusted_fingerprints=[long_keyid])
+
+        with GpgVerifier(cfg) as verifier:
+            assert verifier.verify_detached(data, sig) is True
+
+    def test_fingerprint_pin_mismatch_fails(self, upstream_signer, verifier_home):
+        data = b"payload"
+        sig = upstream_signer.detach_sign(data)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+        cfg = _verify_config(pub, verifier_home, trusted_fingerprints=["0" * 40])
+
+        with GpgVerifier(cfg) as verifier:
+            assert verifier.verify_detached(data, sig) is False
+
+    def test_missing_key_file_raises(self, verifier_home, tmp_path):
+        cfg = SignatureVerificationConfig(
+            enabled=True, key_files=[str(tmp_path / "nope.asc")], gnupg_home=verifier_home
+        )
+        with GpgVerifier(cfg) as verifier:
+            with pytest.raises(GpgVerificationError, match="not found"):
+                verifier.verify_detached(b"x", b"y")


### PR DESCRIPTION
Adds upstream **authenticity** verification for RPM repositories (the dnf `repo_gpgcheck` equivalent), complementing the existing SHA256 **integrity** check. Part of #58, item 1a.

## What
- New `SignatureVerificationConfig` (`verify:`) on repo + global (per-repo overrides global). Requires a trusted key when enabled; supports fingerprint pinning and fail/warn/skip policies.
- New `GpgVerifier` (python-gnupg): imports trusted **public** keys into an isolated keyring and verifies detached signatures.
- RPM sync fetches `repomd.xml` **once**, verifies `repomd.xml.asc` over those exact bytes, then parses the same bytes (transitively authenticates all metadata via its checksums).
- Docs, example (`examples/rpm/verified.yaml`), regenerated JSON schema, tests.

## Process (per request)
Research -> implementation -> self-review -> **fresh-context subagent review**. The subagent review caught a **BLOCKER**: the first draft re-fetched `repomd.xml` separately for verification, so the verified bytes were not the bytes being parsed (TOCTOU/MITM gap). Fixed by fetching once and verifying+parsing the same bytes. Also addressed: empty-string fingerprint disabling pinning, an unsound suffix-match branch, and `gpgcheck being a silent no-op (now rejected by the validator until package-level verification lands in 1b).

## Scope
Package-level signature verification (gpgcheck) is the follow-up (1b); its config is rejected when set so it can never be a silent no-op.

Full suite green; black/ruff/mypy/yamllint clean.