### PR TITLE
feat(rpm): Verify .rpm package signatures on sync (gpgcheck)

### DIFF
--- a/.github/workflows/lint-and-type-check.yml
+++ b/.github/workflows/lint-and-type-check.yml
@@ -95,7 +95,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Install rpm toolchain (for the real-rpm signature golden test)
+        if: matrix.plugin == 'rpm'
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
       - name: Run end-to-end sync->publish test
+        env:
+          # Require the real-rpm signature golden test to run (not skip) on the rpm leg.
+          CHANTAL_REQUIRE_RPM_E2E: ${{ matrix.plugin == 'rpm' && '1' || '' }}
         run: |
           echo "Running E2E sync->publish for ${{ matrix.plugin }}..."
           pytest tests/e2e -v -s -m e2e -k ${{ matrix.plugin }}

--- a/docs/plugins/rpm-plugin.md
+++ b/docs/plugins/rpm-plugin.md
@@ -278,7 +278,7 @@ repositories:
 
 ## Upstream Signature Verification
 
-**Status:** ✅ Available (repository metadata) · 🚧 package signatures (follow-up)
+**Status:** ✅ Available (repository metadata **and** package signatures)
 
 Chantal always verifies **integrity** (SHA256 of every metadata file and package
 against `repomd.xml`/`primary.xml`). A `verify` section additionally checks
@@ -313,7 +313,7 @@ repositories without their own). Options:
 |--------|---------|
 | `enabled` | Turn verification on (default `false`) |
 | `repo_gpgcheck` | Verify the repository metadata signature (`repomd.xml.asc`) |
-| `gpgcheck` | Verify individual package signatures — **not yet implemented** (must be `false`; a follow-up) |
+| `gpgcheck` | Verify individual `.rpm` package signatures (header-only OpenPGP signature; default `true`; requires `repo_gpgcheck` so the authenticated metadata checksums bind the payload) |
 | `key_files` / `keys` | Trusted public keys (file paths / inline ASCII-armored) |
 | `trusted_fingerprints` | Optional allow-list of key fingerprints (pinning) |
 | `on_missing_signature` / `on_invalid_signature` | `fail` (default), `warn`, or `skip` |

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -1177,7 +1177,7 @@
           "type": "boolean"
         },
         "gpgcheck": {
-          "default": false,
+          "default": true,
           "title": "Gpgcheck",
           "type": "boolean"
         },

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -258,9 +258,7 @@ class SignatureVerificationConfig(BaseModel):
 
     # What to verify
     repo_gpgcheck: bool = True  # verify repository metadata signature (repomd.xml.asc)
-    # Verify individual package signatures. Not yet implemented; enabling it is
-    # rejected by the validator so it can never be a silent no-op.
-    gpgcheck: bool = False
+    gpgcheck: bool = True  # verify individual package (.rpm) signatures
 
     # Trust anchors (public keys)
     key_files: list[str] = Field(
@@ -289,11 +287,12 @@ class SignatureVerificationConfig(BaseModel):
                 "Signature verification is enabled but no trusted key is configured. "
                 "Provide 'key_files' or 'keys'."
             )
-        if self.gpgcheck:
+        if self.gpgcheck and not self.repo_gpgcheck:
             raise ValueError(
-                "Package signature verification (gpgcheck) is not yet implemented; "
-                "set gpgcheck: false. Repository metadata verification (repo_gpgcheck) "
-                "is supported."
+                "gpgcheck requires repo_gpgcheck. A package's header-only signature proves "
+                "the vendor built that header, but does not by itself authenticate the package "
+                "payload; repo_gpgcheck authenticates the metadata checksums that bind the "
+                "downloaded bytes. Enable both (the default)."
             )
         if any(not fpr.strip() for fpr in self.trusted_fingerprints):
             raise ValueError("trusted_fingerprints must not contain empty entries")

--- a/src/chantal/core/gpg_verify.py
+++ b/src/chantal/core/gpg_verify.py
@@ -26,6 +26,10 @@ class GpgVerificationError(Exception):
     """Raised when verification cannot be performed (setup/import problems)."""
 
 
+class SignatureVerificationError(Exception):
+    """Raised to abort a sync when a signature check fails under a 'fail' policy."""
+
+
 class GpgVerifier:
     """Verify detached OpenPGP signatures against configured trusted keys.
 

--- a/src/chantal/plugins/rpm/rpm_header.py
+++ b/src/chantal/plugins/rpm/rpm_header.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""
+Minimal pure-Python RPM container parser for signature verification.
+
+An RPM file is::
+
+    [ Lead              96 bytes ]
+    [ Signature header  (header struct, padded to an 8-byte boundary) ]
+    [ Main header       (header struct - the package metadata) ]
+    [ Payload           (compressed cpio) ]
+
+Both headers use the same binary "header" structure::
+
+    magic  : 4 bytes  -> 8e ad e8 01
+    reserved: 4 bytes
+    nindex : uint32 BE  (number of index entries)
+    hsize  : uint32 BE  (size of the data store)
+    index  : nindex * 16 bytes   (tag, type, offset, count - each uint32 BE)
+    store  : hsize bytes
+
+The header-only OpenPGP signature lives in the *signature header* under tag
+``RPMSIGTAG_RSAHEADER`` (268, RSA) or ``RPMSIGTAG_DSAHEADER`` (267, DSA/ECDSA).
+Its value is a raw OpenPGP signature packet, and the signed data is exactly the
+serialized *main header* blob. Verification therefore reduces to a normal
+detached-signature check of that packet over the main-header bytes.
+
+References: RPM file format / ``rpm-head-signing`` (see the research notes).
+"""
+
+import mmap
+import struct
+
+# Accepts in-memory bytes or an mmap of the file (so only the header region is
+# read for large packages). Slicing either yields real ``bytes``.
+_Buffer = bytes | mmap.mmap
+
+RPMTAG_RSAHEADER = 268
+RPMTAG_DSAHEADER = 267
+
+_LEAD_MAGIC = b"\xed\xab\xee\xdb"
+_HEADER_MAGIC = b"\x8e\xad\xe8\x01"
+_LEAD_SIZE = 96
+_INTRO_SIZE = 16
+_INDEX_ENTRY_SIZE = 16
+
+
+class RpmFormatError(Exception):
+    """Raised when the bytes are not a parseable RPM."""
+
+
+def _parse_header(data: _Buffer, offset: int) -> tuple[list[tuple[int, int, int, int]], bytes, int]:
+    """Parse one RPM header structure at ``offset``.
+
+    Returns (index_entries, store_bytes, end_offset).
+    """
+    if len(data) < offset + _INTRO_SIZE:
+        raise RpmFormatError("truncated header intro")
+    intro = data[offset : offset + _INTRO_SIZE]
+    if intro[:4] != _HEADER_MAGIC:
+        raise RpmFormatError(f"bad header magic at offset {offset}")
+
+    nindex, hsize = struct.unpack(">II", intro[8:16])
+    index_start = offset + _INTRO_SIZE
+    store_start = index_start + nindex * _INDEX_ENTRY_SIZE
+    store_end = store_start + hsize
+    if len(data) < store_end:
+        raise RpmFormatError("truncated header (index/store beyond end of file)")
+
+    entries: list[tuple[int, int, int, int]] = []
+    for i in range(nindex):
+        entry = data[
+            index_start + i * _INDEX_ENTRY_SIZE : index_start + (i + 1) * _INDEX_ENTRY_SIZE
+        ]
+        entries.append(struct.unpack(">IIII", entry))  # (tag, type, offset, count)
+
+    store = data[store_start:store_end]
+    return entries, store, store_end
+
+
+def extract_header_signature(data: _Buffer) -> tuple[bytes, bytes] | None:
+    """Extract the header-only OpenPGP signature and the data it covers.
+
+    Args:
+        data: The full ``.rpm`` file bytes.
+
+    Returns:
+        ``(signature_packet, main_header_blob)`` if a header signature
+        (RSAHEADER/DSAHEADER) is present, or ``None`` if the package carries no
+        header signature.
+
+    Raises:
+        RpmFormatError: If the bytes are not a parseable RPM.
+    """
+    if len(data) < _LEAD_SIZE + _INTRO_SIZE or data[:4] != _LEAD_MAGIC:
+        raise RpmFormatError("not an RPM file (bad lead magic)")
+
+    sig_entries, sig_store, sig_end = _parse_header(data, _LEAD_SIZE)
+
+    # The signature header is padded with zeros to the next 8-byte boundary.
+    # The signature header starts at offset 96 (a multiple of 8), so aligning
+    # the absolute end offset is equivalent.
+    main_offset = sig_end + (-sig_end % 8)
+
+    _main_entries, _main_store, main_end = _parse_header(data, main_offset)
+    main_header_blob = data[main_offset:main_end]
+
+    for tag, _type, store_offset, count in sig_entries:
+        if tag in (RPMTAG_RSAHEADER, RPMTAG_DSAHEADER):
+            signature_packet = sig_store[store_offset : store_offset + count]
+            if not signature_packet:
+                raise RpmFormatError("empty header signature packet")
+            return signature_packet, main_header_blob
+
+    return None

--- a/src/chantal/plugins/rpm/sync.py
+++ b/src/chantal/plugins/rpm/sync.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from chantal.core.cache import MetadataCache
 from chantal.core.config import ProxyConfig, RepositoryConfig, SSLConfig
 from chantal.core.downloader import DownloadManager
+from chantal.core.gpg_verify import SignatureVerificationError
 from chantal.core.output import OutputLevel, SyncOutputter
 from chantal.core.storage import StorageManager
 from chantal.db.models import ContentItem, Repository, RepositoryFile
@@ -162,6 +163,9 @@ class RpmSyncPlugin:
         # Backward compatibility for parsers module
         self.session = self.downloader.session
 
+        # Lazily created during sync when package signature verification is on.
+        self._package_verifier: object | None = None
+
     def sync_repository(self, session: Session, repository: Repository) -> SyncResult:
         """Sync repository from upstream.
 
@@ -185,6 +189,9 @@ class RpmSyncPlugin:
             repomd_content = parsers.fetch_repomd_content(self.session, self.config.feed)
             self._verify_repomd_signature(repomd_content)
             repomd_root = ET.fromstring(repomd_content)
+
+            # Set up the reusable package-signature verifier (gpgcheck).
+            self._setup_package_verifier()
 
             # Step 2: Extract ALL metadata info (including primary.xml.gz)
             metadata_files = parsers.extract_all_metadata(repomd_root)
@@ -298,6 +305,10 @@ class RpmSyncPlugin:
                     packages_downloaded += 1
                     bytes_downloaded += downloaded_bytes
                     self.output.downloaded(downloaded_bytes / 1024 / 1024)
+                except SignatureVerificationError:
+                    # A 'fail' signature policy must abort the whole sync rather
+                    # than silently skipping the offending package.
+                    raise
                 except Exception as e:
                     self.output.error(f"Failed to download {nvra}: {e}")
                     # Continue with next package
@@ -407,6 +418,8 @@ class RpmSyncPlugin:
                 success=False,
                 error_message=str(e),
             )
+        finally:
+            self._teardown_package_verifier()
 
     def check_updates(self, session: Session, repository: Repository) -> CheckUpdatesResult:
         """Check for available package updates without downloading.
@@ -632,10 +645,75 @@ class RpmSyncPlugin:
     def _handle_verify_policy(self, policy: str, message: str) -> None:
         """Apply a signature-verification behavior policy (fail/warn/skip)."""
         if policy == "fail":
-            raise ValueError(f"Signature verification failed: {message}")
+            from chantal.core.gpg_verify import SignatureVerificationError
+
+            raise SignatureVerificationError(f"Signature verification failed: {message}")
         if policy == "warn":
             self.output.warning(f"Signature verification: {message}")
         # "skip": silently continue
+
+    def _setup_package_verifier(self) -> None:
+        """Create the reusable package verifier if gpgcheck is enabled."""
+        verify = self.config.verify
+        if verify and verify.enabled and verify.gpgcheck:
+            from chantal.core.gpg_verify import GpgVerifier
+
+            verifier = GpgVerifier(verify)
+            verifier.import_trusted_keys()
+            self._package_verifier = verifier
+
+    def _teardown_package_verifier(self) -> None:
+        """Release the package verifier's keyring, if any."""
+        verifier = self._package_verifier
+        if verifier is not None:
+            verifier.close()  # type: ignore[attr-defined]
+            self._package_verifier = None
+
+    def _verify_package_signature(self, rpm_path: Path, nvra: str) -> None:
+        """Verify a downloaded package's header signature (gpgcheck).
+
+        No-op unless a package verifier was set up. Reads the ``.rpm``, extracts
+        its header-only OpenPGP signature, verifies it against the trusted keys,
+        and applies the configured policy.
+        """
+        verifier = self._package_verifier
+        if verifier is None:
+            return
+
+        import mmap
+
+        from chantal.core.gpg_verify import GpgVerifier
+        from chantal.plugins.rpm.rpm_header import RpmFormatError, extract_header_signature
+
+        assert isinstance(verifier, GpgVerifier)
+        verify = self.config.verify
+        assert verify is not None
+
+        # mmap the file so only the header region (near the start) is read,
+        # not the whole - potentially multi-GB - package. Slicing an mmap yields
+        # real bytes, so the extracted blob/packet stay valid after it closes.
+        try:
+            with (
+                open(rpm_path, "rb") as fh,
+                mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ) as mm,
+            ):
+                extracted = extract_header_signature(mm)
+        except RpmFormatError as exc:
+            self._handle_verify_policy(verify.on_invalid_signature, f"{nvra}: {exc}")
+            return
+
+        if extracted is None:
+            self._handle_verify_policy(
+                verify.on_missing_signature, f"{nvra}: package has no GPG signature"
+            )
+            return
+
+        signature_packet, header_blob = extracted
+        if not verifier.verify_detached(header_blob, signature_packet):
+            self._handle_verify_policy(
+                verify.on_invalid_signature,
+                f"{nvra}: invalid or untrusted package signature",
+            )
 
     def _get_existing_packages(self, session: Session) -> dict[str, ContentItem]:
         """Get existing content items from database.
@@ -687,6 +765,13 @@ class RpmSyncPlugin:
                     bytes_downloaded += len(chunk)
 
                 tmp_file.flush()
+
+                # Verify the package's GPG signature (gpgcheck) before trusting it.
+                nvra = (
+                    f"{pkg_meta['name']}-{pkg_meta['version']}-"
+                    f"{pkg_meta['release']}.{pkg_meta['arch']}"
+                )
+                self._verify_package_signature(tmp_path, nvra)
 
                 # Extract filename from location
                 filename = Path(pkg_meta["location"]).name

--- a/tests/e2e/test_rpm_verify_e2e.py
+++ b/tests/e2e/test_rpm_verify_e2e.py
@@ -1,0 +1,120 @@
+"""
+Golden cross-check: parse and verify the header signature of a *real* RPM.
+
+The synthetic parser test constructs its own RPM, so it cannot prove the
+byte-layout matches what `rpm`/`rpmsign` actually produce. This test builds a
+real package with `rpmbuild`, signs it with the real `rpm` toolchain, then
+asserts that our pure-Python parser finds the header signature and that it
+verifies against the signing key. Skipped where the rpm toolchain is absent
+(e.g. macOS dev machines); runs in the RPM CI leg.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_RPM = bool(
+    shutil.which("rpmbuild")
+    and (shutil.which("rpmsign") or shutil.which("rpm"))
+    and (shutil.which("gpg") or shutil.which("gpg2"))
+)
+# CI sets this for the RPM leg so a missing toolchain fails rather than silently
+# skipping the only test that validates the byte layout against real rpm output.
+_REQUIRED = bool(os.environ.get("CHANTAL_REQUIRE_RPM_E2E"))
+
+
+@pytest.mark.skipif(
+    not _HAVE_RPM and not _REQUIRED, reason="rpm/rpmbuild/gpg toolchain not available"
+)
+def test_real_signed_rpm_header_signature_verifies(tmp_path):
+    if not _HAVE_RPM:
+        pytest.fail("CHANTAL_REQUIRE_RPM_E2E is set but the rpm/rpmbuild/gpg toolchain is missing")
+
+    import gnupg
+
+    from chantal.core.config import SignatureVerificationConfig
+    from chantal.core.gpg_verify import GpgVerifier
+    from chantal.plugins.rpm.rpm_header import extract_header_signature
+
+    # 1. Generate an ephemeral signing key.
+    gnupghome = tmp_path / "gnupg"
+    gnupghome.mkdir()
+    os.chmod(gnupghome, 0o700)
+    gpg = gnupg.GPG(gnupghome=str(gnupghome))
+    gpg.encoding = "utf-8"
+    key = gpg.gen_key(
+        gpg.gen_key_input(
+            name_real="Chantal RPM Test",
+            name_email="rpm-test@chantal.local",
+            key_type="RSA",
+            key_length=3072,
+            expire_date=0,
+            no_protection=True,
+        )
+    )
+    assert key.fingerprint, "failed to generate signing key"
+    public_key = gpg.export_keys(key.fingerprint)
+    assert public_key
+
+    # 2. Build a minimal noarch package.
+    spec = tmp_path / "demo.spec"
+    spec.write_text(
+        "Name: demo\n"
+        "Version: 1.0\n"
+        "Release: 1\n"
+        "Summary: demo\n"
+        "License: MIT\n"
+        "BuildArch: noarch\n"
+        "%description\n"
+        "demo\n"
+        "%files\n",
+        encoding="utf-8",
+    )
+    topdir = tmp_path / "rpmbuild"
+    build = subprocess.run(
+        ["rpmbuild", "--define", f"_topdir {topdir}", "-bb", str(spec)],
+        capture_output=True,
+        text=True,
+    )
+    assert build.returncode == 0, f"rpmbuild failed:\n{build.stdout}\n{build.stderr}"
+    rpms = list(topdir.rglob("*.rpm"))
+    assert rpms, "rpmbuild produced no .rpm"
+    rpm_path = rpms[0]
+
+    # 3. Sign the package header with the real rpm toolchain.
+    signer = "rpmsign" if shutil.which("rpmsign") else "rpm"
+    sign = subprocess.run(
+        [
+            signer,
+            "--define",
+            "_gpg_name rpm-test@chantal.local",
+            "--define",
+            f"_gpg_path {gnupghome}",
+            "--addsign",
+            str(rpm_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert sign.returncode == 0, f"rpm --addsign failed:\n{sign.stdout}\n{sign.stderr}"
+
+    # 4. Our parser must find the header signature, and it must verify.
+    extracted = extract_header_signature(rpm_path.read_bytes())
+    assert extracted is not None, "parser did not find the header signature in a real signed RPM"
+    packet, header_blob = extracted
+
+    cfg = SignatureVerificationConfig(
+        enabled=True, keys=[public_key], gnupg_home=str(tmp_path / "verify")
+    )
+    with GpgVerifier(cfg) as verifier:
+        assert verifier.verify_detached(header_blob, packet) is True
+        # A modified header must not verify.
+        tampered = bytearray(header_blob)
+        tampered[len(tampered) // 2] ^= 0xFF
+        assert verifier.verify_detached(bytes(tampered), packet) is False

--- a/tests/test_rpm_verify.py
+++ b/tests/test_rpm_verify.py
@@ -63,9 +63,15 @@ class TestSignatureVerificationConfig:
         cfg = SignatureVerificationConfig(enabled=True, keys=["-----BEGIN PGP PUBLIC KEY-----"])
         assert cfg.enabled is True
 
-    def test_gpgcheck_rejected_until_implemented(self):
-        with pytest.raises(ValueError, match="not yet implemented"):
-            SignatureVerificationConfig(enabled=True, keys=["k"], gpgcheck=True)
+    def test_gpgcheck_accepted(self):
+        cfg = SignatureVerificationConfig(enabled=True, keys=["k"], gpgcheck=True)
+        assert cfg.gpgcheck is True
+
+    def test_gpgcheck_requires_repo_gpgcheck(self):
+        with pytest.raises(ValueError, match="requires repo_gpgcheck"):
+            SignatureVerificationConfig(
+                enabled=True, keys=["k"], gpgcheck=True, repo_gpgcheck=False
+            )
 
     def test_empty_fingerprint_rejected(self):
         with pytest.raises(ValueError, match="empty entries"):
@@ -149,3 +155,90 @@ class TestGpgVerifier:
         with GpgVerifier(cfg) as verifier:
             with pytest.raises(GpgVerificationError, match="not found"):
                 verifier.verify_detached(b"x", b"y")
+
+
+# --------------------------------------------------------------------------- #
+# RPM header parsing + package signature verification
+# --------------------------------------------------------------------------- #
+
+import struct  # noqa: E402
+
+from chantal.plugins.rpm.rpm_header import (  # noqa: E402
+    RPMTAG_RSAHEADER,
+    RpmFormatError,
+    extract_header_signature,
+)
+
+_LEAD = b"\xed\xab\xee\xdb" + b"\x00" * 92  # 96-byte lead
+
+
+def _build_header(items: list[tuple[int, bytes]]) -> bytes:
+    """Serialize a minimal RPM 'header' structure from (tag, raw_bytes) items."""
+    index = b""
+    store = b""
+    for tag, raw in items:
+        index += struct.pack(">IIII", tag, 7, len(store), len(raw))  # type 7 = BIN
+        store += raw
+    intro = b"\x8e\xad\xe8\x01" + b"\x00" * 4 + struct.pack(">II", len(items), len(store))
+    return intro + index + store
+
+
+def _build_rpm(main_blob: bytes, sig_packet: bytes) -> bytes:
+    """Assemble lead + signature header (RSAHEADER) + padding + main header."""
+    sig_header = _build_header([(RPMTAG_RSAHEADER, sig_packet)])
+    sig_end = _LEAD_SIZE_LOCAL + len(sig_header)
+    pad = b"\x00" * (-sig_end % 8)
+    return _LEAD + sig_header + pad + main_blob
+
+
+_LEAD_SIZE_LOCAL = 96
+
+
+class TestRpmHeaderParser:
+    def test_extract_round_trip(self):
+        main_blob = _build_header([(1000, b"name=demo\x00"), (1001, b"1.0\x00")])
+        rpm = _build_rpm(main_blob, b"FAKE-SIGNATURE-PACKET")
+        result = extract_header_signature(rpm)
+        assert result is not None
+        sig, blob = result
+        assert sig == b"FAKE-SIGNATURE-PACKET"
+        assert blob == main_blob
+
+    def test_unsigned_returns_none(self):
+        main_blob = _build_header([(1000, b"x")])
+        # signature header with a non-signature tag only
+        sig_header = _build_header([(1004, b"\x00" * 16)])  # MD5-ish, not a header sig
+        sig_end = 96 + len(sig_header)
+        rpm = _LEAD + sig_header + b"\x00" * (-sig_end % 8) + main_blob
+        assert extract_header_signature(rpm) is None
+
+    def test_not_an_rpm_raises(self):
+        with pytest.raises(RpmFormatError, match="bad lead magic"):
+            extract_header_signature(b"not an rpm" * 20)
+
+
+class TestPackageSignatureVerification:
+    def test_valid_package_signature(self, upstream_signer, verifier_home):
+        main_blob = _build_header([(1000, b"demo-1.0\x00")])
+        sig = upstream_signer.detach_sign(main_blob)  # detached OpenPGP signature
+        rpm = _build_rpm(main_blob, sig)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+
+        extracted = extract_header_signature(rpm)
+        assert extracted is not None
+        packet, blob = extracted
+        with GpgVerifier(_verify_config(pub, verifier_home)) as verifier:
+            assert verifier.verify_detached(blob, packet) is True
+
+    def test_tampered_header_fails(self, upstream_signer, verifier_home):
+        main_blob = _build_header([(1000, b"demo-1.0\x00")])
+        sig = upstream_signer.detach_sign(main_blob)
+        rpm = bytearray(_build_rpm(main_blob, sig))
+        rpm[-1] ^= 0xFF  # corrupt the last byte of the main header blob
+        pub = upstream_signer.export_public_key().decode("utf-8")
+
+        extracted = extract_header_signature(bytes(rpm))
+        assert extracted is not None
+        packet, blob = extracted
+        with GpgVerifier(_verify_config(pub, verifier_home)) as verifier:
+            assert verifier.verify_detached(blob, packet) is False


### PR DESCRIPTION
Completes **#58 item 1**: package-level upstream authenticity verification (dnf `gpgcheck`), on top of the repo-metadata check from #60.

## What
- `plugins/rpm/rpm_header.py`: pure-Python RPM container parser extracting the header-only OpenPGP signature (RSAHEADER/DSAHEADER) and the main-header blob it covers. No new deps, no `rpm` binary.
- `rpm/sync.py`: one reusable `GpgVerifier` per sync; each downloaded `.rpm` header signature is verified (via mmap, so only the header region is read) **before** it is added to the pool. A `fail` policy raises `SignatureVerificationError` and aborts the sync; `warn`/`skip` supported.
- Config: `gpgcheck` implemented (default `true`) and now **requires `repo_gpgcheck`** so the authenticated metadata checksums bind the payload (header-only sigs do not cover the payload by themselves).

## Process
Research -> implement -> self-review -> **fresh-context subagent review** (no BLOCKER; addressed all SHOULD-FIX): the payload-binding gap (now enforced via the repo_gpgcheck requirement), whole-file read (now mmap), and a golden test that could skip silently (now **required** in CI via `CHANTAL_REQUIRE_RPM_E2E`).

## Tests
- Synthetic RPM round-trip + verification (always runs where gpg present).
- **Golden cross-check**: builds and signs a REAL rpm with `rpmbuild`/`rpmsign` and asserts our parser finds + verifies its signature; enforced (not skipped) on the rpm CI leg (the leg installs rpm).

## Note
gpgcheck now defaults to true - a config that enabled verify for metadata only and has unsigned packages will now fail closed on sync (a CHANGELOG note will accompany the eventual release).

Closes #58 item 1.