### PR TITLE
feat(rpm): algorithm-aware checksum verification (sha256/sha512/sha1)

### DIFF
--- a/src/chantal/core/cache.py
+++ b/src/chantal/core/cache.py
@@ -87,13 +87,22 @@ class MetadataCache:
         logger.info(f"Cache hit for {file_type}: {checksum[:16]}...")
         return cache_file
 
-    def put(self, checksum: str, content: bytes, file_type: str = "metadata") -> Path:
+    def put(
+        self,
+        checksum: str,
+        content: bytes,
+        file_type: str = "metadata",
+        algorithm: str = "sha256",
+    ) -> Path:
         """Store file in cache.
 
         Args:
-            checksum: SHA256 checksum of the file
+            checksum: Checksum of the file (used as the cache key)
             content: File content (compressed .xml.gz)
             file_type: Type hint for logging
+            algorithm: hashlib algorithm name the checksum was computed with
+                (e.g. "sha256", "sha512", "sha1"). Repositories may publish
+                metadata checksums in algorithms other than sha256.
 
         Returns:
             Path to cached file
@@ -107,9 +116,9 @@ class MetadataCache:
 
         cache_file = self.cache_path / f"{checksum}.xml.gz"
 
-        # Verify checksum matches content
-        actual_checksum = hashlib.sha256(content).hexdigest()
-        if actual_checksum != checksum:
+        # Verify checksum matches content (using the declared algorithm).
+        actual_checksum = hashlib.new(algorithm, content).hexdigest()
+        if actual_checksum.lower() != checksum.lower():
             logger.warning(
                 f"Checksum mismatch: expected {checksum[:16]}..., got {actual_checksum[:16]}..."
             )

--- a/src/chantal/plugins/rpm/parsers.py
+++ b/src/chantal/plugins/rpm/parsers.py
@@ -9,9 +9,11 @@ This module provides functions for parsing RPM repository metadata files.
 import bz2
 import configparser
 import gzip
+import hashlib
 import logging
 import lzma
 import xml.etree.ElementTree as ET
+from pathlib import Path
 from urllib.parse import urljoin
 
 import requests
@@ -20,6 +22,62 @@ import zstandard as zstd
 from chantal.core.cache import MetadataCache
 
 logger = logging.getLogger(__name__)
+
+# Map the checksum ``type`` attribute used in repomd.xml / primary.xml to a
+# hashlib algorithm name. RPM repositories use sha256 (common), sha512, or the
+# legacy sha1 (often written as "sha"). md5 is intentionally not accepted: it
+# provides no meaningful integrity guarantee and modern createrepo never emits
+# it.
+_CHECKSUM_ALGORITHMS = {
+    "sha": "sha1",
+    "sha1": "sha1",
+    "sha224": "sha224",
+    "sha256": "sha256",
+    "sha384": "sha384",
+    "sha512": "sha512",
+}
+
+
+def normalize_checksum_type(checksum_type: str | None) -> str:
+    """Resolve a repomd/primary checksum ``type`` to a hashlib algorithm name.
+
+    Defaults to sha256 when unspecified.
+
+    Raises:
+        ValueError: If the checksum type is not supported.
+    """
+    algo = _CHECKSUM_ALGORITHMS.get((checksum_type or "sha256").lower())
+    if algo is None:
+        raise ValueError(f"Unsupported checksum type: {checksum_type!r}")
+    return algo
+
+
+def verify_data_checksum(data: bytes, checksum_type: str | None, expected: str) -> bool:
+    """Return True if ``data`` matches ``expected`` under the declared algorithm.
+
+    Raises:
+        ValueError: If ``expected`` is empty (fail closed rather than skip).
+    """
+    if not expected:
+        raise ValueError("Cannot verify: empty expected checksum")
+    algo = normalize_checksum_type(checksum_type)
+    actual = hashlib.new(algo, data).hexdigest()
+    return actual.lower() == expected.lower()
+
+
+def verify_file_checksum(path: Path, checksum_type: str | None, expected: str) -> bool:
+    """Return True if the file at ``path`` matches ``expected`` (declared algorithm).
+
+    Raises:
+        ValueError: If ``expected`` is empty (fail closed rather than skip).
+    """
+    if not expected:
+        raise ValueError("Cannot verify: empty expected checksum")
+    digest = hashlib.new(normalize_checksum_type(checksum_type))
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest().lower() == expected.lower()
 
 
 def fetch_repomd_content(session: requests.Session, base_url: str) -> bytes:
@@ -122,6 +180,9 @@ def extract_all_metadata(repomd_root: ET.Element) -> list[dict]:
             if open_checksum_elem is None:
                 open_checksum_elem = data_elem.find("open-checksum")
             open_checksum = open_checksum_elem.text if open_checksum_elem is not None else None
+            open_checksum_type = (
+                open_checksum_elem.get("type") if open_checksum_elem is not None else None
+            )
 
             open_size_elem = data_elem.find("repo:open-size", ns)
             if open_size_elem is None:
@@ -137,8 +198,10 @@ def extract_all_metadata(repomd_root: ET.Element) -> list[dict]:
                 "file_type": file_type,
                 "location": location,
                 "checksum": checksum_elem.text,
+                "checksum_type": checksum_elem.get("type"),
                 "size": size,
                 "open_checksum": open_checksum,
+                "open_checksum_type": open_checksum_type,
                 "open_size": open_size,
             }
             metadata_files.append(metadata_info)
@@ -158,32 +221,37 @@ def fetch_metadata_with_cache(
     checksum: str,
     cache: MetadataCache | None = None,
     file_type: str = "metadata",
+    checksum_type: str | None = None,
 ) -> tuple[bytes, bool]:
-    """Download and decompress metadata file with optional caching.
+    """Download, verify and decompress a metadata file (with optional caching).
+
+    The compressed file is verified against the ``checksum`` from repomd.xml
+    using the declared ``checksum_type`` algorithm (sha256/sha512/sha1).
 
     Args:
         session: Requests session (with auth/SSL configured)
         base_url: Base URL of repository
         location: Relative path to metadata file (e.g., "repodata/abc-primary.xml.gz")
-        checksum: Expected SHA256 checksum
+        checksum: Expected checksum from repomd.xml
         cache: Optional MetadataCache instance
         file_type: Type hint for logging (e.g., "primary", "updateinfo")
+        checksum_type: Checksum algorithm from repomd.xml (defaults to sha256)
 
     Returns:
         Tuple of (decompressed XML content as bytes, from_cache boolean)
 
     Raises:
         requests.RequestException: On HTTP errors
-        ValueError: If compression format is unknown or checksum mismatch
+        ValueError: If compression format is unknown or the checksum mismatches
     """
-    # Try cache first if enabled
+    # Try cache first if enabled (re-verify in case the cache entry is corrupt).
     if cache:
         cached_file = cache.get(checksum, file_type)
         if cached_file:
-            # Read cached compressed file
             compressed_content = cached_file.read_bytes()
-            # Decompress and return
-            return _decompress_metadata(compressed_content, location), True
+            if verify_data_checksum(compressed_content, checksum_type, checksum):
+                return _decompress_metadata(compressed_content, location), True
+            logger.warning(f"Cached {file_type} failed checksum verification; re-downloading")
 
     # Cache miss or disabled - download from upstream
     metadata_url = urljoin(base_url + "/", location)
@@ -191,10 +259,15 @@ def fetch_metadata_with_cache(
     response = session.get(metadata_url, timeout=60)
     response.raise_for_status()
 
+    # Verify the downloaded file against repomd.xml before trusting it.
+    algo = normalize_checksum_type(checksum_type)
+    if not verify_data_checksum(response.content, checksum_type, checksum):
+        raise ValueError(f"{file_type} {algo} checksum mismatch for {location}")
+
     # Store in cache if enabled (compressed)
     if cache:
         try:
-            cache.put(checksum, response.content, file_type)
+            cache.put(checksum, response.content, file_type, algorithm=algo)
         except Exception as e:
             logger.warning(f"Failed to cache {file_type}: {e}")
 
@@ -326,6 +399,7 @@ def parse_primary_xml(xml_content: bytes) -> list[dict]:
                 "epoch": version_elem.get("epoch"),
                 "arch": arch_elem.text,
                 "sha256": checksum_elem.text,
+                "checksum_type": checksum_elem.get("type"),
                 "size_bytes": int(size_elem.get("package") or "0") if size_elem is not None else 0,
                 "location": location_elem.get("href"),
                 "summary": summary_elem.text if summary_elem is not None else None,

--- a/src/chantal/plugins/rpm/sync.py
+++ b/src/chantal/plugins/rpm/sync.py
@@ -62,10 +62,11 @@ class MetadataFileInfo:
 
     file_type: str  # e.g., "primary", "updateinfo", "filelists", "other", "comps", "modules"
     location: str  # Relative path (e.g., "repodata/abc123-updateinfo.xml.gz")
-    checksum: str  # SHA256 checksum
+    checksum: str  # Checksum value from repomd.xml
     size: int  # File size in bytes
     open_checksum: str | None = None  # Checksum of uncompressed file
     open_size: int | None = None  # Size of uncompressed file
+    checksum_type: str | None = None  # Checksum algorithm (sha256/sha512/sha1)
 
 
 @dataclass
@@ -225,6 +226,7 @@ class RpmSyncPlugin:
                     checksum=primary_checksum,
                     cache=self.cache,
                     file_type="primary",
+                    checksum_type=primary_metadata.get("checksum_type"),
                 )
                 if from_cache:
                     self.output.verbose("  → primary.xml.gz loaded from cache")
@@ -336,6 +338,7 @@ class RpmSyncPlugin:
                         size=metadata_info["size"],
                         open_checksum=metadata_info.get("open_checksum"),
                         open_size=metadata_info.get("open_size"),
+                        checksum_type=metadata_info.get("checksum_type"),
                     )
                     from_cache = self._download_metadata_file(
                         mfi, session, repository, self.config.feed
@@ -468,6 +471,7 @@ class RpmSyncPlugin:
                     checksum=primary_checksum,
                     cache=self.cache,
                     file_type="primary",
+                    checksum_type=primary_metadata.get("checksum_type"),
                 )
                 if from_cache:
                     print("  → primary.xml.gz loaded from cache")
@@ -773,19 +777,22 @@ class RpmSyncPlugin:
                 )
                 self._verify_package_signature(tmp_path, nvra)
 
+                # Verify the package against the checksum declared in primary.xml,
+                # honoring its algorithm (sha256/sha512/sha1) rather than assuming
+                # sha256. The pool itself is always addressed by sha256.
+                if not parsers.verify_file_checksum(
+                    tmp_path, pkg_meta.get("checksum_type"), pkg_meta["sha256"]
+                ):
+                    algo = parsers.normalize_checksum_type(pkg_meta.get("checksum_type"))
+                    raise ValueError(f"{algo} checksum mismatch for {nvra}")
+
                 # Extract filename from location
                 filename = Path(pkg_meta["location"]).name
 
-                # Add to storage pool (will verify SHA256)
+                # Add to storage pool (computes the sha256 used for addressing)
                 sha256, pool_path, size_bytes = self.storage.add_package(
                     tmp_path, filename, verify_checksum=True
                 )
-
-                # Verify SHA256 matches metadata
-                if sha256 != pkg_meta["sha256"]:
-                    raise ValueError(
-                        f"SHA256 mismatch: expected {pkg_meta['sha256']}, got {sha256}"
-                    )
 
                 # Build RPM metadata
                 rpm_metadata = RpmMetadata(
@@ -868,7 +875,10 @@ class RpmSyncPlugin:
                 # Cache the compressed file
                 try:
                     cached_file = self.cache.put(
-                        metadata_info.checksum, response.content, metadata_info.file_type
+                        metadata_info.checksum,
+                        response.content,
+                        metadata_info.file_type,
+                        algorithm=parsers.normalize_checksum_type(metadata_info.checksum_type),
                     )
                     tmp_path = cached_file
                     cleanup_temp = False
@@ -912,17 +922,21 @@ class RpmSyncPlugin:
             # Extract filename from location
             filename = Path(metadata_info.location).name
 
-            # Add to storage pool using add_repository_file
+            # Verify the file against repomd.xml using the declared algorithm
+            # (sha256/sha512/sha1) before adding it to the pool.
+            if metadata_info.checksum and not parsers.verify_file_checksum(
+                tmp_path, metadata_info.checksum_type, metadata_info.checksum
+            ):
+                algo = parsers.normalize_checksum_type(metadata_info.checksum_type)
+                raise ValueError(
+                    f"{algo} checksum mismatch for {metadata_info.file_type}: "
+                    f"{metadata_info.location}"
+                )
+
+            # Add to storage pool using add_repository_file (sha256-addressed)
             sha256, pool_path, size_bytes = self.storage.add_repository_file(
                 tmp_path, filename, verify_checksum=True
             )
-
-            # Verify SHA256 matches metadata (if provided)
-            if metadata_info.checksum and sha256 != metadata_info.checksum:
-                raise ValueError(
-                    f"SHA256 mismatch for {metadata_info.file_type}: "
-                    f"expected {metadata_info.checksum}, got {sha256}"
-                )
 
             # Check if this RepositoryFile already exists
             existing_file = session.query(RepositoryFile).filter_by(sha256=sha256).first()
@@ -942,7 +956,7 @@ class RpmSyncPlugin:
                     size_bytes=size_bytes,
                     original_path=metadata_info.location,
                     file_metadata={
-                        "checksum_type": "sha256",
+                        "checksum_type": metadata_info.checksum_type or "sha256",
                         "open_checksum": metadata_info.open_checksum,
                         "open_size": metadata_info.open_size,
                     },

--- a/tests/e2e/test_rpm_sha512_e2e.py
+++ b/tests/e2e/test_rpm_sha512_e2e.py
@@ -1,0 +1,109 @@
+"""
+End-to-end test: sync an RPM repo whose metadata/packages use **sha512**
+checksums (not sha256). Proves the algorithm-aware checksum handling: such a
+repo previously broke because chantal assumed sha256 everywhere.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+def _build_sha512_rpm_upstream(root: Path, *, corrupt_package_checksum: bool = False) -> None:
+    repodata = root / "repodata"
+    repodata.mkdir(parents=True, exist_ok=True)
+
+    rpm = b"dummy rpm payload" * 16
+    rpm_name = "demo-1.0-1.el9.x86_64.rpm"
+    (root / rpm_name).write_bytes(rpm)
+    rpm_sha512 = hashlib.sha512(rpm).hexdigest()
+    if corrupt_package_checksum:
+        # Declare a wrong checksum: the package must be rejected, not published.
+        rpm_sha512 = "0" * 128
+
+    primary = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<metadata xmlns="http://linux.duke.edu/metadata/common"'
+        ' xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="1">\n'
+        '<package type="rpm">\n'
+        "  <name>demo</name>\n"
+        "  <arch>x86_64</arch>\n"
+        '  <version epoch="0" ver="1.0" rel="1.el9"/>\n'
+        f'  <checksum type="sha512" pkgid="YES">{rpm_sha512}</checksum>\n'
+        "  <summary>demo</summary>\n"
+        '  <size package="' + str(len(rpm)) + '"/>\n'
+        f'  <location href="{rpm_name}"/>\n'
+        "  <format><rpm:sourcerpm>demo-1.0-1.el9.src.rpm</rpm:sourcerpm></format>\n"
+        "</package>\n"
+        "</metadata>\n"
+    ).encode("utf-8")
+
+    gz = gzip.compress(primary)
+    (repodata / "primary.xml.gz").write_bytes(gz)
+
+    repomd = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<repomd xmlns="http://linux.duke.edu/metadata/repo">\n'
+        "  <revision>1</revision>\n"
+        '  <data type="primary">\n'
+        f'    <checksum type="sha512">{hashlib.sha512(gz).hexdigest()}</checksum>\n'
+        f'    <open-checksum type="sha512">{hashlib.sha512(primary).hexdigest()}</open-checksum>\n'
+        '    <location href="repodata/primary.xml.gz"/>\n'
+        f"    <size>{len(gz)}</size>\n"
+        f"    <open-size>{len(primary)}</open-size>\n"
+        "  </data>\n"
+        "</repomd>\n"
+    )
+    (repodata / "repomd.xml").write_text(repomd, encoding="utf-8")
+
+
+def test_rpm_sha512_sync_and_publish(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_sha512_rpm_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-rpm-sha512",
+            "name": "Demo RPM sha512",
+            "type": "rpm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-rpm-sha512")
+
+    assert (target / "repodata" / "repomd.xml").exists()
+    assert list(target.rglob("demo-1.0-1.el9.x86_64.rpm")), "sha512 package not synced/published"
+
+
+def test_rpm_sha512_bad_package_checksum_is_rejected(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_sha512_rpm_upstream(upstream, corrupt_package_checksum=True)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-rpm-bad",
+            "name": "Demo RPM bad checksum",
+            "type": "rpm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-rpm-bad")
+
+    # Metadata still publishes, but the package with the wrong checksum must not.
+    assert not list(
+        target.rglob("demo-1.0-1.el9.x86_64.rpm")
+    ), "package with invalid sha512 checksum should have been rejected"

--- a/tests/test_rpm_checksums.py
+++ b/tests/test_rpm_checksums.py
@@ -1,0 +1,133 @@
+"""Tests for algorithm-aware RPM checksum handling (sha256/sha512/sha1)."""
+
+from __future__ import annotations
+
+import hashlib
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from chantal.plugins.rpm import parsers
+
+
+class TestNormalizeChecksumType:
+    def test_defaults_to_sha256(self):
+        assert parsers.normalize_checksum_type(None) == "sha256"
+
+    def test_sha_alias_is_sha1(self):
+        assert parsers.normalize_checksum_type("sha") == "sha1"
+        assert parsers.normalize_checksum_type("SHA1") == "sha1"
+
+    def test_sha512(self):
+        assert parsers.normalize_checksum_type("sha512") == "sha512"
+
+    def test_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unsupported checksum type"):
+            parsers.normalize_checksum_type("crc32")
+
+    def test_md5_rejected(self):
+        # md5 gives no meaningful integrity guarantee and is not accepted.
+        with pytest.raises(ValueError, match="Unsupported checksum type"):
+            parsers.normalize_checksum_type("md5")
+
+
+class TestVerifyDataChecksum:
+    def test_sha256_match(self):
+        data = b"hello"
+        assert parsers.verify_data_checksum(data, "sha256", hashlib.sha256(data).hexdigest())
+
+    def test_sha512_match(self):
+        data = b"hello"
+        assert parsers.verify_data_checksum(data, "sha512", hashlib.sha512(data).hexdigest())
+
+    def test_default_type_is_sha256(self):
+        data = b"hello"
+        assert parsers.verify_data_checksum(data, None, hashlib.sha256(data).hexdigest())
+
+    def test_mismatch(self):
+        assert not parsers.verify_data_checksum(b"hello", "sha256", "0" * 64)
+
+    def test_wrong_algorithm_fails(self):
+        # A sha512 value won't match when verified as sha256.
+        data = b"hello"
+        assert not parsers.verify_data_checksum(data, "sha256", hashlib.sha512(data).hexdigest())
+
+    def test_empty_expected_raises(self):
+        # Fail closed rather than silently skip verification.
+        with pytest.raises(ValueError, match="empty expected checksum"):
+            parsers.verify_data_checksum(b"hello", "sha256", "")
+
+
+class TestVerifyFileChecksum:
+    def test_file_sha512(self, tmp_path):
+        f = tmp_path / "blob"
+        f.write_bytes(b"payload" * 100)
+        digest = hashlib.sha512(f.read_bytes()).hexdigest()
+        assert parsers.verify_file_checksum(f, "sha512", digest)
+        assert not parsers.verify_file_checksum(f, "sha512", "0" * 128)
+
+    def test_file_sha1_alias(self, tmp_path):
+        f = tmp_path / "blob"
+        f.write_bytes(b"legacy")
+        digest = hashlib.sha1(f.read_bytes()).hexdigest()
+        # "sha" is the legacy alias for sha1 used by old repositories.
+        assert parsers.verify_file_checksum(f, "sha", digest)
+
+    def test_empty_expected_raises(self, tmp_path):
+        f = tmp_path / "blob"
+        f.write_bytes(b"x")
+        with pytest.raises(ValueError, match="empty expected checksum"):
+            parsers.verify_file_checksum(f, "sha256", "")
+
+
+class TestCacheAlgorithmAware:
+    def test_cache_put_get_sha512(self, tmp_path):
+        from chantal.core.cache import MetadataCache
+
+        cache = MetadataCache(cache_path=tmp_path / "cache", enabled=True)
+        content = b"compressed-metadata-bytes" * 10
+        sha512 = hashlib.sha512(content).hexdigest()
+
+        # Previously this raised because put() assumed sha256 for the key.
+        cached = cache.put(sha512, content, "primary", algorithm="sha512")
+        assert cached.exists()
+        assert cache.get(sha512, "primary") == cached
+        assert cached.read_bytes() == content
+
+    def test_cache_put_rejects_mismatch(self, tmp_path):
+        from chantal.core.cache import MetadataCache
+
+        cache = MetadataCache(cache_path=tmp_path / "cache", enabled=True)
+        with pytest.raises(ValueError, match="Checksum mismatch"):
+            cache.put("0" * 128, b"content", "primary", algorithm="sha512")
+
+
+class TestChecksumTypeParsing:
+    def test_repomd_checksum_type_extracted(self):
+        repomd = (
+            '<repomd xmlns="http://linux.duke.edu/metadata/repo">'
+            '<data type="primary">'
+            '<checksum type="sha512">abc</checksum>'
+            '<open-checksum type="sha512">def</open-checksum>'
+            '<location href="repodata/primary.xml.gz"/>'
+            "<size>1</size><open-size>2</open-size>"
+            "</data></repomd>"
+        )
+        meta = parsers.extract_all_metadata(ET.fromstring(repomd))
+        assert meta[0]["checksum_type"] == "sha512"
+        assert meta[0]["open_checksum_type"] == "sha512"
+
+    def test_primary_checksum_type_extracted(self):
+        primary = (
+            '<metadata xmlns="http://linux.duke.edu/metadata/common"'
+            ' xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="1">'
+            '<package type="rpm"><name>demo</name><arch>x86_64</arch>'
+            '<version epoch="0" ver="1.0" rel="1"/>'
+            '<checksum type="sha512" pkgid="YES">deadbeef</checksum>'
+            "<summary>s</summary>"
+            '<size package="1"/><location href="demo.rpm"/>'
+            "</package></metadata>"
+        )
+        pkgs = parsers.parse_primary_xml(primary.encode("utf-8"))
+        assert pkgs[0]["checksum_type"] == "sha512"
+        assert pkgs[0]["sha256"] == "deadbeef"  # value field holds the declared checksum


### PR DESCRIPTION
## Summary

Item 2 of #58 (RPM core mirroring). Makes RPM checksum verification algorithm-aware and adds verification where it was previously missing.

RPM repositories may publish metadata and package checksums in algorithms other than sha256 — sha512 is common on newer EL/Fedora repos, and sha1 (often written as `sha`) on legacy ones. Previously chantal assumed sha256 everywhere, and metadata files were not actually verified against `repomd.xml` at all (the checksum was only used as a cache key).

## Changes

- Add `normalize_checksum_type` / `verify_data_checksum` / `verify_file_checksum` helpers. `md5` is intentionally rejected (no meaningful integrity guarantee; modern createrepo never emits it).
- Parse the checksum `type` attribute from `repomd.xml` and `primary.xml`, threaded through `MetadataFileInfo` and all call sites.
- Verify downloaded metadata against `repomd.xml` using the declared algorithm — re-verifying cache hits and re-downloading on mismatch.
- Verify packages and metadata files against the declared algorithm **before** pool insertion. The content-addressed pool itself stays sha256-addressed.
- Make `MetadataCache.put` algorithm-aware so sha512 repos can actually be cached.
- Fail closed on empty expected checksums.

## Tests

- `tests/test_rpm_checksums.py`: unit tests for the helpers, the `sha`→sha1 alias, md5 rejection, empty-checksum fail-closed, and the sha512 cache roundtrip.
- `tests/e2e/test_rpm_sha512_e2e.py`: end-to-end sync+publish of a repo using sha512 throughout, plus a negative test asserting a package with a wrong checksum is rejected (not published).

Part of #58