### PR TITLE
feat(rpm): filter modules.yaml (modulemd) in filtered mode

### DIFF
--- a/src/chantal/plugins/rpm/modules.py
+++ b/src/chantal/plugins/rpm/modules.py
@@ -1,0 +1,151 @@
+"""
+Filtering of AppStream modularity metadata (``modules.yaml`` / modulemd).
+
+``modules.yaml`` is a multi-document YAML stream. Only ``modulemd`` (stream)
+documents bind a module stream to concrete RPMs, via ``data.artifacts.rpms`` --
+a list of full NEVRA strings ``name-epoch:version-release.arch`` (the epoch is
+always explicit). The other document types (``modulemd-defaults``,
+``modulemd-translations``, ``modulemd-obsoletes``) are keyed by module *name*,
+not by RPM.
+
+When a repository is mirrored in *filtered* mode the published package set is a
+subset of upstream, so the artifact lists must be pruned to the surviving
+packages -- otherwise the published modules document references RPMs that are no
+longer present, breaking downstream ``dnf module`` operations.
+
+This module is intentionally free of any I/O so the filtering logic can be unit
+tested in isolation; the compression helpers operate on bytes.
+"""
+
+from __future__ import annotations
+
+import bz2
+import gzip
+import logging
+import lzma
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# modulemd stream document -- the only type that binds RPM artifacts.
+_STREAM_DOCUMENT = "modulemd"
+
+# Documents scoped to a module *name* rather than to individual RPMs.
+_MODULE_SCOPED_DOCUMENTS = {
+    "modulemd-defaults",
+    "modulemd-translations",
+    "modulemd-obsoletes",
+}
+
+
+def filter_modules_yaml(yaml_bytes: bytes, available_nevras: set[str]) -> bytes | None:
+    """Prune modulemd documents to the available package set.
+
+    For each ``modulemd`` stream document the ``data.artifacts.rpms`` list is
+    intersected with ``available_nevras``. A stream whose artifacts are entirely
+    absent is dropped. Module-scoped documents (defaults/translations/obsoletes)
+    are kept only while their module still has a surviving stream.
+
+    Args:
+        yaml_bytes: Raw (decompressed) ``modules.yaml`` content.
+        available_nevras: Published-package NEVRAs in modulemd form
+            (``name-epoch:version-release.arch``, epoch always explicit).
+
+    Returns:
+        The filtered multi-document YAML as bytes, or ``None`` if no document
+        survives (the caller should then drop ``modules.yaml`` entirely).
+    """
+    documents = list(yaml.safe_load_all(yaml_bytes.decode("utf-8")))
+
+    surviving_modules: set[str] = set()
+    stream_survives: dict[int, bool] = {}
+
+    # Pass 1: prune stream artifacts and record which modules keep a stream.
+    for index, doc in enumerate(documents):
+        if not isinstance(doc, dict) or doc.get("document") != _STREAM_DOCUMENT:
+            continue
+
+        data = doc.get("data")
+        if not isinstance(data, dict):
+            stream_survives[index] = False
+            continue
+
+        artifacts = data.get("artifacts")
+        if isinstance(artifacts, dict) and isinstance(artifacts.get("rpms"), list):
+            # Only the ``artifacts.rpms`` NEVRA list is pruned. The rarely-used
+            # ``artifacts.rpm-map`` form is left untouched.
+            kept = [nevra for nevra in artifacts["rpms"] if nevra in available_nevras]
+            artifacts["rpms"] = kept
+            survives = bool(kept)
+        else:
+            # No RPM artifact list to prune -- keep the stream as-is.
+            survives = True
+
+        stream_survives[index] = survives
+        name = data.get("name")
+        if survives and isinstance(name, str):
+            surviving_modules.add(name)
+
+    # Pass 2: rebuild the document stream in its original order.
+    result: list[object] = []
+    for index, doc in enumerate(documents):
+        if not isinstance(doc, dict):
+            # Preserve anything we do not understand.
+            result.append(doc)
+            continue
+
+        doc_type = doc.get("document")
+        if doc_type == _STREAM_DOCUMENT:
+            if stream_survives.get(index):
+                result.append(doc)
+        elif doc_type in _MODULE_SCOPED_DOCUMENTS:
+            data = doc.get("data")
+            module = data.get("module") if isinstance(data, dict) else None
+            # Drop only when we can positively tie it to a vanished module.
+            if not isinstance(module, str) or module in surviving_modules:
+                result.append(doc)
+        else:
+            result.append(doc)
+
+    if not result:
+        return None
+
+    dumped = yaml.safe_dump_all(
+        result,
+        default_flow_style=False,
+        sort_keys=False,
+        explicit_start=True,
+        allow_unicode=True,
+    )
+    return dumped.encode("utf-8")
+
+
+def decompress_bytes(data: bytes, suffix: str) -> bytes:
+    """Decompress ``data`` according to a file-name ``suffix`` (e.g. ``.gz``)."""
+    if suffix == ".gz":
+        return gzip.decompress(data)
+    if suffix == ".xz":
+        return lzma.decompress(data)
+    if suffix == ".bz2":
+        return bz2.decompress(data)
+    if suffix == ".zst":
+        import zstandard as zstd
+
+        return zstd.ZstdDecompressor().decompress(data)
+    return data
+
+
+def compress_bytes(data: bytes, suffix: str) -> bytes:
+    """Compress ``data`` according to a file-name ``suffix`` (e.g. ``.gz``)."""
+    if suffix == ".gz":
+        return gzip.compress(data)
+    if suffix == ".xz":
+        return lzma.compress(data)
+    if suffix == ".bz2":
+        return bz2.compress(data)
+    if suffix == ".zst":
+        import zstandard as zstd
+
+        return zstd.ZstdCompressor().compress(data)
+    return data

--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -26,6 +26,11 @@ from chantal.plugins.rpm.compression import (
     add_compression_extension,
     compress_file,
 )
+from chantal.plugins.rpm.modules import (
+    compress_bytes,
+    decompress_bytes,
+    filter_modules_yaml,
+)
 from chantal.plugins.rpm.updateinfo import (
     UpdateInfoFilter,
     UpdateInfoGenerator,
@@ -165,6 +170,9 @@ class RpmPublisher(PublisherPlugin):
                 packages, repodata_path, published_metadata
             )
             published_metadata = self._filter_and_regenerate_other(
+                packages, repodata_path, published_metadata
+            )
+            published_metadata = self._filter_and_regenerate_modules(
                 packages, repodata_path, published_metadata
             )
 
@@ -570,6 +578,8 @@ class RpmPublisher(PublisherPlugin):
 
             # Compress it
             filtered_updateinfo_path = repodata_path / updateinfo_path.name
+            # Break the hardlink to the pool blob before overwriting in place.
+            filtered_updateinfo_path.unlink(missing_ok=True)
 
             # Determine compression based on extension
             if updateinfo_path.suffix == ".bz2":
@@ -641,6 +651,108 @@ class RpmPublisher(PublisherPlugin):
             Set of pkgid strings (SHA256 checksums)
         """
         return {pkg.sha256 for pkg in packages}
+
+    def _build_module_artifact_nevra_set(self, packages: list[ContentItem]) -> set[str]:
+        """Build the modulemd-style NEVRA set used to filter ``modules.yaml``.
+
+        modulemd ``data.artifacts.rpms`` entries are full NEVRAs with an
+        explicit epoch: ``name-epoch:version-release.arch`` (epoch defaults to
+        ``0`` when absent). This differs from :meth:`_build_package_nvra_set`,
+        which omits the epoch.
+
+        Args:
+            packages: List of ContentItem packages
+
+        Returns:
+            Set of NEVRA strings in modulemd artifact form.
+        """
+        nevras = set()
+
+        for pkg in packages:
+            name = pkg.name
+            version = pkg.version
+            meta = pkg.content_metadata or {}
+            release = meta.get("release", "")
+            arch = meta.get("arch", "")
+            epoch = meta.get("epoch")
+            epoch_str = str(epoch) if epoch not in (None, "") else "0"
+
+            if name and version and release and arch:
+                nevras.add(f"{name}-{epoch_str}:{version}-{release}.{arch}")
+
+        return nevras
+
+    def _filter_and_regenerate_modules(
+        self,
+        packages: list[ContentItem],
+        repodata_path: Path,
+        published_metadata: list[tuple[str, Path]],
+    ) -> list[tuple[str, Path]]:
+        """Filter ``modules.yaml`` (modulemd) to the published package set.
+
+        Prunes each module stream's RPM artifacts to the packages actually
+        published so downstream ``dnf module`` operations never reference a
+        missing RPM. If every stream is pruned away, ``modules.yaml`` is dropped
+        from the published set entirely.
+
+        Args:
+            packages: List of available ContentItem packages
+            repodata_path: Path to repodata directory
+            published_metadata: List of (file_type, file_path) tuples
+
+        Returns:
+            Updated list of (file_type, file_path) tuples.
+        """
+        modules_index = None
+        for i, (file_type, _file_path) in enumerate(published_metadata):
+            if file_type == "modules":
+                modules_index = i
+                break
+
+        if modules_index is None:
+            # No modules.yaml in this repository (the common case).
+            return published_metadata
+
+        modules_path = published_metadata[modules_index][1]
+
+        try:
+            available_nevras = self._build_module_artifact_nevra_set(packages)
+            suffix = modules_path.suffix
+
+            raw = decompress_bytes(modules_path.read_bytes(), suffix)
+            filtered = filter_modules_yaml(raw, available_nevras)
+
+            updated_metadata = published_metadata.copy()
+
+            if filtered is None:
+                # Nothing survived: drop modules.yaml so no dangling
+                # <data type="modules"> block is written.
+                modules_path.unlink(missing_ok=True)
+                updated_metadata.pop(modules_index)
+                print("Filtered modules: all streams pruned; dropping modules.yaml")
+                return updated_metadata
+
+            filtered_modules_path = repodata_path / modules_path.name
+            # The published file is a hardlink to the pool blob; remove it first
+            # so we write a fresh inode instead of truncating the shared pool
+            # file in place.
+            filtered_modules_path.unlink(missing_ok=True)
+            filtered_modules_path.write_bytes(compress_bytes(filtered, suffix))
+            updated_metadata[modules_index] = ("modules", filtered_modules_path)
+            print("Filtered modules: pruned module artifacts to published packages")
+            return updated_metadata
+
+        except Exception as e:
+            # Unlike updateinfo/filelists/other (where extra entries are
+            # harmless), an unfiltered modules.yaml would advertise module
+            # artifacts for packages that were filtered out, breaking downstream
+            # `dnf module` operations. Drop it rather than re-publish dangling
+            # metadata.
+            print(f"Warning: Failed to filter modules, dropping modules.yaml: {e}")
+            modules_path.unlink(missing_ok=True)
+            updated_metadata = published_metadata.copy()
+            updated_metadata.pop(modules_index)
+            return updated_metadata
 
     def _filter_and_regenerate_filelists(
         self,
@@ -735,6 +847,8 @@ class RpmPublisher(PublisherPlugin):
 
             # Compress it
             filtered_filelists_path = repodata_path / filelists_path.name
+            # Break the hardlink to the pool blob before overwriting in place.
+            filtered_filelists_path.unlink(missing_ok=True)
 
             # Determine compression based on extension
             if filelists_path.suffix == ".xz":
@@ -870,6 +984,8 @@ class RpmPublisher(PublisherPlugin):
 
             # Compress it
             filtered_other_path = repodata_path / other_path.name
+            # Break the hardlink to the pool blob before overwriting in place.
+            filtered_other_path.unlink(missing_ok=True)
 
             # Determine compression based on extension
             if other_path.suffix == ".xz":

--- a/tests/e2e/test_rpm_modules_e2e.py
+++ b/tests/e2e/test_rpm_modules_e2e.py
@@ -1,0 +1,171 @@
+"""
+End-to-end test: a filtered-mode RPM sync must prune ``modules.yaml`` so the
+published modulemd document only references packages that were actually
+published (no dangling module artifacts).
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.e2e
+
+
+def _build_rpm_upstream_with_modules(root: Path) -> None:
+    repodata = root / "repodata"
+    repodata.mkdir(parents=True, exist_ok=True)
+
+    rpm = b"dummy rpm payload" * 16
+    rpm_name = "demo-1.0-1.el9.x86_64.rpm"
+    (root / rpm_name).write_bytes(rpm)
+    rpm_sha = hashlib.sha256(rpm).hexdigest()
+
+    primary = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<metadata xmlns="http://linux.duke.edu/metadata/common"'
+        ' xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="1">\n'
+        '<package type="rpm">\n'
+        "  <name>demo</name>\n"
+        "  <arch>x86_64</arch>\n"
+        '  <version epoch="0" ver="1.0" rel="1.el9"/>\n'
+        f'  <checksum type="sha256" pkgid="YES">{rpm_sha}</checksum>\n'
+        "  <summary>demo</summary>\n"
+        f'  <size package="{len(rpm)}"/>\n'
+        f'  <location href="{rpm_name}"/>\n'
+        "  <format><rpm:sourcerpm>demo-1.0-1.el9.src.rpm</rpm:sourcerpm></format>\n"
+        "</package>\n"
+        "</metadata>\n"
+    ).encode()
+    primary_gz = gzip.compress(primary)
+    (repodata / "primary.xml.gz").write_bytes(primary_gz)
+
+    # modules.yaml references the published 'demo' package AND a 'ghost' package
+    # that is not in primary.xml (so it never gets synced/published).
+    modules_yaml = (
+        b"---\n"
+        b"document: modulemd\n"
+        b"version: 2\n"
+        b"data:\n"
+        b"  name: demo\n"
+        b'  stream: "1"\n'
+        b"  version: 1\n"
+        b"  context: abcd1234\n"
+        b"  arch: x86_64\n"
+        b"  summary: demo module\n"
+        b"  artifacts:\n"
+        b"    rpms:\n"
+        b"      - demo-0:1.0-1.el9.x86_64\n"
+        b"      - ghost-0:9.9-9.el9.x86_64\n"
+        b"...\n"
+    )
+    modules_gz = gzip.compress(modules_yaml)
+    (repodata / "modules.yaml.gz").write_bytes(modules_gz)
+
+    # filelists/other/updateinfo blobs exercise the sibling in-place rewrite
+    # paths so the pool-integrity assertion covers all four filters (each is a
+    # hardlink into the content-addressed pool and must not be truncated).
+    filelists = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<filelists xmlns="http://linux.duke.edu/metadata/filelists" packages="1">\n'
+        f'<package pkgid="{rpm_sha}" name="demo" arch="x86_64">\n'
+        '  <version epoch="0" ver="1.0" rel="1.el9"/>\n'
+        "  <file>/usr/bin/demo</file>\n"
+        "</package>\n"
+        "</filelists>\n"
+    ).encode()
+    filelists_gz = gzip.compress(filelists)
+    (repodata / "filelists.xml.gz").write_bytes(filelists_gz)
+
+    other = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<otherdata xmlns="http://linux.duke.edu/metadata/other" packages="1">\n'
+        f'<package pkgid="{rpm_sha}" name="demo" arch="x86_64">\n'
+        '  <version epoch="0" ver="1.0" rel="1.el9"/>\n'
+        "</package>\n"
+        "</otherdata>\n"
+    ).encode()
+    other_gz = gzip.compress(other)
+    (repodata / "other.xml.gz").write_bytes(other_gz)
+
+    updateinfo = (
+        b'<?xml version="1.0" encoding="UTF-8"?>\n'
+        b"<updates>\n"
+        b'  <update type="security">\n'
+        b"    <id>DEMO-2024:0001</id>\n"
+        b'    <pkglist><collection><package name="demo" version="1.0"'
+        b' release="1.el9" arch="x86_64"/></collection></pkglist>\n'
+        b"  </update>\n"
+        b"</updates>\n"
+    )
+    updateinfo_gz = gzip.compress(updateinfo)
+    (repodata / "updateinfo.xml.gz").write_bytes(updateinfo_gz)
+
+    def _block(file_type: str, href: str, comp: bytes, raw: bytes) -> str:
+        return (
+            f'  <data type="{file_type}">\n'
+            f'    <checksum type="sha256">{hashlib.sha256(comp).hexdigest()}</checksum>\n'
+            f'    <open-checksum type="sha256">{hashlib.sha256(raw).hexdigest()}</open-checksum>\n'
+            f'    <location href="{href}"/>\n'
+            f"    <size>{len(comp)}</size>\n"
+            f"    <open-size>{len(raw)}</open-size>\n"
+            "  </data>\n"
+        )
+
+    repomd = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<repomd xmlns="http://linux.duke.edu/metadata/repo">\n'
+        "  <revision>1</revision>\n"
+        + _block("primary", "repodata/primary.xml.gz", primary_gz, primary)
+        + _block("filelists", "repodata/filelists.xml.gz", filelists_gz, filelists)
+        + _block("other", "repodata/other.xml.gz", other_gz, other)
+        + _block("updateinfo", "repodata/updateinfo.xml.gz", updateinfo_gz, updateinfo)
+        + _block("modules", "repodata/modules.yaml.gz", modules_gz, modules_yaml)
+        + "</repomd>\n"
+    )
+    (repodata / "repomd.xml").write_text(repomd, encoding="utf-8")
+
+
+def test_rpm_modules_filtered_prunes_dangling_artifacts(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_rpm_upstream_with_modules(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-rpm-modules",
+            "name": "Demo RPM modules",
+            "type": "rpm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-rpm-modules")
+
+    published = list(target.rglob("*modules.yaml*"))
+    assert published, "modules.yaml was not published"
+
+    raw = gzip.decompress(published[0].read_bytes())
+    docs = list(yaml.safe_load_all(raw.decode("utf-8")))
+    stream = next((d for d in docs if d.get("document") == "modulemd"), None)
+    assert stream is not None, "module stream document missing"
+
+    rpms = set(stream["data"]["artifacts"]["rpms"])
+    assert rpms == {"demo-0:1.0-1.el9.x86_64"}, f"dangling artifacts not pruned: {rpms}"
+
+    # Regression: the published files are hardlinks into the content-addressed
+    # pool. Filtering must not truncate the shared pool blob in place. Every
+    # pool file is named "<sha256>_<filename>", so verify each still hashes to
+    # the sha256 embedded in its name.
+    for pool_file in chantal_env.pool.rglob("*"):
+        if not pool_file.is_file():
+            continue
+        expected = pool_file.name.split("_", 1)[0]
+        actual = hashlib.sha256(pool_file.read_bytes()).hexdigest()
+        assert actual == expected, f"pool blob corrupted: {pool_file}"

--- a/tests/test_rpm_modules.py
+++ b/tests/test_rpm_modules.py
@@ -1,0 +1,163 @@
+"""Tests for filtered-mode modulemd (modules.yaml) handling."""
+
+from __future__ import annotations
+
+import yaml
+
+from chantal.plugins.rpm.modules import (
+    compress_bytes,
+    decompress_bytes,
+    filter_modules_yaml,
+)
+
+# A representative multi-document modules.yaml: one stream with four RPM
+# artifacts, a defaults document, and a translations document.
+_MODULES_YAML = """\
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: "18"
+  version: 8060020221108134933
+  context: a51a2f8e
+  arch: x86_64
+  summary: Javascript runtime
+  description: >-
+    Node.js runtime.
+  license:
+    module:
+      - MIT
+  dependencies:
+    - platform: [el9]
+  profiles:
+    common:
+      rpms:
+        - nodejs
+  artifacts:
+    rpms:
+      - nodejs-1:18.12.1-1.module_el9.x86_64
+      - nodejs-devel-1:18.12.1-1.module_el9.x86_64
+      - npm-1:8.19.2-1.18.12.1.1.module_el9.x86_64
+      - nodejs-docs-1:18.12.1-1.module_el9.noarch
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: nodejs
+  stream: "18"
+  profiles:
+    "18": [common]
+...
+---
+document: modulemd-translations
+version: 1
+data:
+  module: nodejs
+  modified: 201810081407
+...
+"""
+
+
+def _docs(yaml_bytes: bytes) -> list[dict]:
+    return list(yaml.safe_load_all(yaml_bytes.decode("utf-8")))
+
+
+def _stream(docs: list[dict]) -> dict | None:
+    return next((d for d in docs if d.get("document") == "modulemd"), None)
+
+
+class TestFilterModulesYaml:
+    def test_prunes_artifacts_to_available(self):
+        available = {
+            "nodejs-1:18.12.1-1.module_el9.x86_64",
+            "npm-1:8.19.2-1.18.12.1.1.module_el9.x86_64",
+        }
+        out = filter_modules_yaml(_MODULES_YAML.encode("utf-8"), available)
+        assert out is not None
+        stream = _stream(_docs(out))
+        assert stream is not None
+        assert set(stream["data"]["artifacts"]["rpms"]) == available
+
+    def test_preserves_non_artifact_fields(self):
+        available = {"nodejs-1:18.12.1-1.module_el9.x86_64"}
+        out = filter_modules_yaml(_MODULES_YAML.encode("utf-8"), available)
+        stream = _stream(_docs(out))
+        # Profiles, dependencies, license, context, etc. must survive untouched.
+        assert stream["data"]["profiles"] == {"common": {"rpms": ["nodejs"]}}
+        assert stream["data"]["dependencies"] == [{"platform": ["el9"]}]
+        assert stream["data"]["license"] == {"module": ["MIT"]}
+        assert stream["data"]["context"] == "a51a2f8e"
+
+    def test_stream_pruned_to_zero_is_dropped_with_its_defaults(self):
+        # None of the available packages belong to the module.
+        available = {"unrelated-0:1.0-1.el9.x86_64"}
+        out = filter_modules_yaml(_MODULES_YAML.encode("utf-8"), available)
+        # Every document referenced the (now-gone) nodejs module -> nothing left.
+        assert out is None
+
+    def test_defaults_and_translations_kept_when_stream_survives(self):
+        available = {"nodejs-1:18.12.1-1.module_el9.x86_64"}
+        out = filter_modules_yaml(_MODULES_YAML.encode("utf-8"), available)
+        docs = _docs(out)
+        types = [d.get("document") for d in docs]
+        assert "modulemd" in types
+        assert "modulemd-defaults" in types
+        assert "modulemd-translations" in types
+
+    def test_epoch_is_significant(self):
+        # Same NVRA but wrong epoch must NOT match.
+        available = {"nodejs-0:18.12.1-1.module_el9.x86_64"}  # epoch 0, not 1
+        out = filter_modules_yaml(_MODULES_YAML.encode("utf-8"), available)
+        assert out is None
+
+    def test_multiple_modules_independent(self):
+        two = _MODULES_YAML + (
+            "---\n"
+            "document: modulemd\n"
+            "version: 2\n"
+            "data:\n"
+            "  name: ruby\n"
+            "  stream: '3.1'\n"
+            "  artifacts:\n"
+            "    rpms:\n"
+            "      - ruby-0:3.1.2-1.module_el9.x86_64\n"
+            "...\n"
+            "---\n"
+            "document: modulemd-defaults\n"
+            "version: 1\n"
+            "data:\n"
+            "  module: ruby\n"
+            "...\n"
+        )
+        # Keep only ruby; nodejs streams all vanish.
+        available = {"ruby-0:3.1.2-1.module_el9.x86_64"}
+        out = filter_modules_yaml(two.encode("utf-8"), available)
+        docs = _docs(out)
+        stream_names = {d["data"]["name"] for d in docs if d.get("document") == "modulemd"}
+        default_modules = {
+            d["data"]["module"] for d in docs if d.get("document") == "modulemd-defaults"
+        }
+        assert stream_names == {"ruby"}
+        assert default_modules == {"ruby"}
+
+    def test_stream_without_artifacts_is_kept(self):
+        doc = "---\ndocument: modulemd\nversion: 2\ndata:\n  name: empty\n  stream: x\n...\n"
+        out = filter_modules_yaml(doc.encode("utf-8"), set())
+        assert out is not None
+        assert _stream(_docs(out))["data"]["name"] == "empty"
+
+
+class TestCompressionHelpers:
+    def test_roundtrip_gz(self):
+        data = b"document: modulemd\n" * 50
+        assert decompress_bytes(compress_bytes(data, ".gz"), ".gz") == data
+
+    def test_roundtrip_zst(self):
+        data = b"document: modulemd\n" * 50
+        assert decompress_bytes(compress_bytes(data, ".zst"), ".zst") == data
+
+    def test_roundtrip_uncompressed(self):
+        data = b"document: modulemd\n"
+        assert decompress_bytes(compress_bytes(data, ".yaml"), ".yaml") == data


### PR DESCRIPTION
## Summary

Item 3 of #58 (RPM core mirroring). In filtered mode chantal publishes a package subset and regenerates the repodata, but `modules.yaml` was copied verbatim — so the published modulemd documents could reference RPM artifacts for packages that were filtered out, leaving dangling references that break downstream `dnf module` operations.

## Changes

- **New `chantal.plugins.rpm.modules.filter_modules_yaml`**: parses the multi-document modulemd stream and prunes each module stream's `artifacts.rpms` to the published packages. A stream pruned to zero is dropped; module-scoped documents (`modulemd-defaults`/`-translations`/`-obsoletes`) are dropped when their module no longer has a surviving stream. `modules.yaml` is dropped entirely when nothing survives **or filtering fails**, rather than re-publishing dangling metadata.
- **`_filter_and_regenerate_modules`** hooked into the filtered-mode publish path, matching modulemd's epoch-explicit NEVRA form (`name-epoch:version-release.arch`).
- **Pool-corruption fix**: published metadata files are hardlinks into the content-addressed pool, so the in-place rewrites in the `updateinfo`/`filelists`/`other` filters were truncating the shared pool blob. The hardlink is now broken (`unlink`) before rewriting, in all four filters.

## Tests

- `tests/test_rpm_modules.py`: unit tests for the modulemd filtering (artifact pruning, epoch significance, stream/defaults/translations drop logic, non-artifact field fidelity, multi-module independence) and the compression helpers.
- `tests/e2e/test_rpm_modules_e2e.py`: an end-to-end filtered sync asserting dangling module artifacts are pruned, plus a pool-integrity assertion covering all four rewrite paths (verified to fail without the hardlink fix).

Part of #58