### PR TITLE
feat(rpm): publish trusted upstream key for downstream clients

### DIFF
--- a/docs/plugins/rpm-plugin.md
+++ b/docs/plugins/rpm-plugin.md
@@ -317,8 +317,32 @@ repositories without their own). Options:
 | `key_files` / `keys` | Trusted public keys (file paths / inline ASCII-armored) |
 | `trusted_fingerprints` | Optional allow-list of key fingerprints (pinning) |
 | `on_missing_signature` / `on_invalid_signature` | `fail` (default), `warn`, or `skip` |
+| `client_key_name` | Filename of the trusted upstream key written into the published repo root (default `RPM-GPG-KEY-{repo_id}`; `{repo_id}` is substituted; empty disables) |
 
 At least one of `key_files` or `keys` is required when `enabled: true`.
+
+### Distributing the upstream key to clients
+
+The mirrored `.rpm` files keep their **upstream** signatures, so a downstream
+client that enables `gpgcheck=1` needs the upstream vendor's public key. When
+`verify` is enabled, chantal publishes the configured trust anchor(s) into the
+repository root as `RPM-GPG-KEY-<repo-id>` (in **both** mirror and filtered
+mode). Clients reference it via `gpgkey=`:
+
+```ini
+[rocky9-baseos]
+baseurl = http://mirror.example.com/repos/rocky9-baseos/
+gpgcheck = 1
+gpgkey = http://mirror.example.com/repos/rocky9-baseos/RPM-GPG-KEY-rocky9-baseos
+```
+
+Set `client_key_name: ""` to disable publishing (e.g. if you distribute the key
+out-of-band). Multiple trusted keys are concatenated into the one file.
+
+> **Trust note:** the published key travels over the same channel as the repo it
+> secures, so a man-in-the-middle on that channel could swap both. Serve the
+> mirror over HTTPS and/or import the key once out-of-band (e.g. via a
+> `*-release` RPM) for real authenticity rather than mere corruption-resistance.
 
 ## How It Works
 

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -1205,6 +1205,12 @@
           "title": "Trusted Fingerprints",
           "type": "array"
         },
+        "client_key_name": {
+          "default": "RPM-GPG-KEY-{repo_id}",
+          "description": "Filename for the trusted upstream public key written into the published repository root (empty disables; '{repo_id}' is substituted)",
+          "title": "Client Key Name",
+          "type": "string"
+        },
         "gnupg_home": {
           "anyOf": [
             {

--- a/examples/rpm/verified.yaml
+++ b/examples/rpm/verified.yaml
@@ -6,6 +6,15 @@
 # other metadata, a valid signature there authenticates the whole repository.
 #
 # `verify` can be set per-repository (below) or globally as a fallback.
+#
+# The mirrored .rpm files keep their upstream signatures, so chantal also writes
+# the trusted upstream key into the published repository root (default file name
+# `RPM-GPG-KEY-<repo-id>`). Downstream clients reference it to enable gpgcheck=1:
+#
+#   [rocky9-baseos]
+#   baseurl = http://mirror.example.com/repos/rocky9-baseos/
+#   gpgcheck = 1
+#   gpgkey  = http://mirror.example.com/repos/rocky9-baseos/RPM-GPG-KEY-rocky9-baseos
 
 repositories:
   - id: rocky9-baseos
@@ -25,3 +34,7 @@ repositories:
       #   - "350D275D51953AAC1788576C70A7050025DB3973"
       on_missing_signature: fail   # fail | warn | skip
       on_invalid_signature: fail
+      # Filename of the trusted upstream key published into the repo root for
+      # clients ('{repo_id}' is substituted). Set to "" to disable publishing
+      # (e.g. if you distribute the key out-of-band via a *-release RPM).
+      # client_key_name: "RPM-GPG-KEY-{repo_id}"

--- a/src/chantal/cli/publish_commands.py
+++ b/src/chantal/cli/publish_commands.py
@@ -401,6 +401,9 @@ def _publish_single_repository(
         # Fall back to the global GPG signing config if the repo has none.
         if repo_config.gpg is None and global_config.gpg is not None:
             repo_config.gpg = global_config.gpg
+        # Fall back to the global verification config (trusted upstream keys).
+        if repo_config.verify is None and global_config.verify is not None:
+            repo_config.verify = global_config.verify
         rpm_publisher = RpmPublisher(storage=storage)
         # Publish repository
         try:
@@ -555,6 +558,9 @@ def _publish_repository_snapshot(
             # Fall back to the global GPG signing config if the repo has none.
             if repo_config.gpg is None and config.gpg is not None:
                 repo_config.gpg = config.gpg
+            # Fall back to the global verification config (trusted upstream keys).
+            if repo_config.verify is None and config.verify is not None:
+                repo_config.verify = config.verify
             rpm_publisher = RpmPublisher(storage=storage)
             # Publish snapshot
             try:
@@ -577,12 +583,21 @@ def _publish_repository_snapshot(
                 click.echo(f"  Packages directory: {target_path}/Packages")
                 click.echo(f"  Metadata directory: {target_path}/repodata")
                 click.echo()
+                client_key = None
+                if repo_config.verify is not None and repo_config.verify.enabled:
+                    client_key = (repo_config.verify.client_key_name or "").replace(
+                        "{repo_id}", repo_config.id
+                    )
                 click.echo("Configure your package manager:")
                 click.echo(f"  [{repository.repo_id}-snapshot-{snapshot}]")
                 click.echo(f"  name={repository.repo_id} Snapshot {snapshot}")
                 click.echo(f"  baseurl=file://{target_path}")
                 click.echo("  enabled=1")
-                click.echo("  gpgcheck=0")
+                if client_key:
+                    click.echo("  gpgcheck=1")
+                    click.echo(f"  gpgkey=file://{target_path}/{client_key}")
+                else:
+                    click.echo("  gpgcheck=0")
             except Exception as e:
                 click.echo(f"\n✗ Publishing failed: {e}", err=True)
                 raise

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -7,7 +7,7 @@ This module provides Pydantic models for configuration validation and
 YAML-based configuration loading with include support.
 """
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 import yaml
@@ -270,6 +270,19 @@ class SignatureVerificationConfig(BaseModel):
         description="Optional allow-list of full key fingerprints (pinning)",
     )
 
+    # Publish the trusted upstream key into the published repository so that
+    # downstream clients can verify the mirrored packages (gpgcheck=1). The
+    # mirrored .rpm files retain their upstream signatures, so clients need the
+    # upstream key. ``{repo_id}`` is substituted with the repository id; an empty
+    # value disables publishing. Relative subdirectories are supported.
+    client_key_name: str = Field(
+        "RPM-GPG-KEY-{repo_id}",
+        description=(
+            "Filename for the trusted upstream public key written into the "
+            "published repository root (empty disables; '{repo_id}' is substituted)"
+        ),
+    )
+
     # Keyring location (a private temporary one is used if unset)
     gnupg_home: str | None = None
 
@@ -296,6 +309,14 @@ class SignatureVerificationConfig(BaseModel):
             )
         if any(not fpr.strip() for fpr in self.trusted_fingerprints):
             raise ValueError("trusted_fingerprints must not contain empty entries")
+        name = self.client_key_name
+        if name:
+            pure = PurePosixPath(name)
+            if pure.is_absolute() or ".." in pure.parts:
+                raise ValueError(
+                    "client_key_name must be a relative path within the repository "
+                    "(no leading '/' or '..')"
+                )
         return self
 
 

--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -195,6 +195,12 @@ class RpmPublisher(PublisherPlugin):
             if gpg_config is not None and gpg_config.enabled:
                 self._sign_repomd(repomd_path, target_path, gpg_config, config)
 
+        # Publish the trusted upstream key(s) so downstream clients can verify
+        # the mirrored packages (gpgcheck=1). Packages retain their upstream
+        # signatures in both mirror and filtered mode, so this is mode-agnostic.
+        if config is not None:
+            self._publish_upstream_key(target_path, config)
+
         # Publish kickstart/installer files
         kickstart_files = [rf for rf in repository_files if rf.file_category == "kickstart"]
 
@@ -224,6 +230,68 @@ class RpmPublisher(PublisherPlugin):
                     print(f"  ✓ Published {name}")
         except GpgSigningError as exc:
             raise RuntimeError(f"GPG signing failed for repo '{config.id}': {exc}") from exc
+
+    def _publish_upstream_key(self, target_path: Path, config: RepositoryConfig) -> None:
+        """Write the trusted upstream public key(s) into the repository root.
+
+        Downstream clients reference this file via ``gpgkey=`` to verify the
+        mirrored packages, which keep their upstream signatures. The key material
+        is the same trust anchor configured for sync-time verification
+        (``verify.key_files`` + ``verify.keys``); it is written verbatim as a
+        single (possibly multi-key) ASCII-armored file. No-op when verification
+        is not configured, disabled, has no key material, or the filename is
+        empty.
+
+        Args:
+            target_path: Repository root where the key file is written.
+            config: Repository configuration (provides ``verify`` and ``id``).
+        """
+        verify = config.verify
+        if verify is None or not verify.enabled:
+            return
+
+        key_name = (verify.client_key_name or "").replace("{repo_id}", config.id)
+        if not key_name:
+            # Publishing explicitly disabled.
+            return
+
+        # Confine the output to the repository tree (the literal name is also
+        # validated in config, but config.id substitution is guarded here too).
+        key_path = (target_path / key_name).resolve()
+        if not key_path.is_relative_to(target_path.resolve()):
+            raise ValueError(f"client_key_name escapes the repository root: {key_name!r}")
+
+        # Avoid clobbering the metadata-signing public key published by
+        # _sign_repomd (GpgConfig.public_key_name).
+        gpg_config = config.gpg
+        if gpg_config is not None and gpg_config.enabled:
+            signing_key_path = (target_path / gpg_config.public_key_name).resolve()
+            if key_path == signing_key_path:
+                print(
+                    f"  ! Skipping upstream key: client_key_name '{key_name}' collides with "
+                    f"the metadata-signing key '{gpg_config.public_key_name}'"
+                )
+                return
+
+        blocks: list[str] = []
+        for key_file in verify.key_files:
+            path = Path(key_file)
+            if not path.is_file():
+                raise FileNotFoundError(f"Trusted key file not found: {key_file}")
+            text = path.read_text(encoding="utf-8").strip()
+            if text:
+                blocks.append(text)
+        for inline in verify.keys:
+            text = inline.strip()
+            if text:
+                blocks.append(text)
+
+        if not blocks:
+            return
+
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        key_path.write_text("\n".join(blocks) + "\n", encoding="utf-8")
+        print(f"  ✓ Published upstream trusted key {key_name}")
 
     def _detect_upstream_compression(
         self, repository_files: list[RepositoryFile]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -91,7 +91,7 @@ def chantal_env(tmp_path: Path):
                 raise AssertionError(f"command failed ({' '.join(args)}): rc={result.returncode}")
             return result
 
-        def write_config(self, repo: dict) -> None:
+        def write_config(self, repo: dict, extra: dict | None = None) -> None:
             config = {
                 "database": {"url": f"sqlite:///{self.db_path}"},
                 "storage": {
@@ -101,6 +101,8 @@ def chantal_env(tmp_path: Path):
                 },
                 "repositories": [repo],
             }
+            if extra:
+                config.update(extra)
             self.config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
             self.run("db", "init")
 

--- a/tests/e2e/test_rpm_client_key_e2e.py
+++ b/tests/e2e/test_rpm_client_key_e2e.py
@@ -1,0 +1,133 @@
+"""
+End-to-end test: publishing an RPM repo with a configured trusted upstream key
+writes that key into the published repository root so downstream clients can
+``gpgcheck=1``. Exercises the full sync->publish CLI path.
+
+``gpgcheck``/``repo_gpgcheck`` are disabled so no signature verification (and
+hence no gpg toolchain) is needed during sync; ``verify`` stays enabled so the
+publisher emits the client key.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_UPSTREAM_KEY = (
+    "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"
+    "mDMEZ-fake-upstream-vendor-key-material\n"
+    "-----END PGP PUBLIC KEY BLOCK-----"
+)
+
+
+def _build_rpm_upstream(root: Path) -> None:
+    repodata = root / "repodata"
+    repodata.mkdir(parents=True, exist_ok=True)
+
+    rpm = b"dummy rpm payload" * 16
+    rpm_name = "demo-1.0-1.el9.x86_64.rpm"
+    (root / rpm_name).write_bytes(rpm)
+    rpm_sha = hashlib.sha256(rpm).hexdigest()
+
+    primary = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<metadata xmlns="http://linux.duke.edu/metadata/common"'
+        ' xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="1">\n'
+        '<package type="rpm">\n'
+        "  <name>demo</name>\n"
+        "  <arch>x86_64</arch>\n"
+        '  <version epoch="0" ver="1.0" rel="1.el9"/>\n'
+        f'  <checksum type="sha256" pkgid="YES">{rpm_sha}</checksum>\n'
+        "  <summary>demo</summary>\n"
+        f'  <size package="{len(rpm)}"/>\n'
+        f'  <location href="{rpm_name}"/>\n'
+        "  <format><rpm:sourcerpm>demo-1.0-1.el9.src.rpm</rpm:sourcerpm></format>\n"
+        "</package>\n"
+        "</metadata>\n"
+    ).encode()
+    primary_gz = gzip.compress(primary)
+    (repodata / "primary.xml.gz").write_bytes(primary_gz)
+
+    repomd = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<repomd xmlns="http://linux.duke.edu/metadata/repo">\n'
+        "  <revision>1</revision>\n"
+        '  <data type="primary">\n'
+        f'    <checksum type="sha256">{hashlib.sha256(primary_gz).hexdigest()}</checksum>\n'
+        f'    <open-checksum type="sha256">{hashlib.sha256(primary).hexdigest()}</open-checksum>\n'
+        '    <location href="repodata/primary.xml.gz"/>\n'
+        f"    <size>{len(primary_gz)}</size>\n"
+        f"    <open-size>{len(primary)}</open-size>\n"
+        "  </data>\n"
+        "</repomd>\n"
+    )
+    (repodata / "repomd.xml").write_text(repomd, encoding="utf-8")
+
+
+def test_rpm_publishes_trusted_upstream_key(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_rpm_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-rpm-clientkey",
+            "name": "Demo RPM client key",
+            "type": "rpm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "verify": {
+                "enabled": True,
+                # No actual verification (keeps the gpg toolchain out of the
+                # test); we only want the publisher to emit the trusted key.
+                "gpgcheck": False,
+                "repo_gpgcheck": False,
+                "keys": [_UPSTREAM_KEY],
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-rpm-clientkey")
+
+    key_file = target / "RPM-GPG-KEY-demo-rpm-clientkey"
+    assert key_file.exists(), "trusted upstream key was not published"
+    assert _UPSTREAM_KEY in key_file.read_text()
+
+
+def test_rpm_publishes_key_from_global_verify_fallback(tmp_path, serve, chantal_env):
+    # verify is configured only globally; the repo inherits it via the publish
+    # global-fallback. Proves the CLI wiring, not just the publisher.
+    upstream = tmp_path / "upstream"
+    _build_rpm_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-rpm-globalkey",
+            "name": "Demo RPM global key",
+            "type": "rpm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+        },
+        extra={
+            "verify": {
+                "enabled": True,
+                "gpgcheck": False,
+                "repo_gpgcheck": False,
+                "keys": [_UPSTREAM_KEY],
+            }
+        },
+    )
+
+    target = chantal_env.sync_and_publish("demo-rpm-globalkey")
+
+    key_file = target / "RPM-GPG-KEY-demo-rpm-globalkey"
+    assert key_file.exists(), "global verify fallback did not publish the key"
+    assert _UPSTREAM_KEY in key_file.read_text()

--- a/tests/test_rpm_client_key.py
+++ b/tests/test_rpm_client_key.py
@@ -1,0 +1,207 @@
+"""
+Tests for publishing the trusted upstream GPG key into an RPM repository.
+
+The mirrored .rpm files keep their upstream signatures, so downstream clients
+need the upstream public key to run ``gpgcheck=1``. The publisher writes the
+configured trust anchor(s) (``verify.key_files`` + ``verify.keys``) into the
+repository root. This is pure file handling -- no gpg binary required.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from chantal.core.config import (
+    RepositoryConfig,
+    SignatureVerificationConfig,
+    StorageConfig,
+)
+from chantal.core.storage import StorageManager
+from chantal.db.models import Base, ContentItem, Repository, RepositoryMode
+from chantal.plugins.rpm.models import RpmMetadata
+from chantal.plugins.rpm.publisher import RpmPublisher
+
+_KEY_A = (
+    "-----BEGIN PGP PUBLIC KEY BLOCK-----\nAAAA-upstream-key-A\n-----END PGP PUBLIC KEY BLOCK-----"
+)
+_KEY_B = (
+    "-----BEGIN PGP PUBLIC KEY BLOCK-----\nBBBB-upstream-key-B\n-----END PGP PUBLIC KEY BLOCK-----"
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def temp_storage(tmp_path):
+    pool_path = tmp_path / "pool"
+    pool_path.mkdir()
+    config = StorageConfig(
+        base_path=str(tmp_path),
+        pool_path=str(pool_path),
+        published_path=str(tmp_path / "published"),
+    )
+    return StorageManager(config)
+
+
+def _make_repo(db_session, temp_storage, tmp_path, mode):
+    repo = Repository(
+        repo_id="test-rpm-repo",
+        name="Test RPM Repo",
+        type="rpm",
+        feed="https://example.com/repo",
+        enabled=True,
+        mode=mode,
+    )
+    db_session.add(repo)
+    db_session.commit()
+
+    rpm_file = tmp_path / "test-package-1.0-1.el9.x86_64.rpm"
+    rpm_file.write_bytes(b"fake rpm contents" * 64)
+    sha256, pool_path, size_bytes = temp_storage.add_package(
+        rpm_file, "test-package-1.0-1.el9.x86_64.rpm"
+    )
+    metadata = RpmMetadata(release="1.el9", arch="x86_64", epoch="0", summary="Test package")
+    item = ContentItem(
+        content_type="rpm",
+        name="test-package",
+        version="1.0",
+        sha256=sha256,
+        filename="test-package-1.0-1.el9.x86_64.rpm",
+        size_bytes=size_bytes,
+        pool_path=pool_path,
+        content_metadata=metadata.model_dump(exclude_none=False),
+    )
+    item.repositories.append(repo)
+    db_session.add(item)
+    db_session.commit()
+    return repo
+
+
+def _config(mode, verify):
+    return RepositoryConfig(
+        id="test-rpm-repo",
+        name="Test RPM Repo",
+        type="rpm",
+        feed="https://example.com/repo",
+        mode=mode,
+        verify=verify,
+    )
+
+
+def _publish(db_session, temp_storage, tmp_path, mode, verify):
+    repo = _make_repo(db_session, temp_storage, tmp_path, mode)
+    config = _config(mode, verify)
+    publisher = RpmPublisher(storage=temp_storage)
+    target = tmp_path / "published" / "test-rpm-repo"
+    publisher.publish_repository(
+        session=db_session, repository=repo, config=config, target_path=target
+    )
+    return target
+
+
+class TestPublishUpstreamKey:
+    def test_published_with_inline_key_filtered(self, db_session, temp_storage, tmp_path):
+        verify = SignatureVerificationConfig(enabled=True, keys=[_KEY_A])
+        target = _publish(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED, verify)
+
+        key_file = target / "RPM-GPG-KEY-test-rpm-repo"
+        assert key_file.exists()
+        assert _KEY_A in key_file.read_text()
+
+    def test_published_in_mirror_mode(self, db_session, temp_storage, tmp_path):
+        # Packages keep upstream signatures in mirror mode too -> key is needed.
+        verify = SignatureVerificationConfig(enabled=True, keys=[_KEY_A])
+        target = _publish(db_session, temp_storage, tmp_path, RepositoryMode.MIRROR, verify)
+        assert (target / "RPM-GPG-KEY-test-rpm-repo").exists()
+
+    def test_no_verify_config_writes_nothing(self, db_session, temp_storage, tmp_path):
+        target = _publish(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED, None)
+        assert not list(target.glob("RPM-GPG-KEY-*"))
+
+    def test_disabled_verify_writes_nothing(self, db_session, temp_storage, tmp_path):
+        verify = SignatureVerificationConfig(enabled=False, keys=[_KEY_A])
+        target = _publish(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED, verify)
+        assert not list(target.glob("RPM-GPG-KEY-*"))
+
+    def test_empty_name_disables_publishing(self, db_session, temp_storage, tmp_path):
+        verify = SignatureVerificationConfig(enabled=True, keys=[_KEY_A], client_key_name="")
+        target = _publish(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED, verify)
+        assert not list(target.rglob("RPM-GPG-KEY-*"))
+
+    def test_multiple_keys_concatenated(self, db_session, temp_storage, tmp_path):
+        verify = SignatureVerificationConfig(enabled=True, keys=[_KEY_A, _KEY_B])
+        target = _publish(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED, verify)
+        content = (target / "RPM-GPG-KEY-test-rpm-repo").read_text()
+        assert _KEY_A in content
+        assert _KEY_B in content
+
+    def test_custom_name_with_subdirectory(self, db_session, temp_storage, tmp_path):
+        verify = SignatureVerificationConfig(
+            enabled=True, keys=[_KEY_A], client_key_name="keys/RPM-GPG-KEY-custom"
+        )
+        target = _publish(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED, verify)
+        key_file = target / "keys" / "RPM-GPG-KEY-custom"
+        assert key_file.exists()
+        assert _KEY_A in key_file.read_text()
+
+    def test_key_files_are_read_from_disk(self, db_session, temp_storage, tmp_path):
+        key_path = tmp_path / "upstream.asc"
+        key_path.write_text(_KEY_B + "\n")
+        verify = SignatureVerificationConfig(enabled=True, key_files=[str(key_path)])
+        target = _publish(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED, verify)
+        assert _KEY_B in (target / "RPM-GPG-KEY-test-rpm-repo").read_text()
+
+    def test_missing_key_file_raises(self, db_session, temp_storage, tmp_path):
+        verify = SignatureVerificationConfig(
+            enabled=True, key_files=[str(tmp_path / "does-not-exist.asc")]
+        )
+        with pytest.raises(FileNotFoundError, match="Trusted key file not found"):
+            _publish(db_session, temp_storage, tmp_path, RepositoryMode.FILTERED, verify)
+
+    def test_collision_with_signing_key_is_skipped(self, db_session, temp_storage, tmp_path):
+        # client_key_name resolving to the metadata-signing key must not clobber it.
+        from chantal.core.config import GpgConfig
+
+        config = RepositoryConfig(
+            id="test-rpm-repo",
+            name="Test RPM Repo",
+            type="rpm",
+            feed="https://example.com/repo",
+            mode=RepositoryMode.FILTERED,
+            gpg=GpgConfig(enabled=True, key_id="DEADBEEF"),  # publishes key.gpg
+            verify=SignatureVerificationConfig(
+                enabled=True, keys=[_KEY_A], client_key_name="key.gpg"
+            ),
+        )
+        target = tmp_path / "published" / "test-rpm-repo"
+        target.mkdir(parents=True)
+        publisher = RpmPublisher(storage=temp_storage)
+        # Call the helper directly to avoid invoking gpg for repomd signing.
+        publisher._publish_upstream_key(target, config)
+        # The upstream key was NOT written over the signing-key filename.
+        assert not (target / "key.gpg").exists()
+
+
+class TestClientKeyNameValidation:
+    def test_rejects_absolute_path(self):
+        with pytest.raises(ValueError, match="relative path"):
+            SignatureVerificationConfig(enabled=True, keys=[_KEY_A], client_key_name="/etc/passwd")
+
+    def test_rejects_parent_traversal(self):
+        with pytest.raises(ValueError, match="relative path"):
+            SignatureVerificationConfig(enabled=True, keys=[_KEY_A], client_key_name="../../etc/x")
+
+    def test_accepts_relative_subdir(self):
+        cfg = SignatureVerificationConfig(
+            enabled=True, keys=[_KEY_A], client_key_name="keys/RPM-GPG-KEY-foo"
+        )
+        assert cfg.client_key_name == "keys/RPM-GPG-KEY-foo"


### PR DESCRIPTION
## Summary

Closes the last open Core/Basic item of #58 ("Import/distribute the public key for downstream clients").

The mirrored `.rpm` files keep their **upstream** signatures, so a downstream client that enables `gpgcheck=1` needs the upstream vendor's public key. When a `verify` section is configured, the publisher now writes the configured trust anchor(s) into the repository root so clients can reference them via `gpgkey=`.

## Changes

- **Config**: new `SignatureVerificationConfig.client_key_name` (default `RPM-GPG-KEY-{repo_id}`; `{repo_id}` substituted; empty disables). A validator rejects absolute paths and `..` so the key stays inside the repository.
- **Publisher**: `_publish_upstream_key` writes the key in **both** mirror and filtered mode (packages retain upstream signatures in both). The runtime path is confined to the repo root and refuses to clobber the metadata-signing key (`GpgConfig.public_key_name`, default `key.gpg`). Multiple trusted keys are concatenated into one file; a missing `key_file` raises a clear error.
- **CLI**: apply the global `verify` fallback in the publish path (repo + snapshot), and emit a `gpgcheck=1`/`gpgkey=` hint after snapshot publish when a key was written.
- **Docs/schema**: documented the feature + a TOFU/MITM trust caveat; regenerated `docs/schema/chantal-config.schema.json`.

## Behavior note

Publishing is **on by default** whenever `verify.enabled` is true (benign extra file). Set `client_key_name: ""` to opt out (e.g. when distributing the key out-of-band).

## Tests

- Unit (`tests/test_rpm_client_key.py`, no gpg needed): both modes, all no-op cases, multi-key concatenation, custom subdir, `key_files` from disk, missing-file error, signing-key collision skip, and `client_key_name` path-traversal validation.
- E2E (`tests/e2e/test_rpm_client_key_e2e.py`): full sync→publish via the CLI, both per-repo `verify` and the **global fallback**.

Part of #58