### PR TITLE
feat(apt): verify upstream Release signature during sync

### DIFF
--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -463,6 +463,58 @@ See [Filters Configuration](../configuration/filters.md) for complete documentat
 | Client Trust | Automatic (GPG) | GPG (signed-by) or manual (trusted=yes) |
 | Use Case | Exact mirrors | Curated subsets |
 
+## Upstream Signature Verification
+
+**Status:** ✅ Available
+
+Chantal always verifies **integrity** (SHA256 of `Packages`/`.deb` against the
+`Release` checksums). A `verify` section additionally checks **authenticity** —
+that the upstream `Release` was signed by a key you trust — analogous to apt's
+own `Release` signature check.
+
+When enabled, the upstream `InRelease` (inline-clearsigned) is verified against
+the configured trusted key(s), and the **verified payload** is what gets parsed
+(so the checksum chain that gates every subsequent download is anchored to the
+signature). If only the split `Release` + `Release.gpg` form is published, the
+detached signature is verified instead. Since `Release` carries the checksums of
+`Packages`, a valid signature there transitively authenticates the whole repo.
+
+```yaml
+repositories:
+  - id: ubuntu-jammy
+    type: apt
+    feed: http://archive.ubuntu.com/ubuntu
+    apt:
+      distribution: jammy
+      components: [main]
+      architectures: [amd64]
+    verify:
+      enabled: true
+      key_files:
+        - /usr/share/keyrings/ubuntu-archive-keyring.gpg
+      # keys: ["-----BEGIN PGP PUBLIC KEY BLOCK----- ..."]   # inline alternative
+      # trusted_fingerprints: ["<fpr>"]                        # optional pinning
+      on_missing_signature: fail     # fail | warn | skip
+      on_invalid_signature: fail
+```
+
+The `verify` section can also be set globally (a fallback for all repositories
+without their own). Notes specific to APT:
+
+- Verification is gated on `enabled` (and `repo_gpgcheck`, default `true`). The
+  RPM-only `gpgcheck` field has no APT meaning and is ignored — APT package
+  authenticity is transitive via the signed `Release` → `Packages` → SHA256
+  chain, so there is no per-`.deb` signature step. To turn verification off,
+  set `enabled: false` (the simple off-switch); don't toggle `repo_gpgcheck`
+  on its own, as the shared validator couples it to the RPM `gpgcheck` field.
+- A failed check under `on_invalid_signature: fail` (or a missing signature
+  under `on_missing_signature: fail`) aborts the sync before any metadata is
+  trusted or any package is downloaded.
+
+> **Note:** this verifies the *upstream* signature on sync. Re-signing the
+> regenerated metadata for *your* clients (filtered mode) is the separate `gpg`
+> section below.
+
 ## GPG Signing (Filtered Mode)
 
 **Status:** ✅ Available

--- a/examples/apt/verified.yaml
+++ b/examples/apt/verified.yaml
@@ -1,0 +1,35 @@
+# APT repository with upstream signature verification
+#
+# Chantal always checks integrity (SHA256 of Packages/.deb against Release).
+# The `verify` section adds authenticity: the upstream InRelease/Release
+# signature is verified against a trusted key before any checksum is trusted
+# (like apt's own Release signature check). Because Release carries the
+# checksums of Packages, a valid signature authenticates the whole repository.
+#
+# `verify` can be set per-repository (below) or globally as a fallback.
+
+repositories:
+  - id: ubuntu-jammy
+    name: "Ubuntu 22.04 - main (verified)"
+    type: apt
+    feed: "http://archive.ubuntu.com/ubuntu"
+    enabled: true
+    mode: mirror
+
+    apt:
+      distribution: "jammy"
+      components:
+        - main
+      architectures:
+        - amd64
+
+    verify:
+      enabled: true
+      key_files:
+        - /usr/share/keyrings/ubuntu-archive-keyring.gpg
+      # keys: ["-----BEGIN PGP PUBLIC KEY BLOCK----- ..."]   # inline alternative
+      # Optional key pinning by fingerprint:
+      # trusted_fingerprints:
+      #   - "790BC7277767219C42C86F933B4FE6ACC0B21F32"
+      on_missing_signature: fail   # fail | warn | skip
+      on_invalid_signature: fail

--- a/src/chantal/core/gpg_verify.py
+++ b/src/chantal/core/gpg_verify.py
@@ -133,6 +133,33 @@ class GpgVerifier:
             return self._fingerprint_pinned(verified.fingerprint)
         return True
 
+    def verify_clearsigned(self, blob: bytes) -> bytes | None:
+        """Verify an inline-clearsigned document (e.g. APT ``InRelease``).
+
+        Unlike a detached signature, a clearsigned document embeds both the
+        payload and the signature. Verifying and then re-extracting the payload
+        separately would be a TOCTOU gap, so this returns the exact bytes that
+        were covered by the verified signature.
+
+        Args:
+            blob: The full ASCII-armored clearsigned document.
+
+        Returns:
+            The verified signed payload bytes if the signature is valid AND made
+            by a trusted (and, when pinned, allow-listed) key; otherwise None.
+        """
+        self._ensure_keys()
+
+        # For a sign-only (clearsigned) message, python-gnupg's ``decrypt``
+        # performs signature verification and returns the canonical signed
+        # payload in ``.data``.
+        result = self.gpg.decrypt(blob)
+        if not getattr(result, "valid", False):
+            return None
+        if self.config.trusted_fingerprints and not self._fingerprint_pinned(result.fingerprint):
+            return None
+        return bytes(result.data)
+
     def _fingerprint_pinned(self, fingerprint: str | None) -> bool:
         """Check the signing key fingerprint against the pin allow-list.
 

--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -302,6 +302,10 @@ class AptSyncPlugin:
 
         release_content = None
         inrelease_downloaded = False
+        # Raw bytes kept for signature verification (the exact signed material).
+        inrelease_bytes: bytes | None = None
+        release_bytes: bytes | None = None
+        release_gpg_bytes: bytes | None = None
 
         # Try InRelease (preferred)
         try:
@@ -309,6 +313,7 @@ class AptSyncPlugin:
             response = self.session.get(inrelease_url, timeout=60)
             response.raise_for_status()
             release_content = response.text
+            inrelease_bytes = response.content
             inrelease_downloaded = True
 
             # Store InRelease as RepositoryFile
@@ -334,6 +339,7 @@ class AptSyncPlugin:
                 response = self.session.get(release_url, timeout=60)
                 response.raise_for_status()
                 release_content = response.text
+                release_bytes = response.content
 
                 # Store Release file
                 self._store_file_as_repository_file(
@@ -351,6 +357,7 @@ class AptSyncPlugin:
                 try:
                     gpg_response = self.session.get(release_gpg_url, timeout=60)
                     gpg_response.raise_for_status()
+                    release_gpg_bytes = gpg_response.content
 
                     self._store_file_as_repository_file(
                         session=session,
@@ -372,24 +379,37 @@ class AptSyncPlugin:
         if not release_content:
             raise Exception("Failed to download Release metadata")
 
+        # Verify the upstream Release signature (authenticity) before trusting
+        # any of its checksums. When verification is enabled this returns the
+        # exact signed payload to parse (closing a TOCTOU/canonicalization gap);
+        # when disabled it returns None and the legacy strip path is used.
+        verified_payload = self._verify_release_signature(
+            inrelease_bytes=inrelease_bytes,
+            release_bytes=release_bytes,
+            release_gpg_bytes=release_gpg_bytes,
+        )
+
         # Parse Release file
         try:
-            # Remove GPG signature if present (from InRelease)
-            release_text = release_content
-            if "-----BEGIN PGP SIGNED MESSAGE-----" in release_content:
-                # Extract content between headers and signature
-                lines = release_content.split("\n")
-                content_lines = []
-                in_content = False
-                for line in lines:
-                    if line.startswith("Hash:"):
-                        in_content = True
-                        continue
-                    if in_content and line.startswith("-----BEGIN PGP SIGNATURE-----"):
-                        break
-                    if in_content:
-                        content_lines.append(line)
-                release_text = "\n".join(content_lines)
+            if verified_payload is not None:
+                release_text = verified_payload.decode("utf-8")
+            else:
+                # Remove GPG signature if present (from InRelease)
+                release_text = release_content
+                if "-----BEGIN PGP SIGNED MESSAGE-----" in release_content:
+                    # Extract content between headers and signature
+                    lines = release_content.split("\n")
+                    content_lines = []
+                    in_content = False
+                    for line in lines:
+                        if line.startswith("Hash:"):
+                            in_content = True
+                            continue
+                        if in_content and line.startswith("-----BEGIN PGP SIGNATURE-----"):
+                            break
+                        if in_content:
+                            content_lines.append(line)
+                    release_text = "\n".join(content_lines)
 
             release_metadata = parse_release_file(release_text)
             self.output.verbose(
@@ -409,6 +429,75 @@ class AptSyncPlugin:
 
         except Exception as e:
             raise Exception(f"Failed to parse Release file: {e}") from e
+
+    def _verify_release_signature(
+        self,
+        *,
+        inrelease_bytes: bytes | None,
+        release_bytes: bytes | None,
+        release_gpg_bytes: bytes | None,
+    ) -> bytes | None:
+        """Verify the upstream ``Release`` signature (authenticity).
+
+        No-op (returns ``None``) unless verification is enabled for this
+        repository. When enabled it verifies the clearsigned ``InRelease`` (if
+        present) or the detached ``Release.gpg`` over ``Release`` against the
+        configured trusted keys, applies the behavior policy on a missing or
+        invalid signature, and returns the *verified* payload bytes to be
+        parsed.
+
+        Returns:
+            The verified Release payload bytes, or ``None`` when verification is
+            disabled or skipped (policy ``skip``/``warn``).
+        """
+        verify = self.config.verify
+        if not verify or not verify.enabled or not verify.repo_gpgcheck:
+            return None
+
+        from chantal.core.gpg_verify import GpgVerifier
+
+        with GpgVerifier(verify) as verifier:
+            if inrelease_bytes is not None:
+                payload = verifier.verify_clearsigned(inrelease_bytes)
+                if payload is not None:
+                    self.output.info("✓ Verified upstream InRelease signature")
+                    return payload
+                self._handle_verify_policy(
+                    verify.on_invalid_signature,
+                    "upstream InRelease signature is invalid or not from a trusted key",
+                )
+                return None
+
+            if release_bytes is not None:
+                if release_gpg_bytes is None:
+                    self._handle_verify_policy(
+                        verify.on_missing_signature,
+                        "upstream Release.gpg not available",
+                    )
+                    return None
+                if verifier.verify_detached(release_bytes, release_gpg_bytes):
+                    self.output.info("✓ Verified upstream Release signature")
+                    return release_bytes
+                self._handle_verify_policy(
+                    verify.on_invalid_signature,
+                    "upstream Release signature is invalid or not from a trusted key",
+                )
+                return None
+
+        self._handle_verify_policy(
+            verify.on_missing_signature, "no upstream Release signature available"
+        )
+        return None
+
+    def _handle_verify_policy(self, policy: str, message: str) -> None:
+        """Apply a signature-verification behavior policy (fail/warn/skip)."""
+        if policy == "fail":
+            from chantal.core.gpg_verify import SignatureVerificationError
+
+            raise SignatureVerificationError(f"Signature verification failed: {message}")
+        if policy == "warn":
+            self.output.warning(f"Signature verification: {message}")
+        # "skip": silently continue
 
     def _build_metadata_file_list(self, release_metadata: dict) -> list[MetadataFileInfo]:
         """Build list of metadata files to download based on configuration.

--- a/tests/e2e/test_apt_verify_e2e.py
+++ b/tests/e2e/test_apt_verify_e2e.py
@@ -1,0 +1,211 @@
+"""
+End-to-end test: APT upstream Release signature verification during sync.
+
+Builds a signed apt repo (InRelease clearsigned + Release + Release.gpg), then
+syncs with ``verify.enabled`` and asserts: a valid signature passes, a tampered
+Release fails (on_invalid_signature=fail), and an untrusted key fails.
+
+Needs the gpg toolchain; skipped where unavailable.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_GPG = shutil.which("gpg") is not None or shutil.which("gpg2") is not None
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _short_home() -> str:
+    base = "/tmp" if Path("/tmp").is_dir() else None
+    return tempfile.mkdtemp(prefix="cg-", dir=base)
+
+
+def _build_signed_apt_upstream(
+    root: Path,
+    *,
+    tamper: bool = False,
+    with_inrelease: bool = True,
+    with_release_gpg: bool = True,
+) -> str:
+    """Build a GPG-signed apt repo; return the upstream public key (armored)."""
+    from chantal.core.config import GpgConfig
+    from chantal.core.gpg import GpgSigner
+
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    deb_path = root / deb_rel
+    deb_path.parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    deb_path.write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        "Maintainer: Test <test@example.com>\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo package\n"
+        "\n"
+    ).encode()
+
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    rel_pkgs = f"{COMP}/binary-{ARCH}/Packages"
+    sha = hashlib.sha256
+    release = (
+        "Origin: Test\n"
+        "Label: Test\n"
+        f"Suite: {DIST}\n"
+        f"Codename: {DIST}\n"
+        f"Components: {COMP}\n"
+        f"Architectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\n"
+        "SHA256:\n"
+        f" {sha(packages).hexdigest()} {len(packages)} {rel_pkgs}\n"
+        f" {sha(packages_gz).hexdigest()} {len(packages_gz)} {rel_pkgs}.gz\n"
+    ).encode()
+
+    home = _short_home()
+    signer = GpgSigner(GpgConfig(generate_key=True, gnupg_home=home, key_email="vendor@upstream"))
+    try:
+        pub = signer.export_public_key().decode("utf-8")
+        inrelease = signer.clearsign(release)
+        release_gpg = signer.detach_sign(release)
+    finally:
+        signer.close()
+
+    dist_dir = root / "dists" / DIST
+    if tamper:
+        # Corrupt the signed payload: the signature no longer matches.
+        inrelease = inrelease.replace(b"Origin: Test", b"Origin: Evil")
+    if with_inrelease:
+        (dist_dir / "InRelease").write_bytes(inrelease)
+    (dist_dir / "Release").write_bytes(release)
+    if with_release_gpg:
+        (dist_dir / "Release.gpg").write_bytes(release_gpg)
+
+    shutil.rmtree(home, ignore_errors=True)
+    return pub
+
+
+def _config(repo_id: str, base_url: str, pub: str, **verify_extra) -> dict:
+    return {
+        "id": repo_id,
+        "name": repo_id,
+        "type": "apt",
+        "feed": base_url,
+        "enabled": True,
+        "mode": "filtered",
+        "apt": {"distribution": DIST, "components": [COMP], "architectures": [ARCH]},
+        "verify": {"enabled": True, "keys": [pub], **verify_extra},
+    }
+
+
+@pytest.mark.skipif(not _HAVE_GPG, reason="gpg toolchain not available")
+def test_apt_verify_valid_signature_syncs(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    pub = _build_signed_apt_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-verified", base_url, pub))
+    target = chantal_env.sync_and_publish("demo-apt-verified")
+
+    assert (target / "dists" / DIST / "Release").exists()
+    assert list(target.rglob("demo_1.0_amd64.deb")), "published .deb not found"
+
+
+@pytest.mark.skipif(not _HAVE_GPG, reason="gpg toolchain not available")
+def test_apt_verify_tampered_release_fails(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    pub = _build_signed_apt_upstream(upstream, tamper=True)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-tampered", base_url, pub))
+    result = chantal_env.run("repo", "sync", "--repo-id", "demo-apt-tampered", "-v", check=False)
+
+    output = (result.stdout + result.stderr).lower()
+    assert "signature verification failed" in output, "verification failure not reported"
+    # The sync must abort before trusting metadata / downloading packages.
+    assert not list(chantal_env.pool.rglob("*.deb")), "no .deb should be synced on bad signature"
+
+
+@pytest.mark.skipif(not _HAVE_GPG, reason="gpg toolchain not available")
+def test_apt_verify_untrusted_key_fails(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_signed_apt_upstream(upstream)  # signed by the real upstream key
+    base_url = serve(upstream)
+
+    # Configure a DIFFERENT trusted key than the one that signed.
+    other_home = _short_home()
+    from chantal.core.config import GpgConfig
+    from chantal.core.gpg import GpgSigner
+
+    other = GpgSigner(GpgConfig(generate_key=True, gnupg_home=other_home, key_email="x@y"))
+    try:
+        other_pub = other.export_public_key().decode("utf-8")
+    finally:
+        other.close()
+        shutil.rmtree(other_home, ignore_errors=True)
+
+    chantal_env.write_config(_config("demo-apt-untrusted", base_url, other_pub))
+    result = chantal_env.run("repo", "sync", "--repo-id", "demo-apt-untrusted", "-v", check=False)
+
+    output = (result.stdout + result.stderr).lower()
+    assert "signature verification failed" in output, "verification failure not reported"
+    assert not list(chantal_env.pool.rglob("*.deb")), "no .deb should be synced on untrusted key"
+
+
+@pytest.mark.skipif(not _HAVE_GPG, reason="gpg toolchain not available")
+def test_apt_verify_detached_release_syncs(tmp_path, serve, chantal_env):
+    # No InRelease: the detached Release + Release.gpg path must verify.
+    upstream = tmp_path / "upstream"
+    pub = _build_signed_apt_upstream(upstream, with_inrelease=False)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-detached", base_url, pub))
+    target = chantal_env.sync_and_publish("demo-apt-detached")
+    assert list(target.rglob("demo_1.0_amd64.deb")), "detached-verified .deb not published"
+
+
+@pytest.mark.skipif(not _HAVE_GPG, reason="gpg toolchain not available")
+def test_apt_verify_missing_signature_fails(tmp_path, serve, chantal_env):
+    # No InRelease and no Release.gpg: on_missing_signature=fail must abort.
+    upstream = tmp_path / "upstream"
+    pub = _build_signed_apt_upstream(upstream, with_inrelease=False, with_release_gpg=False)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-nosig", base_url, pub))
+    result = chantal_env.run("repo", "sync", "--repo-id", "demo-apt-nosig", "-v", check=False)
+
+    output = (result.stdout + result.stderr).lower()
+    assert "signature verification failed" in output, "missing-signature failure not reported"
+    assert not list(chantal_env.pool.rglob("*.deb")), "no .deb should be synced without a signature"
+
+
+@pytest.mark.skipif(not _HAVE_GPG, reason="gpg toolchain not available")
+def test_apt_verify_warn_policy_continues(tmp_path, serve, chantal_env):
+    # on_invalid_signature=warn: a bad signature warns but the sync proceeds.
+    upstream = tmp_path / "upstream"
+    pub = _build_signed_apt_upstream(upstream, tamper=True)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-warn", base_url, pub, on_invalid_signature="warn"))
+    target = chantal_env.sync_and_publish("demo-apt-warn")
+    assert list(target.rglob("demo_1.0_amd64.deb")), "warn policy should not block the sync"

--- a/tests/test_apt_verify.py
+++ b/tests/test_apt_verify.py
@@ -1,0 +1,121 @@
+"""
+Tests for APT upstream Release signature verification.
+
+Covers the clearsigned ``InRelease`` path (new ``GpgVerifier.verify_clearsigned``)
+and the detached ``Release`` + ``Release.gpg`` path (existing ``verify_detached``).
+Uses an ephemeral "upstream" key to sign, then verifies with a fresh keyring
+holding only the public key.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from chantal.core.config import GpgConfig, SignatureVerificationConfig
+from chantal.core.gpg import GpgSigner
+from chantal.core.gpg_verify import GpgVerifier
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("gpg") is None and shutil.which("gpg2") is None,
+    reason="gpg binary not available",
+)
+
+_RELEASE = (
+    b"Origin: Test\n"
+    b"Suite: jammy\n"
+    b"Codename: jammy\n"
+    b"Components: main\n"
+    b"Architectures: amd64\n"
+    b"SHA256:\n"
+    b" 0000000000000000000000000000000000000000000000000000000000000000 10 main/binary-amd64/Packages\n"
+)
+
+
+def _short_home() -> str:
+    base = "/tmp" if Path("/tmp").is_dir() else None
+    return tempfile.mkdtemp(prefix="cg-", dir=base)
+
+
+@pytest.fixture
+def upstream_signer():
+    home = _short_home()
+    signer = GpgSigner(GpgConfig(generate_key=True, gnupg_home=home, key_email="vendor@upstream"))
+    _ = signer.key_id
+    yield signer
+    signer.close()
+    shutil.rmtree(home, ignore_errors=True)
+
+
+@pytest.fixture
+def verifier_home():
+    home = _short_home()
+    yield home
+    shutil.rmtree(home, ignore_errors=True)
+
+
+def _verify_config(public_key: str, home: str, **kw) -> SignatureVerificationConfig:
+    return SignatureVerificationConfig(enabled=True, keys=[public_key], gnupg_home=home, **kw)
+
+
+class TestVerifyClearsigned:
+    def test_valid_inrelease_returns_payload(self, upstream_signer, verifier_home):
+        blob = upstream_signer.clearsign(_RELEASE)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+
+        with GpgVerifier(_verify_config(pub, verifier_home)) as verifier:
+            payload = verifier.verify_clearsigned(blob)
+
+        assert payload is not None
+        # The verified payload must carry the signed Release fields.
+        assert b"Suite: jammy" in payload
+        assert b"Architectures: amd64" in payload
+
+    def test_tampered_payload_returns_none(self, upstream_signer, verifier_home):
+        blob = upstream_signer.clearsign(_RELEASE)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+        # Flip a byte inside the signed content.
+        tampered = blob.replace(b"Suite: jammy", b"Suite: trusty")
+
+        with GpgVerifier(_verify_config(pub, verifier_home)) as verifier:
+            assert verifier.verify_clearsigned(tampered) is None
+
+    def test_untrusted_key_returns_none(self, upstream_signer, verifier_home):
+        blob = upstream_signer.clearsign(_RELEASE)
+
+        other_home = _short_home()
+        other = GpgSigner(GpgConfig(generate_key=True, gnupg_home=other_home, key_email="x@y"))
+        try:
+            other_pub = other.export_public_key().decode("utf-8")
+            with GpgVerifier(_verify_config(other_pub, verifier_home)) as verifier:
+                assert verifier.verify_clearsigned(blob) is None
+        finally:
+            other.close()
+            shutil.rmtree(other_home, ignore_errors=True)
+
+    def test_fingerprint_pin_match(self, upstream_signer, verifier_home):
+        blob = upstream_signer.clearsign(_RELEASE)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+        cfg = _verify_config(pub, verifier_home, trusted_fingerprints=[upstream_signer.key_id])
+
+        with GpgVerifier(cfg) as verifier:
+            assert verifier.verify_clearsigned(blob) is not None
+
+    def test_fingerprint_pin_mismatch_returns_none(self, upstream_signer, verifier_home):
+        blob = upstream_signer.clearsign(_RELEASE)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+        cfg = _verify_config(pub, verifier_home, trusted_fingerprints=["0" * 40])
+
+        with GpgVerifier(cfg) as verifier:
+            assert verifier.verify_clearsigned(blob) is None
+
+
+class TestVerifyDetachedRelease:
+    def test_release_plus_gpg(self, upstream_signer, verifier_home):
+        sig = upstream_signer.detach_sign(_RELEASE)
+        pub = upstream_signer.export_public_key().decode("utf-8")
+
+        with GpgVerifier(_verify_config(pub, verifier_home)) as verifier:
+            assert verifier.verify_detached(_RELEASE, sig) is True
+            assert verifier.verify_detached(_RELEASE + b"x", sig) is False


### PR DESCRIPTION
## Summary

#57 item 1 — the named 1.0 blocker for APT. Previously the APT sync verified only SHA256 **integrity** of `Packages` against `Release`, not the cryptographic signature. When a `verify` section is configured it now authenticates the upstream `Release` **before trusting any checksum**.

## Changes

- **`GpgVerifier.verify_clearsigned()`** (core): verifies an inline-clearsigned `InRelease` and returns the *exact verified payload bytes* — so the parsed checksums (which gate every `Packages`/`.deb` download) are anchored to the signature, with no TOCTOU/canonicalization gap.
- **APT sync**: verifies in `_fetch_and_store_release` before `parse_release_file`. Prefers `InRelease` (clearsigned), falls back to `Release` + `Release.gpg` (detached, via existing `verify_detached`). An invalid `InRelease` never silently falls back to an unsigned `Release`. Policy (`fail`/`warn`/`skip`) on missing/invalid signatures mirrors the RPM plugin.
- **Config**: reuses the existing `SignatureVerificationConfig` (`RepositoryConfig.verify`); the global `verify` fallback already applies to APT. The RPM-only `gpgcheck` field is ignored for APT (no per-`.deb` signature step; package authenticity is transitive via signed `Release` → `Packages` → SHA256).

## Tests

- Unit (`tests/test_apt_verify.py`): clearsign valid/tampered/untrusted/pinning + detached path.
- E2E (`tests/e2e/test_apt_verify_e2e.py`): valid syncs, tampered fails, untrusted-key fails, **detached** `Release`+`Release.gpg` syncs, **missing-signature** fails, **warn** policy continues.

Docs + `examples/apt/verified.yaml` added. No schema change (config reused).

A fresh-context security review found no blockers; its SHOULD-FIX items (detached/missing/warn e2e coverage, config off-switch docs) are addressed here.

Part of #57