### PR TITLE
feat(apt): mirror source packages and regenerate Sources

### DIFF
--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -25,7 +25,7 @@ The APT plugin consists of:
 - ✅ Architecture filtering (amd64, arm64, armhf, i386, all, etc.)
 - ✅ Component filtering (main, contrib, non-free, etc.)
 - ✅ Pattern-based package filtering
-- ✅ Source package exclusion
+- ✅ Source package mirroring (`.dsc` / `.orig.tar.*` / `.debian.tar.*`) + `Sources` regeneration
 - ✅ Version filtering (only latest)
 
 **Metadata Support:**
@@ -41,7 +41,6 @@ The APT plugin consists of:
 - 🚧 Translation files (i18n)
 - 🚧 Contents indices
 - 🚧 diff/Index support
-- 🚧 Source package syncing
 
 ## Configuration
 
@@ -151,8 +150,15 @@ The `apt` section in repository configuration supports these options:
 ### Optional Options
 
 - **`include_source_packages`** (boolean, default: false)
-  - Whether to sync source packages (.dsc, .tar.gz, etc.)
-  - Note: Source packages are stored separately and require significant space
+  - Sync source packages: download the `.dsc` / `.orig.tar.*` / `.debian.tar.*`
+    artifacts referenced by the `Sources` index, verify each against its
+    `Checksums-Sha256` entry, and publish them under `<component>/source/` with a
+    regenerated `Sources` index (referenced from `Release`).
+  - In filtered mode, source stanzas are filtered by component and by the
+    `filters.patterns` rules **matched on the source-package name** (which can
+    differ from binary names, e.g. source `foo` → binary `libfoo1`); priority
+    and `only_latest_version` are binary-only.
+  - Note: source packages require significant additional space.
 
 - **`flat_repository`** (boolean, default: false)
   - Support for flat repositories (no dists/ structure)

--- a/src/chantal/plugins/apt/models.py
+++ b/src/chantal/plugins/apt/models.py
@@ -160,6 +160,7 @@ class SourcesMetadata(BaseModel):
     vcs_bzr: str | None = Field(None, description="Bazaar repository URL")
 
     # Files
+    component: str | None = None  # repository component, set from the index path
     directory: str | None = Field(None, description="Directory in pool/")
     files: list[dict[str, str]] = Field(
         default_factory=list, description="Source files (dsc, orig.tar.gz, debian.tar.xz)"

--- a/src/chantal/plugins/apt/parsers.py
+++ b/src/chantal/plugins/apt/parsers.py
@@ -511,3 +511,22 @@ def parse_sources_gz(file_path: Path) -> list[SourcesMetadata]:
     with gzip.open(file_path, "rt", encoding="utf-8") as f:
         content = f.read()
     return parse_sources_file(content)
+
+
+def parse_sources_from_bytes(data: bytes, compressed: bool = False) -> list[SourcesMetadata]:
+    """
+    Parse Sources file from bytes.
+
+    Args:
+        data: Sources file data
+        compressed: Whether data is gzip-compressed
+
+    Returns:
+        List of SourcesMetadata objects
+    """
+    if compressed:
+        with gzip.open(BytesIO(data), "rt", encoding="utf-8") as f:
+            content = f.read()
+    else:
+        content = data.decode("utf-8")
+    return parse_sources_file(content)

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -24,6 +24,9 @@ from chantal.plugins.rpm.compression import CompressionFormat, compress_file, ge
 # Used when collecting checksums for the Release file.
 _PACKAGES_VARIANTS = ("Packages", "Packages.gz", "Packages.xz", "Packages.zst", "Packages.bz2")
 
+# Sources index variants (the source-package analog of _PACKAGES_VARIANTS).
+_SOURCES_VARIANTS = ("Sources", "Sources.gz", "Sources.xz", "Sources.zst", "Sources.bz2")
+
 
 class AptPublisher(PublisherPlugin):
     """Publisher for APT/DEB repositories.
@@ -160,10 +163,15 @@ class AptPublisher(PublisherPlugin):
                 component_packages, component_arch_path, component, architecture
             )
 
-            # Generate Packages file(s) (uncompressed + configured compression)
-            generated = self._generate_packages_file(
-                component_packages, component_arch_path, component, architecture, compression
-            )
+            # Generate the index: Sources for the source group, Packages else.
+            if architecture == "source":
+                generated = self._generate_sources_file(
+                    component_packages, component_arch_path, component, compression
+                )
+            else:
+                generated = self._generate_packages_file(
+                    component_packages, component_arch_path, component, architecture, compression
+                )
 
             published_metadata.append(
                 {
@@ -427,6 +435,96 @@ class AptPublisher(PublisherPlugin):
 
         return generated
 
+    def _generate_sources_file(
+        self,
+        packages: list[ContentItem],
+        source_path: Path,
+        component: str,
+        compression: CompressionFormat = "gzip",
+    ) -> list[Path]:
+        """Generate a ``Sources`` index for source-package artifacts.
+
+        Each source ``ContentItem`` is one artifact file; they are regrouped by
+        (source package, source version) into one stanza listing all artifacts
+        with their MD5/SHA1/SHA256 checksums.
+
+        Returns:
+            The generated paths; uncompressed ``Sources`` first, then the
+            compressed variant (if any).
+        """
+        groups: dict[tuple[str, str], list[ContentItem]] = {}
+        for pkg in packages:
+            key = (
+                pkg.content_metadata.get("source_package") or pkg.name,
+                pkg.content_metadata.get("source_version") or pkg.version,
+            )
+            groups.setdefault(key, []).append(pkg)
+
+        stanzas: list[str] = []
+        for (src_name, src_version), artifacts in groups.items():
+            meta = artifacts[0].content_metadata
+            lines = [f"Package: {src_name}"]
+
+            if meta.get("source_format"):
+                lines.append(f"Format: {meta['source_format']}")
+            binary = meta.get("binary") or []
+            if binary:
+                lines.append(f"Binary: {', '.join(binary)}")
+            lines.append(f"Version: {src_version}")
+            if meta.get("maintainer"):
+                lines.append(f"Maintainer: {meta['maintainer']}")
+            lines.append(f"Architecture: {meta.get('source_architecture') or 'any'}")
+            if meta.get("priority"):
+                lines.append(f"Priority: {meta['priority']}")
+            if meta.get("section"):
+                lines.append(f"Section: {meta['section']}")
+            lines.append(f"Directory: {component}/source")
+
+            files_lines = []
+            sha1_lines = []
+            sha256_lines = []
+            for art in sorted(artifacts, key=lambda a: a.filename):
+                size = art.size_bytes
+                amd5 = art.content_metadata.get("md5sum")
+                asha1 = art.content_metadata.get("sha1")
+                if amd5:
+                    files_lines.append(f" {amd5} {size} {art.filename}")
+                if asha1:
+                    sha1_lines.append(f" {asha1} {size} {art.filename}")
+                sha256_lines.append(f" {art.sha256} {size} {art.filename}")
+
+            if files_lines:
+                lines.append("Files:")
+                lines.extend(files_lines)
+            if sha1_lines:
+                lines.append("Checksums-Sha1:")
+                lines.extend(sha1_lines)
+            if sha256_lines:
+                lines.append("Checksums-Sha256:")
+                lines.extend(sha256_lines)
+
+            stanzas.append("\n".join(lines))
+
+        full_content = "\n\n".join(stanzas)
+        if full_content:
+            full_content += "\n"
+
+        sources_file_path = source_path / "Sources"
+        sources_file_path.write_text(full_content, encoding="utf-8")
+        generated = [sources_file_path]
+
+        if compression != "none":
+            ext = get_extension(compression)
+            compressed_path = source_path / f"Sources{ext}"
+            compressed_path.write_bytes(compress_file(sources_file_path.read_bytes(), compression))
+            generated.append(compressed_path)
+
+        print(
+            f"  ✓ Generated Sources for {component}: {len(groups)} source packages ({compression})"
+        )
+
+        return generated
+
     def _publish_metadata_files(
         self, repository_files: list[RepositoryFile], dists_path: Path
     ) -> None:
@@ -550,10 +648,12 @@ class AptPublisher(PublisherPlugin):
 
             if architecture == "source":
                 rel_prefix = f"{component}/source"
+                variants = _SOURCES_VARIANTS
             else:
                 rel_prefix = f"{component}/binary-{architecture}"
+                variants = _PACKAGES_VARIANTS
 
-            for variant in _PACKAGES_VARIANTS:
+            for variant in variants:
                 variant_path = component_dir / variant
                 if not variant_path.exists():
                     continue

--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -20,8 +20,12 @@ from chantal.core.downloader import DownloadManager
 from chantal.core.output import OutputLevel, SyncOutputter
 from chantal.core.storage import StorageManager
 from chantal.db.models import ContentItem, Repository, RepositoryFile
-from chantal.plugins.apt.models import DebMetadata
-from chantal.plugins.apt.parsers import parse_packages_from_bytes, parse_release_file
+from chantal.plugins.apt.models import DebMetadata, SourcesMetadata
+from chantal.plugins.apt.parsers import (
+    parse_packages_from_bytes,
+    parse_release_file,
+    parse_sources_from_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -247,6 +251,14 @@ class AptSyncPlugin:
                 self.output.update_progress()
 
             self.output.finish_progress()
+
+            # Source packages (.dsc, .orig.tar.*, .debian.tar.*/.diff.gz)
+            if self.apt_config.include_source_packages:
+                src_downloaded, src_bytes = self._sync_source_packages(
+                    session, repository, metadata_files
+                )
+                packages_downloaded += src_downloaded
+                bytes_downloaded += src_bytes
 
             # Sync complete
             self.output.summary(
@@ -920,3 +932,249 @@ class AptSyncPlugin:
             filtered = list(by_name_arch.values())
 
         return filtered
+
+    # ------------------------------------------------------------------ #
+    # Source packages
+    # ------------------------------------------------------------------ #
+
+    def _sync_source_packages(
+        self,
+        session: Session,
+        repository: Repository,
+        metadata_files: list[MetadataFileInfo],
+    ) -> tuple[int, int]:
+        """Download source package artifacts referenced by the Sources indices.
+
+        Returns:
+            Tuple of (artifacts_downloaded, bytes_downloaded).
+        """
+        import gzip
+
+        # Collect source stanzas from every Sources index.
+        all_sources: list[SourcesMetadata] = []
+        for metadata_info in metadata_files:
+            if metadata_info.file_type != "Sources":
+                continue
+            sources_path = self._get_metadata_file_path(session, metadata_info, repository)
+            if not sources_path or not sources_path.exists():
+                logger.warning(f"Sources file not found in storage: {metadata_info.relative_path}")
+                continue
+            try:
+                content = gzip.decompress(sources_path.read_bytes())
+                stanzas = parse_sources_from_bytes(content, compressed=False)
+            except Exception as e:
+                logger.error(f"Failed to parse Sources file: {e}")
+                continue
+            for src in stanzas:
+                if not src.component:
+                    src.component = metadata_info.component
+            all_sources.extend(stanzas)
+
+        if not all_sources:
+            return 0, 0
+
+        self.output.info(f"Total source packages found: {len(all_sources)}")
+
+        if repository.mode == "filtered":
+            all_sources = self._apply_source_filters(all_sources, self.config)
+            self.output.info(f"After filtering: {len(all_sources)} source packages")
+
+        artifacts = self._flatten_source_artifacts(all_sources)
+        if not artifacts:
+            return 0, 0
+
+        existing = self._get_existing_source_artifacts(session)
+        downloaded = 0
+        total_bytes = 0
+
+        self.output.start_progress(len(artifacts), "Downloading source artifacts", "files")
+        for art in artifacts:
+            try:
+                if art["sha256"] in existing:
+                    existing_item = existing[art["sha256"]]
+                    if repository not in existing_item.repositories:
+                        existing_item.repositories.append(repository)
+                        session.commit()
+                    self.output.update_progress()
+                    continue
+
+                directory = art["directory"]
+                rel = f"{directory}/{art['filename']}" if directory else art["filename"]
+                url = urljoin(self.config.feed + "/", rel)
+                bytes_dl, item = self._download_source_artifact(url, art, session, repository)
+                # Record in-run so a duplicate sha256 later in the same set links
+                # instead of re-inserting (ContentItem.sha256 is unique).
+                existing[art["sha256"]] = item
+                total_bytes += bytes_dl
+                downloaded += 1
+            except Exception as e:
+                session.rollback()
+                logger.error(f"Failed to download source artifact {art['filename']}: {e}")
+                self.output.error(f"{art['filename']}: {e}")
+            self.output.update_progress()
+        self.output.finish_progress()
+
+        return downloaded, total_bytes
+
+    def _flatten_source_artifacts(self, sources: list[SourcesMetadata]) -> list[dict]:
+        """Flatten source stanzas into per-artifact download descriptors.
+
+        The ``Checksums-Sha256`` block is authoritative for the artifact set;
+        MD5 (``Files``) and SHA1 (``Checksums-Sha1``) are merged in by filename
+        so the publisher can regenerate a faithful ``Sources`` index.
+        """
+        artifacts: list[dict] = []
+        for src in sources:
+            if not src.checksums_sha256:
+                # Modern Debian/Ubuntu always ship Checksums-Sha256; without it
+                # we cannot verify the artifacts, so skip them visibly.
+                if src.files:
+                    self.output.warning(
+                        f"Source package {src.package} {src.version} has no SHA256 "
+                        "checksums; skipping its artifacts"
+                    )
+                continue
+            md5_by_name = {f["filename"]: f["checksum"] for f in src.files}
+            sha1_by_name = {f["filename"]: f["checksum"] for f in src.checksums_sha1}
+            source_format = src.extra_fields.get("Format")
+            for entry in src.checksums_sha256:
+                filename = entry["filename"]
+                artifacts.append(
+                    {
+                        "filename": filename,
+                        "sha256": entry["checksum"],
+                        "size": int(entry["size"]) if entry.get("size") else 0,
+                        "md5": md5_by_name.get(filename),
+                        "sha1": sha1_by_name.get(filename),
+                        "directory": src.directory or "",
+                        "source_package": src.package,
+                        "source_version": src.version,
+                        "component": src.component,
+                        "binary": src.binary,
+                        "maintainer": src.maintainer,
+                        "priority": src.priority,
+                        "section": src.section,
+                        "source_architecture": src.architecture,
+                        "source_format": source_format,
+                    }
+                )
+        return artifacts
+
+    def _get_existing_source_artifacts(self, session: Session) -> dict[str, ContentItem]:
+        """Return existing source-artifact content items keyed by SHA256."""
+        items = session.query(ContentItem).filter(ContentItem.content_type == "deb-source").all()
+        return {item.sha256: item for item in items}
+
+    def _apply_source_filters(
+        self, sources: list[SourcesMetadata], config: RepositoryConfig
+    ) -> list[SourcesMetadata]:
+        """Filter source stanzas by component and name patterns.
+
+        Reuses the binary component/pattern filters (matched on the *source*
+        package name). Priority and only_latest_version are binary-only.
+        """
+        if not config.filters:
+            return sources
+
+        filtered = sources
+
+        if config.filters.deb and config.filters.deb.components:
+            if config.filters.deb.components.include:
+                filtered = [
+                    s
+                    for s in filtered
+                    if s.component and s.component in config.filters.deb.components.include
+                ]
+            if config.filters.deb.components.exclude:
+                filtered = [
+                    s
+                    for s in filtered
+                    if not (s.component and s.component in config.filters.deb.components.exclude)
+                ]
+
+        if config.filters.patterns:
+            if config.filters.patterns.include:
+                import re
+
+                include_patterns = [re.compile(p) for p in config.filters.patterns.include]
+                filtered = [
+                    s for s in filtered if any(p.match(s.package) for p in include_patterns)
+                ]
+            if config.filters.patterns.exclude:
+                import re
+
+                exclude_patterns = [re.compile(p) for p in config.filters.patterns.exclude]
+                filtered = [
+                    s for s in filtered if not any(p.match(s.package) for p in exclude_patterns)
+                ]
+
+        return filtered
+
+    def _download_source_artifact(
+        self,
+        url: str,
+        art: dict,
+        session: Session,
+        repository: Repository,
+    ) -> tuple[int, ContentItem]:
+        """Download one source artifact and store it as a ContentItem.
+
+        Returns:
+            Tuple of (bytes_downloaded, the created ContentItem).
+        """
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".src") as tmp_file:
+            tmp_path = Path(tmp_file.name)
+            try:
+                response = self.session.get(url, stream=True, timeout=300)
+                response.raise_for_status()
+
+                bytes_downloaded = 0
+                for chunk in response.iter_content(chunk_size=65536):
+                    tmp_file.write(chunk)
+                    bytes_downloaded += len(chunk)
+                tmp_file.flush()
+
+                filename = Path(art["filename"]).name
+                sha256, pool_path, size_bytes = self.storage.add_package(
+                    tmp_path, filename, verify_checksum=True
+                )
+                if sha256 != art["sha256"]:
+                    raise ValueError(
+                        f"SHA256 mismatch for {filename}: expected {art['sha256']}, got {sha256}"
+                    )
+
+                content_metadata = {
+                    "component": art["component"],
+                    "architecture": "source",
+                    "source_package": art["source_package"],
+                    "source_version": art["source_version"],
+                    "directory": art["directory"],
+                    "binary": art["binary"],
+                    "maintainer": art["maintainer"],
+                    "priority": art["priority"],
+                    "section": art["section"],
+                    "source_architecture": art["source_architecture"],
+                    "source_format": art.get("source_format"),
+                    "md5sum": art["md5"],
+                    "sha1": art["sha1"],
+                }
+                content_item = ContentItem(
+                    content_type="deb-source",
+                    name=art["source_package"],
+                    version=art["source_version"],
+                    sha256=sha256,
+                    size_bytes=size_bytes,
+                    pool_path=pool_path,
+                    filename=filename,
+                    content_metadata=content_metadata,
+                )
+                session.add(content_item)
+                session.commit()
+
+                content_item.repositories.append(repository)
+                session.commit()
+
+                return bytes_downloaded, content_item
+            finally:
+                if tmp_path.exists():
+                    tmp_path.unlink()

--- a/tests/e2e/test_apt_sources_e2e.py
+++ b/tests/e2e/test_apt_sources_e2e.py
@@ -1,0 +1,244 @@
+"""
+End-to-end test: APT source-package mirroring.
+
+With ``include_source_packages: true`` the sync must download the source
+artifacts (.dsc / .orig.tar.* / .debian.tar.*) referenced by the Sources index,
+pool them, and the publisher must regenerate a ``Sources`` index and list it in
+``Release``.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _build_apt_upstream_with_sources(root: Path, *, corrupt: str | None = None) -> None:
+    # --- binary package ---
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    (root / deb_rel).write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        "Maintainer: Test <test@example.com>\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo package\n"
+        "\n"
+    ).encode()
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    # --- source artifacts ---
+    src_dir_rel = f"pool/{COMP}/d/demo"
+    artifacts = {
+        "demo_1.0.dsc": b"fake dsc contents\n",
+        "demo_1.0.orig.tar.gz": b"fake orig tarball" * 8,
+        "demo_1.0.debian.tar.xz": b"fake debian tarball" * 8,
+    }
+    for name, data in artifacts.items():
+        (root / src_dir_rel / name).write_bytes(data)
+
+    def _sha256(name, data):
+        if corrupt and name == corrupt:
+            return "0" * 64
+        return hashlib.sha256(data).hexdigest()
+
+    files_md5 = "".join(
+        f" {hashlib.md5(d).hexdigest()} {len(d)} {n}\n" for n, d in artifacts.items()
+    )
+    files_sha256 = "".join(f" {_sha256(n, d)} {len(d)} {n}\n" for n, d in artifacts.items())
+
+    sources = (
+        "Package: demo\n"
+        "Format: 3.0 (quilt)\n"
+        "Binary: demo\n"
+        "Version: 1.0\n"
+        "Maintainer: Test <test@example.com>\n"
+        "Architecture: any\n"
+        f"Directory: {src_dir_rel}\n"
+        "Files:\n" + files_md5 + "Checksums-Sha256:\n" + files_sha256 + "\n"
+    ).encode()
+    src_index_dir = root / "dists" / DIST / COMP / "source"
+    src_index_dir.mkdir(parents=True, exist_ok=True)
+    (src_index_dir / "Sources").write_bytes(sources)
+    sources_gz = gzip.compress(sources)
+    (src_index_dir / "Sources.gz").write_bytes(sources_gz)
+
+    # --- Release ---
+    sha = hashlib.sha256
+
+    def _rel(path, data):
+        return f" {sha(data).hexdigest()} {len(data)} {path}\n"
+
+    release = (
+        "Origin: Test\n"
+        f"Suite: {DIST}\n"
+        f"Codename: {DIST}\n"
+        f"Components: {COMP}\n"
+        f"Architectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\n"
+        "SHA256:\n"
+        + _rel(f"{COMP}/binary-{ARCH}/Packages", packages)
+        + _rel(f"{COMP}/binary-{ARCH}/Packages.gz", packages_gz)
+        + _rel(f"{COMP}/source/Sources", sources)
+        + _rel(f"{COMP}/source/Sources.gz", sources_gz)
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def test_apt_sources_sync_and_publish(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream_with_sources(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt-src",
+            "name": "Demo APT sources",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {
+                "distribution": DIST,
+                "components": [COMP],
+                "architectures": [ARCH],
+                "include_source_packages": True,
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt-src")
+
+    source_dir = target / "dists" / DIST / COMP / "source"
+    # The regenerated Sources index exists and lists all three artifacts.
+    sources_index = source_dir / "Sources"
+    assert sources_index.exists(), "regenerated Sources index missing"
+    text = sources_index.read_text()
+    for name in ("demo_1.0.dsc", "demo_1.0.orig.tar.gz", "demo_1.0.debian.tar.xz"):
+        assert name in text, f"{name} missing from regenerated Sources"
+        assert (source_dir / name).exists(), f"{name} not published"
+    # The Format field is preserved (apt-get source needs it).
+    assert "Format: 3.0 (quilt)" in text, "Format field not preserved"
+
+    # Release lists the source index.
+    release_text = (target / "dists" / DIST / "Release").read_text()
+    assert f"{COMP}/source/Sources" in release_text, "Release does not reference Sources"
+
+
+def test_apt_sources_checksum_mismatch_rejected(tmp_path, serve, chantal_env):
+    # An artifact whose declared sha256 is wrong must be rejected, not published.
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream_with_sources(upstream, corrupt="demo_1.0.dsc")
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt-src-bad",
+            "name": "Demo APT bad source checksum",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {
+                "distribution": DIST,
+                "components": [COMP],
+                "architectures": [ARCH],
+                "include_source_packages": True,
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt-src-bad")
+    source_dir = target / "dists" / DIST / COMP / "source"
+    # The corrupt .dsc is rejected; the well-formed artifacts still publish.
+    assert not (source_dir / "demo_1.0.dsc").exists(), "artifact with bad checksum was published"
+    assert (source_dir / "demo_1.0.orig.tar.gz").exists(), "valid artifact missing"
+
+
+def _build_shared_artifact_upstream(root: Path) -> None:
+    """Two source packages that share an identical .orig.tar.gz (same sha256)."""
+    src_dir_rel = f"pool/{COMP}/s/shared"
+    shared = b"shared upstream tarball" * 8
+    stanzas = []
+    src_pkg_dir = root / src_dir_rel
+    src_pkg_dir.mkdir(parents=True, exist_ok=True)
+    (src_pkg_dir / "shared_1.0.orig.tar.gz").write_bytes(shared)
+    for pkg in ("alpha", "beta"):
+        dsc = f"fake dsc {pkg}\n".encode()
+        (src_pkg_dir / f"{pkg}_1.0.dsc").write_bytes(dsc)
+        arts = {f"{pkg}_1.0.dsc": dsc, "shared_1.0.orig.tar.gz": shared}
+        md5 = "".join(f" {hashlib.md5(d).hexdigest()} {len(d)} {n}\n" for n, d in arts.items())
+        s256 = "".join(f" {hashlib.sha256(d).hexdigest()} {len(d)} {n}\n" for n, d in arts.items())
+        stanzas.append(
+            f"Package: {pkg}\nVersion: 1.0\nArchitecture: any\n"
+            f"Directory: {src_dir_rel}\nFiles:\n{md5}Checksums-Sha256:\n{s256}"
+        )
+    sources = ("\n".join(stanzas) + "\n").encode()
+    src_index_dir = root / "dists" / DIST / COMP / "source"
+    src_index_dir.mkdir(parents=True, exist_ok=True)
+    (src_index_dir / "Sources").write_bytes(sources)
+    sources_gz = gzip.compress(sources)
+    (src_index_dir / "Sources.gz").write_bytes(sources_gz)
+
+    sha = hashlib.sha256
+    release = (
+        f"Origin: Test\nSuite: {DIST}\nCodename: {DIST}\n"
+        f"Components: {COMP}\nArchitectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\nSHA256:\n"
+        f" {sha(sources).hexdigest()} {len(sources)} {COMP}/source/Sources\n"
+        f" {sha(sources_gz).hexdigest()} {len(sources_gz)} {COMP}/source/Sources.gz\n"
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def test_apt_sources_shared_artifact_dedup(tmp_path, serve, chantal_env):
+    # A shared identical artifact across two source stanzas must not crash the
+    # sync (duplicate sha256 -> in-run dedup, no IntegrityError cascade).
+    upstream = tmp_path / "upstream"
+    _build_shared_artifact_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt-src-shared",
+            "name": "Demo APT shared source artifact",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {
+                "distribution": DIST,
+                "components": [COMP],
+                "architectures": [ARCH],
+                "include_source_packages": True,
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt-src-shared")
+    source_dir = target / "dists" / DIST / COMP / "source"
+    assert (source_dir / "shared_1.0.orig.tar.gz").exists(), "shared artifact missing"
+    assert (source_dir / "alpha_1.0.dsc").exists()
+    assert (source_dir / "beta_1.0.dsc").exists()
+    # The shared artifact lives once in the pool (content-addressed).
+    pooled = list(chantal_env.pool.rglob("*shared_1.0.orig.tar.gz"))
+    assert len(pooled) == 1, f"shared artifact should be pooled once, got {len(pooled)}"

--- a/tests/test_apt_parsers.py
+++ b/tests/test_apt_parsers.py
@@ -16,6 +16,7 @@ from chantal.plugins.apt.parsers import (
     parse_rfc822_file,
     parse_rfc822_stanza,
     parse_sources_file,
+    parse_sources_from_bytes,
     parse_sources_gz,
 )
 
@@ -561,3 +562,36 @@ Version: 1.18.0"""
             assert sources[0].package == "nginx"
         finally:
             tmp_path.unlink()
+
+    def test_parse_sources_from_bytes(self):
+        """Sources parsed from raw bytes, with the multi-file checksum block."""
+        content = (
+            "Package: demo\n"
+            "Binary: demo, demo-dev\n"
+            "Version: 1.0-1\n"
+            "Architecture: any\n"
+            "Directory: pool/main/d/demo\n"
+            "Checksums-Sha256:\n"
+            " aaaa 18 demo_1.0.dsc\n"
+            " bbbb 100 demo_1.0.orig.tar.gz\n"
+            " cccc 50 demo_1.0-1.debian.tar.xz\n"
+        )
+        sources = parse_sources_from_bytes(content.encode("utf-8"), compressed=False)
+        assert len(sources) == 1
+        src = sources[0]
+        assert src.package == "demo"
+        assert src.binary == ["demo", "demo-dev"]
+        assert src.directory == "pool/main/d/demo"
+        names = {f["filename"] for f in src.checksums_sha256}
+        assert names == {
+            "demo_1.0.dsc",
+            "demo_1.0.orig.tar.gz",
+            "demo_1.0-1.debian.tar.xz",
+        }
+
+    def test_parse_sources_from_bytes_compressed(self):
+        """Sources parsed from gzip-compressed bytes."""
+        content = "Package: demo\nVersion: 1.0\nDirectory: pool/main/d/demo\n"
+        sources = parse_sources_from_bytes(gzip.compress(content.encode("utf-8")), compressed=True)
+        assert len(sources) == 1
+        assert sources[0].package == "demo"


### PR DESCRIPTION
## Summary

#57 item 2. `include_source_packages` existed but the sync **skipped** the `Sources` index, so source artifacts were never downloaded. This completes the feature end to end.

## Changes

- **Parser**: `parse_sources_from_bytes`; `SourcesMetadata` gains a `component` field.
- **Sync**: collect `Sources` stanzas → filter (component + `filters.patterns` on the source name) in filtered mode → flatten each stanza's `Checksums-Sha256` into per-artifact descriptors (merging MD5/SHA1 by filename) → download each artifact (`feed/{Directory}/{filename}`) into the pool as a `content_type='deb-source'` ContentItem, verifying sha256 against the index. **Dedup within a run + rollback** on a failed insert so a shared `.orig.tar.gz` never aborts the sync. **Warn** (not silently skip) when a stanza lacks SHA256 checksums.
- **Publisher**: source items group under `(component, 'source')`; regenerate a `Sources` index (`Directory`/`Format`/`Files`/`Checksums-Sha1`/`Checksums-Sha256`) and list `{component}/source/Sources*` in `Release` via `_SOURCES_VARIANTS`.

## Tests

- Unit: `parse_sources_from_bytes` (incl. multi-file checksum block, compressed).
- E2E: filtered sync+publish (artifacts pooled + published, `Sources` regenerated, `Release` references it, `Format` preserved); **checksum-mismatch rejection**; **shared-artifact dedup** (the duplicate-sha256 case).

## Review notes

A fresh-context review found one BLOCKER — duplicate-sha256 within a run could cascade via a missing `session.rollback()` — now fixed (in-run dedup + rollback) and covered by the shared-artifact test. Known limitation (consistent with the existing binary convention): the generated `Directory:`/`Filename:` omit the `dists/<suite>/` prefix, tracked under the roadmap's real-world client-testing item; not changed here to avoid diverging source from binary behavior.

Part of #57