### PR TITLE
feat(apt): mirror Contents-<arch> indices (apt-file)

### DIFF
--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -26,6 +26,7 @@ The APT plugin consists of:
 - ✅ Component filtering (main, contrib, non-free, etc.)
 - ✅ Pattern-based package filtering
 - ✅ Source package mirroring (`.dsc` / `.orig.tar.*` / `.debian.tar.*`) + `Sources` regeneration
+- ✅ `Contents-<arch>` index mirroring (apt-file; mirror mode)
 - ✅ Version filtering (only latest)
 
 **Metadata Support:**
@@ -39,7 +40,6 @@ The APT plugin consists of:
 
 **Planned:**
 - 🚧 Translation files (i18n)
-- 🚧 Contents indices
 - 🚧 diff/Index support
 
 ## Configuration
@@ -159,6 +159,17 @@ The `apt` section in repository configuration supports these options:
     differ from binary names, e.g. source `foo` → binary `libfoo1`); priority
     and `only_latest_version` are binary-only.
   - Note: source packages require significant additional space.
+
+- **`include_contents`** (boolean, default: false)
+  - Mirror `Contents-<arch>` indices (the file→package map used by `apt-file`),
+    including `Contents-all` and `udeb` variants where present, at both the
+    component-scoped (`<component>/Contents-<arch>`) and suite-level paths.
+  - **Mirror mode only**: the indices are republished verbatim and referenced in
+    the regenerated `Release`. In **filtered mode** Contents are **dropped** —
+    regenerating an accurate index would require per-`.deb` file-list extraction
+    that chantal does not perform, and shipping the upstream one would reference
+    packages that were filtered out.
+  - Note: Contents files are large (tens to hundreds of MB).
 
 - **`flat_repository`** (boolean, default: false)
   - Support for flat repositories (no dists/ structure)

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -52,6 +52,12 @@
           "description": "Include source packages (.dsc, .orig.tar.gz, etc.)",
           "title": "Include Source Packages",
           "type": "boolean"
+        },
+        "include_contents": {
+          "default": false,
+          "description": "Mirror Contents-<arch> indices (apt-file). Large; mirror mode only.",
+          "title": "Include Contents",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -162,6 +162,10 @@ class AptConfig(BaseModel):
     include_source_packages: bool = Field(
         default=False, description="Include source packages (.dsc, .orig.tar.gz, etc.)"
     )
+    include_contents: bool = Field(
+        default=False,
+        description="Mirror Contents-<arch> indices (apt-file). Large; mirror mode only.",
+    )
 
 
 class GpgConfig(BaseModel):

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -183,12 +183,15 @@ class AptPublisher(PublisherPlugin):
             )
 
         # In mirror mode, publish all metadata files (Release, InRelease, etc.)
+        # and the Contents indices (filtered mode drops Contents entirely).
+        contents_files: list[tuple[str, Path]] = []
         if mode == RepositoryMode.MIRROR:
             self._publish_metadata_files(repository_files, dists_path)
+            contents_files = self._publish_contents_files(repository_files, dists_path)
 
         # Generate Release file (always generated, even in mirror mode for completeness)
         release_file = self._generate_release_file(
-            dists_path, published_metadata, repository_files, mode
+            dists_path, published_metadata, repository_files, mode, extra_files=contents_files
         )
 
         # In filtered mode the regenerated Release invalidates upstream signatures.
@@ -541,6 +544,11 @@ class AptPublisher(PublisherPlugin):
             if repo_file.file_category != "metadata":
                 continue
 
+            # Contents indices are placed by _publish_contents_files at their
+            # full dists-relative path (this method flattens nested paths).
+            if repo_file.file_type == "Contents":
+                continue
+
             # Get pool path
             pool_file_path = self.storage.pool_path / repo_file.pool_path
 
@@ -581,12 +589,47 @@ class AptPublisher(PublisherPlugin):
 
             print(f"  ✓ Published {repo_file.file_type}: {relative_path}")
 
+    def _publish_contents_files(
+        self, repository_files: list[RepositoryFile], dists_path: Path
+    ) -> list[tuple[str, Path]]:
+        """Publish Contents-<arch> indices at their dists-relative location.
+
+        Contents indices are stored with a dists-relative ``original_path``
+        (e.g. ``main/Contents-amd64.gz``) and republished verbatim. Returns
+        ``(relative_path, published_path)`` tuples so the regenerated Release
+        can reference them.
+        """
+        import os
+
+        published: list[tuple[str, Path]] = []
+        for repo_file in repository_files:
+            if repo_file.file_type != "Contents":
+                continue
+
+            pool_file_path = self.storage.pool_path / repo_file.pool_path
+            if not pool_file_path.exists():
+                print(f"Warning: Pool file not found: {pool_file_path}")
+                continue
+
+            relative_path = repo_file.original_path
+            target_path = dists_path / relative_path
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            if target_path.exists():
+                target_path.unlink()
+            os.link(pool_file_path, target_path)
+
+            published.append((relative_path, target_path))
+            print(f"  ✓ Published Contents: {relative_path}")
+
+        return published
+
     def _generate_release_file(
         self,
         dists_path: Path,
         published_metadata: list[dict],
         repository_files: list[RepositoryFile],
         mode: str,
+        extra_files: list[tuple[str, Path]] | None = None,
     ) -> Path:
         """Generate Release file for the distribution.
 
@@ -595,6 +638,8 @@ class AptPublisher(PublisherPlugin):
             published_metadata: List of metadata info dicts
             repository_files: List of repository files
             mode: Repository mode
+            extra_files: Additional (dists-relative path, file) entries to
+                checksum into Release (e.g. Contents indices).
 
         Returns:
             Path to generated Release file
@@ -665,6 +710,15 @@ class AptPublisher(PublisherPlugin):
                 md5sums.append(f" {hashlib.md5(data).hexdigest()} {size:8} {rel}")
                 sha1sums.append(f" {hashlib.sha1(data).hexdigest()} {size:8} {rel}")
                 sha256sums.append(f" {hashlib.sha256(data).hexdigest()} {size:8} {rel}")
+
+        # Extra metadata files (e.g. Contents indices) referenced by their
+        # dists-relative path.
+        for rel, file_path in extra_files or []:
+            data = file_path.read_bytes()
+            size = len(data)
+            md5sums.append(f" {hashlib.md5(data).hexdigest()} {size:8} {rel}")
+            sha1sums.append(f" {hashlib.sha1(data).hexdigest()} {size:8} {rel}")
+            sha256sums.append(f" {hashlib.sha256(data).hexdigest()} {size:8} {rel}")
 
         # Add checksum sections
         if md5sums:

--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -135,7 +135,7 @@ class AptSyncPlugin:
 
             # Phase 2: Download Packages.gz/Sources.gz for all components/architectures
             self.output.phase("Downloading repository metadata", number=2)
-            metadata_files = self._build_metadata_file_list(release_metadata)
+            metadata_files = self._build_metadata_file_list(release_metadata, repository.mode)
             self.output.info(f"Found {len(metadata_files)} metadata files to download")
 
             metadata_downloaded = 0
@@ -511,11 +511,14 @@ class AptSyncPlugin:
             self.output.warning(f"Signature verification: {message}")
         # "skip": silently continue
 
-    def _build_metadata_file_list(self, release_metadata: dict) -> list[MetadataFileInfo]:
+    def _build_metadata_file_list(
+        self, release_metadata: dict, mode: str = "mirror"
+    ) -> list[MetadataFileInfo]:
         """Build list of metadata files to download based on configuration.
 
         Args:
             release_metadata: Parsed Release metadata
+            mode: Repository mode (Contents are mirror-only)
 
         Returns:
             List of MetadataFileInfo objects
@@ -579,6 +582,35 @@ class AptSyncPlugin:
                             architecture=None,
                         )
                     )
+
+            # Contents-<arch> indices (apt-file). Mirror mode only: regenerating
+            # a filtered Contents would need per-.deb file lists we do not
+            # extract, and shipping the upstream one would reference removed
+            # packages. Only download them when they will also be published
+            # (mirror), so non-mirror modes don't fetch huge unused files.
+            if self.apt_config.include_contents and mode == "mirror":
+                seen = {m.relative_path for m in metadata_files}
+                for arch in [*architectures, "all"]:
+                    for variant in ("", "udeb-"):
+                        base = f"Contents-{variant}{arch}"
+                        # Component-scoped (modern) first, then suite-level.
+                        for rel_base in (f"{component}/{base}", base):
+                            for ext in (".gz", ".xz", ""):
+                                path = f"{rel_base}{ext}"
+                                if path in seen or path not in sha256_checksums:
+                                    continue
+                                checksum, size = sha256_checksums[path]
+                                metadata_files.append(
+                                    MetadataFileInfo(
+                                        file_type="Contents",
+                                        relative_path=path,
+                                        checksum=checksum,
+                                        size=size,
+                                        component=component,
+                                        architecture=arch,
+                                    )
+                                )
+                                seen.add(path)
 
         return metadata_files
 

--- a/tests/e2e/test_apt_contents_e2e.py
+++ b/tests/e2e/test_apt_contents_e2e.py
@@ -1,0 +1,119 @@
+"""
+End-to-end test: APT Contents-<arch> index mirroring.
+
+With ``include_contents: true`` in MIRROR mode the Contents index is downloaded,
+republished at its component path, and referenced in the regenerated Release.
+In FILTERED mode Contents are dropped (regenerating one would need per-.deb file
+lists chantal does not extract).
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _build_apt_upstream_with_contents(root: Path) -> None:
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    (root / deb_rel).write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo\n"
+        "\n"
+    ).encode()
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    # Component-scoped Contents index (file -> package mapping).
+    contents = b"usr/bin/demo    main/demo\nusr/share/doc/demo/README    main/demo\n"
+    contents_gz = gzip.compress(contents)
+    (root / "dists" / DIST / COMP / f"Contents-{ARCH}.gz").write_bytes(contents_gz)
+
+    sha = hashlib.sha256
+
+    def _rel(path, data):
+        return f" {sha(data).hexdigest()} {len(data)} {path}\n"
+
+    release = (
+        "Origin: Test\n"
+        f"Suite: {DIST}\n"
+        f"Codename: {DIST}\n"
+        f"Components: {COMP}\n"
+        f"Architectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\n"
+        "SHA256:\n"
+        + _rel(f"{COMP}/binary-{ARCH}/Packages", packages)
+        + _rel(f"{COMP}/binary-{ARCH}/Packages.gz", packages_gz)
+        + _rel(f"{COMP}/Contents-{ARCH}.gz", contents_gz)
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def _config(repo_id: str, base_url: str, mode: str) -> dict:
+    return {
+        "id": repo_id,
+        "name": repo_id,
+        "type": "apt",
+        "feed": base_url,
+        "enabled": True,
+        "mode": mode,
+        "apt": {
+            "distribution": DIST,
+            "components": [COMP],
+            "architectures": [ARCH],
+            "include_contents": True,
+        },
+    }
+
+
+def test_apt_contents_mirror_published(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream_with_contents(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-contents", base_url, "mirror"))
+    target = chantal_env.sync_and_publish("demo-apt-contents")
+
+    # Republished at the correct component path (not flattened to the suite root).
+    published = target / "dists" / DIST / COMP / f"Contents-{ARCH}.gz"
+    assert published.exists(), "Contents index not republished at component path"
+    assert not (target / "dists" / DIST / f"Contents-{ARCH}.gz").exists(), "Contents flattened"
+
+    # Release references the Contents index with a matching checksum.
+    release_text = (target / "dists" / DIST / "Release").read_text()
+    assert f"{COMP}/Contents-{ARCH}.gz" in release_text, "Release does not reference Contents"
+    expected_sha = hashlib.sha256(published.read_bytes()).hexdigest()
+    assert expected_sha in release_text, "Release Contents checksum mismatch"
+
+
+def test_apt_contents_dropped_in_filtered_mode(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream_with_contents(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-contents-filtered", base_url, "filtered"))
+    target = chantal_env.sync_and_publish("demo-apt-contents-filtered")
+
+    assert not list(target.rglob("Contents-*")), "Contents must be dropped in filtered mode"
+    release_text = (target / "dists" / DIST / "Release").read_text()
+    assert "Contents-" not in release_text, "filtered Release must not reference Contents"

--- a/tests/test_apt_sync.py
+++ b/tests/test_apt_sync.py
@@ -240,6 +240,94 @@ class TestReleaseFileParsing:
         # Additional metadata files are discovered but handled separately
         # This test verifies the basic structure is working
 
+    def test_build_metadata_file_list_contents(self):
+        """Contents indices are discovered in mirror mode and dropped in filtered."""
+        from chantal.core.config import AptConfig, RepositoryConfig
+
+        release_metadata = {
+            "components": ["main"],
+            "architectures": ["amd64"],
+            "sha256": {
+                "main/binary-amd64/Packages.gz": ("abc", 1000),
+                "main/Contents-amd64.gz": ("def", 5000),
+            },
+        }
+        repo_config = RepositoryConfig(
+            id="test-repo",
+            name="Test Repo",
+            type="apt",
+            feed="https://example.com/repo",
+            mode="mirror",
+            apt=AptConfig(
+                distribution="jammy",
+                components=["main"],
+                architectures=["amd64"],
+                include_contents=True,
+            ),
+        )
+        plugin = AptSyncPlugin(storage=None, config=repo_config, proxy_config=None, ssl_config=None)
+
+        mirror = plugin._build_metadata_file_list(release_metadata, "mirror")
+        contents = [f for f in mirror if f.file_type == "Contents"]
+        assert len(contents) == 1
+        assert contents[0].relative_path == "main/Contents-amd64.gz"
+
+        # Filtered mode drops Contents entirely.
+        filtered = plugin._build_metadata_file_list(release_metadata, "filtered")
+        assert not [f for f in filtered if f.file_type == "Contents"]
+
+        # Default (include_contents=False) discovers no Contents.
+        repo_config.apt.include_contents = False
+        none = plugin._build_metadata_file_list(release_metadata, "mirror")
+        assert not [f for f in none if f.file_type == "Contents"]
+
+    def test_build_metadata_file_list_contents_variants_and_dedup(self):
+        """Contents-all/udeb/.xz variants are picked up; suite-level deduped."""
+        from chantal.core.config import AptConfig, RepositoryConfig
+
+        release_metadata = {
+            "components": ["main", "universe"],
+            "architectures": ["amd64"],
+            "sha256": {
+                "main/binary-amd64/Packages.gz": ("p1", 1),
+                "universe/binary-amd64/Packages.gz": ("p2", 1),
+                "main/Contents-amd64.xz": ("c1", 1),  # .xz variant
+                "main/Contents-all.gz": ("c2", 1),  # arch "all"
+                "universe/Contents-udeb-amd64.gz": ("c3", 1),  # udeb variant
+                "Contents-amd64.gz": ("c4", 1),  # suite-level (no component)
+            },
+        }
+        repo_config = RepositoryConfig(
+            id="test-repo",
+            name="Test Repo",
+            type="apt",
+            feed="https://example.com/repo",
+            mode="mirror",
+            apt=AptConfig(
+                distribution="jammy",
+                components=["main", "universe"],
+                architectures=["amd64"],
+                include_contents=True,
+            ),
+        )
+        plugin = AptSyncPlugin(storage=None, config=repo_config, proxy_config=None, ssl_config=None)
+
+        contents = [
+            f.relative_path
+            for f in plugin._build_metadata_file_list(release_metadata, "mirror")
+            if f.file_type == "Contents"
+        ]
+        # Each present variant discovered exactly once (suite-level not duplicated
+        # across the two components).
+        assert sorted(contents) == sorted(
+            [
+                "main/Contents-amd64.xz",
+                "main/Contents-all.gz",
+                "universe/Contents-udeb-amd64.gz",
+                "Contents-amd64.gz",
+            ]
+        )
+
 
 class TestMetadataFileInfo:
     """Tests for MetadataFileInfo dataclass."""


### PR DESCRIPTION
## Summary

#57 item 3. Mirror the `Contents-<arch>` indices (the file→package map used by `apt-file`) when `include_contents` is set.

**Mirror mode only.** An accurate *filtered* Contents would need per-`.deb` file-list extraction chantal does not do, and republishing the upstream one would reference filtered-out packages — so Contents are **dropped in filtered mode** (not downloaded, not published, not in Release).

## Changes

- **Config**: `AptConfig.include_contents` (default false); schema regenerated.
- **Sync**: discover Contents entries (components × architectures+`all` × udeb/normal × `.gz`/`.xz`/none, component-scoped then suite-level), gated on presence in the Release SHA256 map + `include_contents` + mirror mode, deduped. They use the generic metadata download/store path (no per-package handling).
- **Publisher**: carve Contents out of `_publish_metadata_files` (which flattens nested paths) into `_publish_contents_files`, hardlinking each index to its full dists-relative path and feeding its checksums into the regenerated `Release` via a new `extra_files` arg.

## Tests

- Unit: discovery, the `Contents-all`/`udeb`/`.xz` variants, suite-level cross-component dedup, mirror-vs-filtered, default-off.
- E2E: mirror (published at the component path — not flattened — and referenced in `Release` with a matching checksum); filtered (dropped, no `Contents-` in `Release`).

## Review notes

Fresh-context review found no blockers. Its SHOULD-FIX (a `hosted`-mode repo would download Contents but never publish them) is fixed by tightening the sync gate to mirror-only. Pre-existing `_publish_metadata_files` flattening of upstream `Packages.gz`/`Sources.gz` is left as-is (doesn't collide with Contents; tracked separately).

Part of #57