### PR TITLE
feat(apt): mirror i18n Translation files and i18n/Index

### DIFF
--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -27,6 +27,7 @@ The APT plugin consists of:
 - ✅ Pattern-based package filtering
 - ✅ Source package mirroring (`.dsc` / `.orig.tar.*` / `.debian.tar.*`) + `Sources` regeneration
 - ✅ `Contents-<arch>` index mirroring (apt-file; mirror mode)
+- ✅ Translation/i18n mirroring (`i18n/Translation-*` + `i18n/Index`; mirror mode)
 - ✅ Version filtering (only latest)
 
 **Metadata Support:**
@@ -39,7 +40,6 @@ The APT plugin consists of:
 - ✅ Dependency metadata (Depends, Recommends, Suggests, Conflicts, etc.)
 
 **Planned:**
-- 🚧 Translation files (i18n)
 - 🚧 diff/Index support
 
 ## Configuration
@@ -170,6 +170,15 @@ The `apt` section in repository configuration supports these options:
     that chantal does not perform, and shipping the upstream one would reference
     packages that were filtered out.
   - Note: Contents files are large (tens to hundreds of MB).
+
+- **`include_translations`** (boolean, default: false)
+  - Mirror the `i18n/Translation-<lang>.{gz,xz,bz2}` files (localized package
+    descriptions) and the `i18n/Index`, for every language/variant present in
+    `Release`, republished verbatim and referenced in the regenerated `Release`.
+  - **Mirror mode only** (dropped in filtered mode, like `include_contents`):
+    regenerating localized descriptions for the filtered set would require
+    remapping each kept package's `Description-md5`; the full descriptions are
+    already carried inline in the regenerated `Packages`.
 
 - **`flat_repository`** (boolean, default: false)
   - Support for flat repositories (no dists/ structure)

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -58,6 +58,12 @@
           "description": "Mirror Contents-<arch> indices (apt-file). Large; mirror mode only.",
           "title": "Include Contents",
           "type": "boolean"
+        },
+        "include_translations": {
+          "default": false,
+          "description": "Mirror i18n/Translation-* files and i18n/Index (localized package descriptions). Mirror mode only.",
+          "title": "Include Translations",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -166,6 +166,13 @@ class AptConfig(BaseModel):
         default=False,
         description="Mirror Contents-<arch> indices (apt-file). Large; mirror mode only.",
     )
+    include_translations: bool = Field(
+        default=False,
+        description=(
+            "Mirror i18n/Translation-* files and i18n/Index (localized package "
+            "descriptions). Mirror mode only."
+        ),
+    )
 
 
 class GpgConfig(BaseModel):

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -183,15 +183,18 @@ class AptPublisher(PublisherPlugin):
             )
 
         # In mirror mode, publish all metadata files (Release, InRelease, etc.)
-        # and the Contents indices (filtered mode drops Contents entirely).
-        contents_files: list[tuple[str, Path]] = []
+        # and the verbatim Contents/Translation indices (filtered mode drops
+        # them entirely).
+        passthrough_files: list[tuple[str, Path]] = []
         if mode == RepositoryMode.MIRROR:
             self._publish_metadata_files(repository_files, dists_path)
-            contents_files = self._publish_contents_files(repository_files, dists_path)
+            passthrough_files = self._publish_passthrough_files(
+                repository_files, dists_path, ("Contents", "Translation")
+            )
 
         # Generate Release file (always generated, even in mirror mode for completeness)
         release_file = self._generate_release_file(
-            dists_path, published_metadata, repository_files, mode, extra_files=contents_files
+            dists_path, published_metadata, repository_files, mode, extra_files=passthrough_files
         )
 
         # In filtered mode the regenerated Release invalidates upstream signatures.
@@ -544,9 +547,10 @@ class AptPublisher(PublisherPlugin):
             if repo_file.file_category != "metadata":
                 continue
 
-            # Contents indices are placed by _publish_contents_files at their
-            # full dists-relative path (this method flattens nested paths).
-            if repo_file.file_type == "Contents":
+            # Contents/Translation indices are placed by
+            # _publish_passthrough_files at their full dists-relative path (this
+            # method flattens nested paths).
+            if repo_file.file_type in ("Contents", "Translation"):
                 continue
 
             # Get pool path
@@ -589,13 +593,17 @@ class AptPublisher(PublisherPlugin):
 
             print(f"  ✓ Published {repo_file.file_type}: {relative_path}")
 
-    def _publish_contents_files(
-        self, repository_files: list[RepositoryFile], dists_path: Path
+    def _publish_passthrough_files(
+        self,
+        repository_files: list[RepositoryFile],
+        dists_path: Path,
+        file_types: tuple[str, ...],
     ) -> list[tuple[str, Path]]:
-        """Publish Contents-<arch> indices at their dists-relative location.
+        """Publish verbatim metadata indices at their dists-relative location.
 
-        Contents indices are stored with a dists-relative ``original_path``
-        (e.g. ``main/Contents-amd64.gz``) and republished verbatim. Returns
+        Used for Contents and i18n/Translation indices, which are stored with a
+        dists-relative ``original_path`` (e.g. ``main/Contents-amd64.gz`` or
+        ``main/i18n/Translation-en.gz``) and republished verbatim. Returns
         ``(relative_path, published_path)`` tuples so the regenerated Release
         can reference them.
         """
@@ -603,7 +611,7 @@ class AptPublisher(PublisherPlugin):
 
         published: list[tuple[str, Path]] = []
         for repo_file in repository_files:
-            if repo_file.file_type != "Contents":
+            if repo_file.file_type not in file_types:
                 continue
 
             pool_file_path = self.storage.pool_path / repo_file.pool_path
@@ -619,7 +627,7 @@ class AptPublisher(PublisherPlugin):
             os.link(pool_file_path, target_path)
 
             published.append((relative_path, target_path))
-            print(f"  ✓ Published Contents: {relative_path}")
+            print(f"  ✓ Published {repo_file.file_type}: {relative_path}")
 
         return published
 

--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -612,6 +612,29 @@ class AptSyncPlugin:
                                 )
                                 seen.add(path)
 
+            # i18n Translation files + i18n/Index (localized descriptions).
+            # Mirror mode only (same rationale as Contents). A prefix scan
+            # captures every present language, compression variant and the
+            # Index in one pass.
+            if self.apt_config.include_translations and mode == "mirror":
+                seen = {m.relative_path for m in metadata_files}
+                prefix = f"{component}/i18n/"
+                for path in sha256_checksums:
+                    if path in seen or not path.startswith(prefix):
+                        continue
+                    checksum, size = sha256_checksums[path]
+                    metadata_files.append(
+                        MetadataFileInfo(
+                            file_type="Translation",
+                            relative_path=path,
+                            checksum=checksum,
+                            size=size,
+                            component=component,
+                            architecture=None,
+                        )
+                    )
+                    seen.add(path)
+
         return metadata_files
 
     def _download_metadata_file(

--- a/tests/e2e/test_apt_translation_e2e.py
+++ b/tests/e2e/test_apt_translation_e2e.py
@@ -1,0 +1,125 @@
+"""
+End-to-end test: APT i18n Translation mirroring.
+
+With ``include_translations: true`` in MIRROR mode the Translation files and the
+``i18n/Index`` are downloaded, republished at their component i18n path, and
+referenced in the regenerated Release. FILTERED mode drops them.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _build_apt_upstream_with_translations(root: Path) -> None:
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    (root / deb_rel).write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo\n"
+        "\n"
+    ).encode()
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    # i18n Translation file + Index.
+    i18n_dir = root / "dists" / DIST / COMP / "i18n"
+    i18n_dir.mkdir(parents=True, exist_ok=True)
+    translation = b"Package: demo\nDescription-md5: 0123456789abcdef\nDescription-en: A demo\n"
+    translation_gz = gzip.compress(translation)
+    (i18n_dir / "Translation-en.gz").write_bytes(translation_gz)
+    index = (
+        b"SHA256:\n"
+        + f" {hashlib.sha256(translation_gz).hexdigest()} {len(translation_gz)} Translation-en.gz\n".encode()
+    )
+    (i18n_dir / "Index").write_bytes(index)
+
+    sha = hashlib.sha256
+
+    def _rel(path, data):
+        return f" {sha(data).hexdigest()} {len(data)} {path}\n"
+
+    release = (
+        "Origin: Test\n"
+        f"Suite: {DIST}\n"
+        f"Codename: {DIST}\n"
+        f"Components: {COMP}\n"
+        f"Architectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\n"
+        "SHA256:\n"
+        + _rel(f"{COMP}/binary-{ARCH}/Packages", packages)
+        + _rel(f"{COMP}/binary-{ARCH}/Packages.gz", packages_gz)
+        + _rel(f"{COMP}/i18n/Translation-en.gz", translation_gz)
+        + _rel(f"{COMP}/i18n/Index", index)
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def _config(repo_id: str, base_url: str, mode: str) -> dict:
+    return {
+        "id": repo_id,
+        "name": repo_id,
+        "type": "apt",
+        "feed": base_url,
+        "enabled": True,
+        "mode": mode,
+        "apt": {
+            "distribution": DIST,
+            "components": [COMP],
+            "architectures": [ARCH],
+            "include_translations": True,
+        },
+    }
+
+
+def test_apt_translation_mirror_published(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream_with_translations(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-i18n", base_url, "mirror"))
+    target = chantal_env.sync_and_publish("demo-apt-i18n")
+
+    i18n = target / "dists" / DIST / COMP / "i18n"
+    published = i18n / "Translation-en.gz"
+    assert published.exists(), "Translation not republished at i18n path"
+    assert (i18n / "Index").exists(), "i18n/Index not republished"
+
+    release_text = (target / "dists" / DIST / "Release").read_text()
+    assert f"{COMP}/i18n/Translation-en.gz" in release_text, "Release missing Translation"
+    assert f"{COMP}/i18n/Index" in release_text, "Release missing i18n/Index"
+    assert hashlib.sha256(published.read_bytes()).hexdigest() in release_text
+
+
+def test_apt_translation_dropped_in_filtered_mode(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream_with_translations(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-i18n-filtered", base_url, "filtered"))
+    target = chantal_env.sync_and_publish("demo-apt-i18n-filtered")
+
+    assert not list(target.rglob("Translation-*")), "Translation must be dropped in filtered mode"
+    release_text = (target / "dists" / DIST / "Release").read_text()
+    assert "i18n/Translation" not in release_text, "filtered Release must not reference Translation"

--- a/tests/test_apt_sync.py
+++ b/tests/test_apt_sync.py
@@ -328,6 +328,64 @@ class TestReleaseFileParsing:
             ]
         )
 
+    def test_build_metadata_file_list_translations(self):
+        """i18n Translation files + Index are discovered (mirror only)."""
+        from chantal.core.config import AptConfig, RepositoryConfig
+
+        release_metadata = {
+            "components": ["main", "universe"],
+            "architectures": ["amd64"],
+            "sha256": {
+                "main/binary-amd64/Packages.gz": ("p1", 1),
+                "universe/binary-amd64/Packages.gz": ("p2", 1),
+                "main/i18n/Translation-en.gz": ("t1", 1),
+                "main/i18n/Translation-de.xz": ("t2", 1),
+                "main/i18n/Index": ("t3", 1),
+                "universe/i18n/Translation-en.gz": ("t4", 1),
+            },
+        }
+        repo_config = RepositoryConfig(
+            id="test-repo",
+            name="Test Repo",
+            type="apt",
+            feed="https://example.com/repo",
+            mode="mirror",
+            apt=AptConfig(
+                distribution="jammy",
+                components=["main", "universe"],
+                architectures=["amd64"],
+                include_translations=True,
+            ),
+        )
+        plugin = AptSyncPlugin(storage=None, config=repo_config, proxy_config=None, ssl_config=None)
+
+        translations = [
+            f.relative_path
+            for f in plugin._build_metadata_file_list(release_metadata, "mirror")
+            if f.file_type == "Translation"
+        ]
+        assert sorted(translations) == sorted(
+            [
+                "main/i18n/Translation-en.gz",
+                "main/i18n/Translation-de.xz",
+                "main/i18n/Index",
+                "universe/i18n/Translation-en.gz",
+            ]
+        )
+
+        # Filtered mode drops Translation; default flag discovers none.
+        assert not [
+            f
+            for f in plugin._build_metadata_file_list(release_metadata, "filtered")
+            if f.file_type == "Translation"
+        ]
+        repo_config.apt.include_translations = False
+        assert not [
+            f
+            for f in plugin._build_metadata_file_list(release_metadata, "mirror")
+            if f.file_type == "Translation"
+        ]
+
 
 class TestMetadataFileInfo:
     """Tests for MetadataFileInfo dataclass."""


### PR DESCRIPTION
## Summary

#57 item 4. Mirror the localized package-description indices (`i18n/Translation-<lang>.*` + `i18n/Index`) when `include_translations` is set. **Mirror mode only**, consistent with `include_contents`: a filtered Translation would need per-package `Description-md5` remapping, and the full descriptions are already inline in the regenerated `Packages`.

## Changes

- **Config**: `AptConfig.include_translations` (default false); schema regenerated.
- **Sync**: discover i18n entries via a prefix scan of the Release SHA256 map (`{component}/i18n/`), capturing every language, compression variant and the `Index` in one pass; gated on `include_translations` + mirror mode, deduped.
- **Publisher**: generalize `_publish_contents_files` → `_publish_passthrough_files(file_types)` and extend the `_publish_metadata_files` skip to `Translation`, so both Contents and Translation hardlink to their dists-relative path and feed their checksums into the regenerated `Release`.

## Tests

- Unit: discovery incl. `Index`, multi-component, `.xz` variant, mirror-vs-filtered, default-off.
- E2E: mirror (publishes Translation + Index at the i18n path + references both in `Release` with a matching checksum); filtered (drops both).

## Review notes

Fresh-context review: **no blockers, no SHOULD-FIX**. NITs only — pdiff (`Translation-*.diff/Index`) remains out of scope and is tracked under the planned diff/Index item.

Part of #57