### PR TITLE
feat(apt): by-hash acquisition and publishing (Acquire-By-Hash)

### DIFF
--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -28,6 +28,7 @@ The APT plugin consists of:
 - ✅ Source package mirroring (`.dsc` / `.orig.tar.*` / `.debian.tar.*`) + `Sources` regeneration
 - ✅ `Contents-<arch>` index mirroring (apt-file; mirror mode)
 - ✅ Translation/i18n mirroring (`i18n/Translation-*` + `i18n/Index`; mirror mode)
+- ✅ `by-hash` acquisition and publishing (`Acquire-By-Hash`)
 - ✅ Version filtering (only latest)
 
 **Metadata Support:**
@@ -179,6 +180,14 @@ The `apt` section in repository configuration supports these options:
     regenerating localized descriptions for the filtered set would require
     remapping each kept package's `Description-md5`; the full descriptions are
     already carried inline in the regenerated `Packages`.
+
+- **`by_hash`** (boolean, default: false)
+  - On **sync**, fetch each index from `by-hash/SHA256/<checksum>` (falling back
+    to the plain path when upstream has no by-hash tree) so a mirror stays
+    consistent while upstream is being updated.
+  - On **publish**, emit `by-hash/SHA256/<sha256>` copies of every regenerated
+    index (Packages/Sources/Contents/Translation) and set `Acquire-By-Hash: yes`
+    in the generated `Release`. Recommended `true` for modern apt clients.
 
 - **`flat_repository`** (boolean, default: false)
   - Support for flat repositories (no dists/ structure)

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -64,6 +64,12 @@
           "description": "Mirror i18n/Translation-* files and i18n/Index (localized package descriptions). Mirror mode only.",
           "title": "Include Translations",
           "type": "boolean"
+        },
+        "by_hash": {
+          "default": false,
+          "description": "Use/publish by-hash indices. On sync, fetch indices via by-hash/SHA256/<checksum> (falling back to the plain path). On publish, emit by-hash/SHA256/ copies and set Acquire-By-Hash: yes in the generated Release.",
+          "title": "By Hash",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -173,6 +173,15 @@ class AptConfig(BaseModel):
             "descriptions). Mirror mode only."
         ),
     )
+    by_hash: bool = Field(
+        default=False,
+        description=(
+            "Use/publish by-hash indices. On sync, fetch indices via "
+            "by-hash/SHA256/<checksum> (falling back to the plain path). On "
+            "publish, emit by-hash/SHA256/ copies and set Acquire-By-Hash: yes "
+            "in the generated Release."
+        ),
+    )
 
 
 class GpgConfig(BaseModel):

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -631,6 +631,37 @@ class AptPublisher(PublisherPlugin):
 
         return published
 
+    def _emit_by_hash(
+        self, file_path: Path, sha256_hex: str, emitted: dict[Path, set[str]]
+    ) -> None:
+        """Hardlink ``file_path`` into its sibling ``by-hash/SHA256/<sha>`` dir.
+
+        apt fetches indices from these content-addressed copies so a mirror
+        stays consistent while it is being updated. The emitted sha is recorded
+        in ``emitted`` so stale entries can be pruned afterwards.
+        """
+        import os
+
+        by_hash_dir = file_path.parent / "by-hash" / "SHA256"
+        by_hash_dir.mkdir(parents=True, exist_ok=True)
+        target = by_hash_dir / sha256_hex
+        if target.exists():
+            target.unlink()
+        os.link(file_path, target)
+        emitted.setdefault(by_hash_dir, set()).add(sha256_hex)
+
+    def _prune_by_hash(self, emitted: dict[Path, set[str]]) -> None:
+        """Remove by-hash entries left over from previous publishes.
+
+        Content-addressed by-hash files are never overwritten in place, so a
+        republish into an existing target would otherwise accumulate stale
+        entries indefinitely.
+        """
+        for by_hash_dir, keep in emitted.items():
+            for entry in by_hash_dir.iterdir():
+                if entry.is_file() and entry.name not in keep:
+                    entry.unlink()
+
     def _generate_release_file(
         self,
         dists_path: Path,
@@ -687,7 +718,13 @@ class AptPublisher(PublisherPlugin):
         # Description
         release_lines.append(f"Description: {self.config.name}")
 
+        # Advertise by-hash availability for the indices listed below.
+        if self.apt_config.by_hash:
+            release_lines.append("Acquire-By-Hash: yes")
+
         # Build file checksums
+        by_hash = self.apt_config.by_hash
+        by_hash_emitted: dict[Path, set[str]] = {}
         md5sums = []
         sha1sums = []
         sha256sums = []
@@ -715,18 +752,27 @@ class AptPublisher(PublisherPlugin):
                 size = len(data)
                 rel = f"{rel_prefix}/{variant}"
 
+                sha = hashlib.sha256(data).hexdigest()
                 md5sums.append(f" {hashlib.md5(data).hexdigest()} {size:8} {rel}")
                 sha1sums.append(f" {hashlib.sha1(data).hexdigest()} {size:8} {rel}")
-                sha256sums.append(f" {hashlib.sha256(data).hexdigest()} {size:8} {rel}")
+                sha256sums.append(f" {sha} {size:8} {rel}")
+                if by_hash:
+                    self._emit_by_hash(variant_path, sha, by_hash_emitted)
 
         # Extra metadata files (e.g. Contents indices) referenced by their
         # dists-relative path.
         for rel, file_path in extra_files or []:
             data = file_path.read_bytes()
             size = len(data)
+            sha = hashlib.sha256(data).hexdigest()
             md5sums.append(f" {hashlib.md5(data).hexdigest()} {size:8} {rel}")
             sha1sums.append(f" {hashlib.sha1(data).hexdigest()} {size:8} {rel}")
-            sha256sums.append(f" {hashlib.sha256(data).hexdigest()} {size:8} {rel}")
+            sha256sums.append(f" {sha} {size:8} {rel}")
+            if by_hash:
+                self._emit_by_hash(file_path, sha, by_hash_emitted)
+
+        if by_hash:
+            self._prune_by_hash(by_hash_emitted)
 
         # Add checksum sections
         if md5sums:

--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -10,7 +10,7 @@ Supports mirror mode (1:1 copy with all metadata and GPG signatures preserved).
 import logging
 import tempfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from urllib.parse import urljoin
 
 from sqlalchemy.orm import Session
@@ -637,6 +637,13 @@ class AptSyncPlugin:
 
         return metadata_files
 
+    @staticmethod
+    def _by_hash_url(dists_url: str, relative_path: str, checksum: str) -> str:
+        """Build the by-hash URL for an index (sibling ``by-hash/SHA256/<h>``)."""
+        parent = PurePosixPath(relative_path).parent
+        prefix = "" if str(parent) == "." else f"{parent}/"
+        return urljoin(dists_url, f"{prefix}by-hash/SHA256/{checksum}")
+
     def _download_metadata_file(
         self,
         session: Session,
@@ -663,9 +670,27 @@ class AptSyncPlugin:
             tmp_path = Path(tmp_file.name)
 
             try:
-                # Download file
-                response = self.session.get(metadata_url, timeout=120)
-                response.raise_for_status()
+                # Download file. With by-hash enabled, fetch the content-addressed
+                # copy first (atomic during upstream updates) and fall back to the
+                # plain path when upstream has no by-hash tree.
+                response = None
+                if self.apt_config.by_hash:
+                    by_hash_url = self._by_hash_url(
+                        dists_url, metadata_info.relative_path, metadata_info.checksum
+                    )
+                    try:
+                        candidate = self.session.get(by_hash_url, timeout=120)
+                        candidate.raise_for_status()
+                        response = candidate
+                    except Exception as by_hash_error:
+                        logger.debug(
+                            f"by-hash fetch failed for {metadata_info.relative_path}, "
+                            f"falling back to the plain path: {by_hash_error}"
+                        )
+                        response = None
+                if response is None:
+                    response = self.session.get(metadata_url, timeout=120)
+                    response.raise_for_status()
 
                 # Write to temp file
                 tmp_file.write(response.content)

--- a/tests/e2e/test_apt_byhash_e2e.py
+++ b/tests/e2e/test_apt_byhash_e2e.py
@@ -1,0 +1,194 @@
+"""
+End-to-end test: APT by-hash support.
+
+Acquisition: with ``by_hash: true`` sync fetches indices from
+``by-hash/SHA256/<checksum>`` (falling back to the plain path). Publishing:
+emit ``by-hash/SHA256/`` copies of every regenerated index and set
+``Acquire-By-Hash: yes`` in the generated Release.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _packages_and_release(root: Path):
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    (root / deb_rel).write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo\n"
+        "\n"
+    ).encode()
+    packages_gz = gzip.compress(packages)
+
+    def _rel(path, data):
+        return f" {hashlib.sha256(data).hexdigest()} {len(data)} {path}\n"
+
+    release = (
+        "Origin: Test\n"
+        f"Suite: {DIST}\n"
+        f"Codename: {DIST}\n"
+        f"Components: {COMP}\n"
+        f"Architectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\n"
+        "Acquire-By-Hash: yes\n"
+        "SHA256:\n" + _rel(f"{COMP}/binary-{ARCH}/Packages.gz", packages_gz)
+    )
+    dist_dir = root / "dists" / DIST
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    (dist_dir / "Release").write_text(release, encoding="utf-8")
+    return packages_gz
+
+
+def _build_byhash_only_upstream(root: Path) -> None:
+    """Serve Packages.gz ONLY under by-hash/SHA256 (plain path 404s)."""
+    packages_gz = _packages_and_release(root)
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    by_hash = comp_dir / "by-hash" / "SHA256"
+    by_hash.mkdir(parents=True, exist_ok=True)
+    (by_hash / hashlib.sha256(packages_gz).hexdigest()).write_bytes(packages_gz)
+    # Note: the plain Packages.gz is intentionally NOT written.
+
+
+def _build_plain_upstream(root: Path) -> None:
+    packages_gz = _packages_and_release(root)
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+
+def _config(repo_id, base_url, mode, by_hash):
+    return {
+        "id": repo_id,
+        "name": repo_id,
+        "type": "apt",
+        "feed": base_url,
+        "enabled": True,
+        "mode": mode,
+        "apt": {
+            "distribution": DIST,
+            "components": [COMP],
+            "architectures": [ARCH],
+            "by_hash": by_hash,
+        },
+    }
+
+
+def test_apt_byhash_acquisition(tmp_path, serve, chantal_env):
+    # Upstream serves the index only via by-hash; sync must fetch it there.
+    upstream = tmp_path / "upstream"
+    _build_byhash_only_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-byhash-acq", base_url, "mirror", True))
+    target = chantal_env.sync_and_publish("demo-apt-byhash-acq")
+    assert list(target.rglob("demo_1.0_amd64.deb")), "by-hash index not fetched / package missing"
+
+
+def test_apt_byhash_acquisition_disabled_fails(tmp_path, serve, chantal_env):
+    # Without by_hash the plain path 404s, so no package is synced.
+    upstream = tmp_path / "upstream"
+    _build_byhash_only_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-byhash-off", base_url, "mirror", False))
+    chantal_env.run("repo", "sync", "--repo-id", "demo-apt-byhash-off", "-v", check=False)
+    assert not list(chantal_env.pool.rglob("*.deb")), "plain-path 404 should yield no package"
+
+
+def test_apt_byhash_publishing(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_plain_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-byhash-pub", base_url, "mirror", True))
+    target = chantal_env.sync_and_publish("demo-apt-byhash-pub")
+
+    comp_dir = target / "dists" / DIST / COMP / f"binary-{ARCH}"
+    by_hash = comp_dir / "by-hash" / "SHA256"
+    assert by_hash.is_dir(), "by-hash/SHA256 dir not created"
+
+    # Every regenerated index has a by-hash copy named by its own sha256.
+    for index in ("Packages", "Packages.gz"):
+        idx = comp_dir / index
+        assert idx.exists()
+        sha = hashlib.sha256(idx.read_bytes()).hexdigest()
+        copy = by_hash / sha
+        assert copy.exists(), f"by-hash copy missing for {index}"
+        assert hashlib.sha256(copy.read_bytes()).hexdigest() == sha
+
+    release_text = (target / "dists" / DIST / "Release").read_text()
+    assert "Acquire-By-Hash: yes" in release_text
+
+
+def test_apt_byhash_publishing_filtered(tmp_path, serve, chantal_env):
+    # by-hash publishing also applies in filtered mode (Release regenerated).
+    upstream = tmp_path / "upstream"
+    _build_plain_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-byhash-filt", base_url, "filtered", True))
+    target = chantal_env.sync_and_publish("demo-apt-byhash-filt")
+
+    comp_dir = target / "dists" / DIST / COMP / f"binary-{ARCH}"
+    by_hash = comp_dir / "by-hash" / "SHA256"
+    assert by_hash.is_dir(), "by-hash not emitted in filtered mode"
+    pkg = comp_dir / "Packages"
+    assert (by_hash / hashlib.sha256(pkg.read_bytes()).hexdigest()).exists()
+    assert "Acquire-By-Hash: yes" in (target / "dists" / DIST / "Release").read_text()
+
+
+def test_apt_byhash_prune_stale(tmp_path, serve, chantal_env):
+    # Re-publishing prunes stale content-addressed entries from a prior publish.
+    upstream = tmp_path / "upstream"
+    _build_plain_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-byhash-prune", base_url, "mirror", True))
+    target = chantal_env.sync_and_publish("demo-apt-byhash-prune")
+
+    comp_dir = target / "dists" / DIST / COMP / f"binary-{ARCH}"
+    by_hash = comp_dir / "by-hash" / "SHA256"
+    stale = by_hash / ("0" * 64)
+    stale.write_bytes(b"stale entry from a previous publish")
+
+    chantal_env.run(
+        "publish", "repo", "--repo-id", "demo-apt-byhash-prune", "--target", str(target)
+    )
+
+    assert not stale.exists(), "stale by-hash entry not pruned on republish"
+    # The current index still has its by-hash entry.
+    pkg_gz = comp_dir / "Packages.gz"
+    assert (by_hash / hashlib.sha256(pkg_gz.read_bytes()).hexdigest()).exists()
+
+
+def test_apt_byhash_disabled_no_dirs(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_plain_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(_config("demo-apt-byhash-none", base_url, "mirror", False))
+    target = chantal_env.sync_and_publish("demo-apt-byhash-none")
+
+    assert not list(target.rglob("by-hash")), "no by-hash dirs when disabled"
+    release_text = (target / "dists" / DIST / "Release").read_text()
+    assert "Acquire-By-Hash" not in release_text

--- a/tests/test_apt_sync.py
+++ b/tests/test_apt_sync.py
@@ -387,6 +387,21 @@ class TestReleaseFileParsing:
         ]
 
 
+class TestByHashUrl:
+    """Tests for by-hash URL construction."""
+
+    def test_nested_index(self):
+        url = AptSyncPlugin._by_hash_url(
+            "http://h/dists/jammy/", "main/binary-amd64/Packages.gz", "abc123"
+        )
+        assert url == "http://h/dists/jammy/main/binary-amd64/by-hash/SHA256/abc123"
+
+    def test_top_level_index(self):
+        # A suite-level file (parent == ".") must not get a "./" prefix.
+        url = AptSyncPlugin._by_hash_url("http://h/dists/jammy/", "Contents-amd64.gz", "deadbeef")
+        assert url == "http://h/dists/jammy/by-hash/SHA256/deadbeef"
+
+
 class TestMetadataFileInfo:
     """Tests for MetadataFileInfo dataclass."""
 


### PR DESCRIPTION
## Summary

#57 item 5 — the **last APT core item**. by-hash support so a mirror stays consistent while upstream is updating. One flag (`AptConfig.by_hash`, default false) controls both sides.

## Changes

- **Sync**: fetch each index from `by-hash/SHA256/<checksum>` first (the checksum is already known from `Release`), falling back to the plain path on error. SHA256 verification of the downloaded bytes is unchanged. `Release`/`InRelease` are correctly not by-hash.
- **Publish**: emit `by-hash/SHA256/<sha>` hardlink copies of every regenerated index (Packages/Sources/Contents/Translation) using the sha already computed for the `Release` block; set `Acquire-By-Hash: yes`; and **prune stale** content-addressed entries on republish so by-hash dirs don't grow unboundedly. Mirror and filtered mode.

## Tests

- Unit: by-hash URL construction (nested + top-level edge case).
- E2E: by-hash-only-upstream acquisition (+ disabled-fails control), publishing copies + `Acquire-By-Hash` in **mirror and filtered**, **stale-prune on republish**, default-off.

## Review notes

Fresh-context review: no blockers. Both SHOULD-FIX addressed — stale by-hash pruning (S1, with a republish test) and a debug log on by-hash fallback (S2). Acquisition is sound: the SHA256 verification against the signed `Release` checksum runs regardless of which URL served the bytes.

With this, **all five APT core items of #57 are complete.** The Advanced/optional section (pdiffs, `Architecture: all` dedup, Release-field parity) remains.

Closes #57