### PR TITLE
ci: add semantic-release and PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - main  # stable releases -> TestPyPI + PyPI
+      - rc     # release candidates -> TestPyPI only
   workflow_dispatch:
 
 permissions:
@@ -92,10 +93,13 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [test, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rc')
     outputs:
       released: ${{ steps.semantic.outputs.released }}
       version: ${{ steps.semantic.outputs.version }}
+      is_prerelease: ${{ steps.semantic.outputs.is_prerelease }}
 
     steps:
       - name: Checkout code
@@ -155,7 +159,8 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.released == 'true'
+    # Stable releases only - prereleases (rc) never reach PyPI.
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false'
     environment:
       name: pypi
       url: https://pypi.org/project/chantal/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,183 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  test:
+    name: Test and Lint Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12', '3.13', '3.14']
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run ruff (linting)
+        run: ruff check src/chantal/ tests/ --output-format=github
+
+      - name: Run black (code formatting check)
+        run: black --check --diff src/chantal/ tests/
+
+      - name: Run yamllint (YAML linting)
+        run: yamllint --strict examples/ .github/
+
+      - name: Run mypy (type checking)
+        run: mypy src/chantal/ --ignore-missing-imports
+
+      - name: Run pytest (unit tests)
+        run: pytest tests/ -v --tb=short -m "not e2e"
+
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package
+        run: twine check dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      released: ${{ steps.semantic.outputs.released }}
+      version: ${{ steps.semantic.outputs.version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Python Semantic Release
+        id: semantic
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          changelog: false
+          vcs_release: true
+          tag: true
+          commit: true
+          push: true
+          root_options: "-vv"
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    continue-on-error: true
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/chantal/
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    environment:
+      name: pypi
+      url: https://pypi.org/project/chantal/
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,3 +153,26 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "@abstractmethod",
 ]
+
+# Semantic release configuration.
+# Release notes are published only in the GitHub Release (no CHANGELOG.md in the
+# repo); the release workflow passes `changelog: false` to the action.
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+version_variables = ["src/chantal/__init__.py:__version__"]
+build_command = "pip install build && python -m build"
+commit_parser = "conventional"
+major_on_zero = true
+tag_format = "v{version}"
+commit_message = "chore(release): {version} [skip ci]"
+upload_to_pypi = false
+upload_to_release = true
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]
+
+[tool.semantic_release.branches.main]
+match = "(main|master)"
+prerelease = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,3 +176,11 @@ patch_tags = ["fix", "perf"]
 [tool.semantic_release.branches.main]
 match = "(main|master)"
 prerelease = false
+
+# Release-candidate channel: pushing the `rc` branch cuts prerelease versions
+# (e.g. 0.2.0-rc.1). The release workflow publishes prereleases to TestPyPI
+# only, never to PyPI.
+[tool.semantic_release.branches.rc]
+match = "rc"
+prerelease = true
+prerelease_token = "rc"


### PR DESCRIPTION
## Summary

Automated releasing on push to `main`, modeled on the `slauger/check_netscaler` (v10.5.3) and `slauger/gitops-replacer` pattern.

## Changes

- **`[tool.semantic_release]` in `pyproject.toml`**: version managed in `pyproject.toml` (`project.version`) and `src/chantal/__init__.py` (`__version__`); conventional commit parser; `tag_format = v{version}`; `commit_message = chore(release): {version} [skip ci]`. **No `CHANGELOG.md`** is committed — release notes live only in the GitHub Release.
- **`.github/workflows/release.yml`**:
  - **test** matrix (Python 3.12/3.13/3.14): ruff, black, yamllint, mypy, pytest (unit).
  - **build**: `python -m build` + `twine check` + artifact upload.
  - **release** (push to `main` only): `python-semantic-release/python-semantic-release@v10.5.3` with `changelog: false`, `vcs_release: true`, `tag: true`, `commit: true`, `push: true`; outputs `released`/`version`.
  - **publish-testpypi** / **publish-pypi**: `pypa/gh-action-pypi-publish` via **Trusted Publisher (OIDC)** — no tokens. Run only when a release was made, each gated to its GitHub environment.
- **GitHub environments `testpypi` and `pypi`** created for OIDC.

## Manual steps required (outside this repo)

1. **Configure Trusted Publishers** on PyPI and TestPyPI for project `chantal`:
   - Owner `slauger`, repo `chantal`, workflow `release.yml`, environment `pypi` (resp. `testpypi`).
2. **First release**: there is no existing version tag, so the first run on `main` computes the initial version from commit history. If you want to pin the starting point (e.g. keep `0.1.0`), create a `v0.1.0` tag before merging — otherwise semantic-release picks the next version from the conventional commits.

## Validation

- `yamllint --strict` passes on the new workflow.
- `pyproject.toml` parses; `semantic-release --noop version` runs clean (no deprecation; `conventional` parser).

Part of the 1.0.0 roadmap (#32).