### PR TITLE
feat(apt): control generated Release fields (Suite/Codename, NotAutomatic, Valid-Until)

### DIFF
--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -189,6 +189,26 @@ The `apt` section in repository configuration supports these options:
     index (Packages/Sources/Contents/Translation) and set `Acquire-By-Hash: yes`
     in the generated `Release`. Recommended `true` for modern apt clients.
 
+- **Generated `Release` fields** — the published `Release` is regenerated and
+  re-signed, so its header fields are controllable:
+  - **`origin`** / **`label`** — `Origin` / `Label` (default: `Chantal` / the
+    repository name).
+  - **`suite`** / **`codename`** — distinct `Suite` / `Codename` (default: both
+    the `distribution`). Upstream often differs (e.g. Suite `stable`, Codename
+    `bookworm`).
+  - **`not_automatic`** (bool) → `NotAutomatic: yes` (apt won't auto-select this
+    repo's packages — pin priority 1).
+  - **`but_automatic_upgrades`** (bool) → `ButAutomaticUpgrades: yes` (raises the
+    pin to 100 so already-installed packages still upgrade). Only valid together
+    with `not_automatic`.
+  - **`valid_until_days`** (int) → emit `Valid-Until` = publish time + N days.
+    Omitted by default; the upstream date is never copied (it is usually already
+    expired by publish time).
+  - **Note:** changing `suite`/`codename` on an *already-deployed* mirror makes
+    clients fail the next `apt update` with a "Repository changed its Suite/
+    Codename" error until they accept it (`apt update --allow-releaseinfo-change`).
+    Set these once, up front.
+
 - **`flat_repository`** (boolean, default: false)
   - Support for flat repositories (no dists/ structure)
   - Rare, used by some very old repositories

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -70,6 +70,83 @@
           "description": "Use/publish by-hash indices. On sync, fetch indices via by-hash/SHA256/<checksum> (falling back to the plain path). On publish, emit by-hash/SHA256/ copies and set Acquire-By-Hash: yes in the generated Release.",
           "title": "By Hash",
           "type": "boolean"
+        },
+        "origin": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Release Origin field (default: Chantal)",
+          "title": "Origin"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Release Label field (default: repository name)",
+          "title": "Label"
+        },
+        "suite": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Release Suite field (default: distribution)",
+          "title": "Suite"
+        },
+        "codename": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Release Codename field (default: distribution)",
+          "title": "Codename"
+        },
+        "not_automatic": {
+          "default": false,
+          "description": "Emit 'NotAutomatic: yes' so apt does not auto-select this repo's packages",
+          "title": "Not Automatic",
+          "type": "boolean"
+        },
+        "but_automatic_upgrades": {
+          "default": false,
+          "description": "Emit 'ButAutomaticUpgrades: yes' (only valid together with not_automatic)",
+          "title": "But Automatic Upgrades",
+          "type": "boolean"
+        },
+        "valid_until_days": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Emit 'Valid-Until' = publish time + this many days (omitted when unset). Upstream's date is never copied as it is usually already expired by publish time.",
+          "title": "Valid Until Days"
         }
       },
       "required": [

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -183,6 +183,40 @@ class AptConfig(BaseModel):
         ),
     )
 
+    # Generated-Release field overrides (the published Release is regenerated
+    # and re-signed; these control its header fields).
+    origin: str | None = Field(None, description="Release Origin field (default: Chantal)")
+    label: str | None = Field(None, description="Release Label field (default: repository name)")
+    suite: str | None = Field(None, description="Release Suite field (default: distribution)")
+    codename: str | None = Field(None, description="Release Codename field (default: distribution)")
+    not_automatic: bool = Field(
+        default=False,
+        description="Emit 'NotAutomatic: yes' so apt does not auto-select this repo's packages",
+    )
+    but_automatic_upgrades: bool = Field(
+        default=False,
+        description="Emit 'ButAutomaticUpgrades: yes' (only valid together with not_automatic)",
+    )
+    valid_until_days: int | None = Field(
+        default=None,
+        description=(
+            "Emit 'Valid-Until' = publish time + this many days (omitted when unset). "
+            "Upstream's date is never copied as it is usually already expired by publish time."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_release_fields(self) -> AptConfig:
+        """Validate the generated-Release field options."""
+        if self.but_automatic_upgrades and not self.not_automatic:
+            raise ValueError(
+                "but_automatic_upgrades requires not_automatic (apt only honors "
+                "ButAutomaticUpgrades together with NotAutomatic)"
+            )
+        if self.valid_until_days is not None and self.valid_until_days <= 0:
+            raise ValueError("valid_until_days must be a positive number of days")
+        return self
+
 
 class GpgConfig(BaseModel):
     """GPG signing configuration for APT repositories.

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -8,7 +8,7 @@ This module implements publishing for APT repositories with Debian package metad
 
 import hashlib
 import shutil
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from sqlalchemy.orm import Session
@@ -684,20 +684,31 @@ class AptPublisher(PublisherPlugin):
             Path to generated Release file
         """
         release_lines = []
+        cfg = self.apt_config
+        date_fmt = "%a, %d %b %Y %H:%M:%S UTC"
 
         # Origin and Label
-        release_lines.append("Origin: Chantal")
-        release_lines.append(f"Label: {self.config.name}")
+        release_lines.append(f"Origin: {cfg.origin or 'Chantal'}")
+        release_lines.append(f"Label: {cfg.label or self.config.name}")
 
-        # Suite and Codename
-        release_lines.append(f"Suite: {self.apt_config.distribution}")
-        release_lines.append(f"Codename: {self.apt_config.distribution}")
+        # Suite and Codename (distinct upstream values, e.g. 'stable' vs
+        # 'bookworm'; default both to the configured distribution).
+        release_lines.append(f"Suite: {cfg.suite or cfg.distribution}")
+        release_lines.append(f"Codename: {cfg.codename or cfg.distribution}")
 
-        # Date
+        # Date (and optional relative Valid-Until)
         now = datetime.now(UTC)
-        # Format: "Thu, 12 Jan 2026 10:30:45 UTC"
-        date_str = now.strftime("%a, %d %b %Y %H:%M:%S UTC")
+        date_str = now.strftime(date_fmt)
         release_lines.append(f"Date: {date_str}")
+        if cfg.valid_until_days is not None:
+            valid_until = now + timedelta(days=cfg.valid_until_days)
+            release_lines.append(f"Valid-Until: {valid_until.strftime(date_fmt)}")
+
+        # Apt pinning hints
+        if cfg.not_automatic:
+            release_lines.append("NotAutomatic: yes")
+        if cfg.but_automatic_upgrades:
+            release_lines.append("ButAutomaticUpgrades: yes")
 
         # Architectures
         architectures = sorted(
@@ -719,11 +730,11 @@ class AptPublisher(PublisherPlugin):
         release_lines.append(f"Description: {self.config.name}")
 
         # Advertise by-hash availability for the indices listed below.
-        if self.apt_config.by_hash:
+        if cfg.by_hash:
             release_lines.append("Acquire-By-Hash: yes")
 
         # Build file checksums
-        by_hash = self.apt_config.by_hash
+        by_hash = cfg.by_hash
         by_hash_emitted: dict[Path, set[str]] = {}
         md5sums = []
         sha1sums = []

--- a/tests/e2e/test_apt_release_fields_e2e.py
+++ b/tests/e2e/test_apt_release_fields_e2e.py
@@ -1,0 +1,134 @@
+"""
+End-to-end test: generated-Release field parity.
+
+Asserts the regenerated Release honors the AptConfig overrides: distinct
+Suite/Codename, Origin/Label, NotAutomatic/ButAutomaticUpgrades, and a relative
+Valid-Until.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _build_apt_upstream(root: Path) -> None:
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    (root / deb_rel).write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo\n"
+        "\n"
+    ).encode()
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    sha = hashlib.sha256
+    release = (
+        "Origin: Upstream\n"
+        f"Suite: {DIST}\n"
+        f"Codename: {DIST}\n"
+        f"Components: {COMP}\n"
+        f"Architectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\n"
+        "SHA256:\n"
+        f" {sha(packages).hexdigest()} {len(packages)} {COMP}/binary-{ARCH}/Packages\n"
+        f" {sha(packages_gz).hexdigest()} {len(packages_gz)} {COMP}/binary-{ARCH}/Packages.gz\n"
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def test_apt_release_field_overrides(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt-relfields",
+            "name": "Demo APT Release fields",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {
+                "distribution": DIST,
+                "components": [COMP],
+                "architectures": [ARCH],
+                "origin": "ACME Mirror",
+                "label": "ACME",
+                "suite": "stable",
+                "codename": "bookworm",
+                "not_automatic": True,
+                "but_automatic_upgrades": True,
+                "valid_until_days": 7,
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt-relfields")
+    release = (target / "dists" / DIST / "Release").read_text()
+
+    assert "Origin: ACME Mirror" in release
+    assert "Label: ACME" in release
+    # Suite and Codename are distinct (the key bug this fixes).
+    assert "Suite: stable" in release
+    assert "Codename: bookworm" in release
+    assert "NotAutomatic: yes" in release
+    assert "ButAutomaticUpgrades: yes" in release
+    # Valid-Until must use the same RFC1123-style format as Date (apt parses it).
+    assert re.search(
+        r"Valid-Until: \w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} UTC", release
+    ), "Valid-Until missing or wrong date format"
+
+
+def test_apt_release_defaults(tmp_path, serve, chantal_env):
+    # Without overrides: Origin defaults to Chantal, Suite==Codename==distribution,
+    # and no pinning / Valid-Until fields.
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt-reldefault",
+            "name": "Demo APT defaults",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {"distribution": DIST, "components": [COMP], "architectures": [ARCH]},
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt-reldefault")
+    release = (target / "dists" / DIST / "Release").read_text()
+
+    assert "Origin: Chantal" in release
+    assert "Label: Demo APT defaults" in release  # defaults to the repository name
+    assert f"Suite: {DIST}" in release
+    assert f"Codename: {DIST}" in release
+    assert "NotAutomatic" not in release
+    assert "ButAutomaticUpgrades" not in release
+    assert "Valid-Until" not in release

--- a/tests/test_apt_models.py
+++ b/tests/test_apt_models.py
@@ -371,3 +371,32 @@ class TestAptConfig:
         assert config.distribution == "bookworm"
         assert "contrib" in config.components
         assert "non-free" in config.components
+
+    def test_release_field_overrides(self):
+        from chantal.core.config import AptConfig
+
+        cfg = AptConfig(
+            distribution="jammy",
+            suite="stable",
+            codename="bookworm",
+            origin="ACME",
+            not_automatic=True,
+            but_automatic_upgrades=True,
+            valid_until_days=7,
+        )
+        assert cfg.suite == "stable"
+        assert cfg.codename == "bookworm"
+        assert cfg.but_automatic_upgrades is True
+
+    def test_but_automatic_upgrades_requires_not_automatic(self):
+        from chantal.core.config import AptConfig
+
+        with pytest.raises(ValidationError, match="requires not_automatic"):
+            AptConfig(distribution="jammy", but_automatic_upgrades=True)
+
+    def test_valid_until_days_must_be_positive(self):
+        from chantal.core.config import AptConfig
+
+        for bad in (0, -1):
+            with pytest.raises(ValidationError, match="positive number of days"):
+                AptConfig(distribution="jammy", valid_until_days=bad)


### PR DESCRIPTION
## Summary

#75 item 3. The published `Release` is regenerated and re-signed, so its header fields should be configurable. Adds `AptConfig` overrides and fixes a real bug.

## Changes
- **`origin`/`label`/`suite`/`codename`** overrides. Fixes the **Suite==Codename bug**: both were hardcoded to `distribution`, but upstream often differs (Suite `stable` vs Codename `bookworm`).
- **`not_automatic`** → `NotAutomatic: yes`; **`but_automatic_upgrades`** → `ButAutomaticUpgrades: yes` (validated to require `not_automatic`).
- **`valid_until_days`** → relative `Valid-Until` = publish time + N days (omitted by default; the upstream — usually already-expired — date is never copied).
- Defaults are byte-identical to the previous output.

## Validated with real apt (Docker)
`apt-get update` accepts the repo, and `apt-cache policy` reports priority **100** for the package → `NotAutomatic` + `ButAutomaticUpgrades` are honored by real apt.

## Tests
- Unit: validator rejection paths (`but_automatic_upgrades` without `not_automatic`; non-positive `valid_until_days`).
- E2E: field overrides (distinct Suite/Codename, NotAutomatic/ButAutomaticUpgrades, Valid-Until format) + defaults regression.

## Note
Changing `suite`/`codename` on an already-deployed mirror triggers apt's "Repository changed its Suite/Codename" prompt on the next update — documented in the plugin docs. Set them up front.

Part of #75