### PR TITLE
fix(apt): publish packages in a real pool/ layout so apt can install them

### DIFF
--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -9,7 +9,7 @@ This module implements publishing for APT repositories with Debian package metad
 import hashlib
 import shutil
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from sqlalchemy.orm import Session
 
@@ -158,10 +158,9 @@ class AptPublisher(PublisherPlugin):
 
             component_arch_path.mkdir(parents=True, exist_ok=True)
 
-            # Create hardlinks for packages in this component/arch
-            self._create_package_hardlinks(
-                component_packages, component_arch_path, component, architecture
-            )
+            # Place the actual package files in the content pool (not under
+            # dists/), so Filename:/Directory: resolve for a real apt client.
+            self._link_packages_into_pool(component_packages, target_path, component)
 
             # Generate the index: Sources for the source group, Packages else.
             if architecture == "source":
@@ -252,38 +251,69 @@ class AptPublisher(PublisherPlugin):
 
         return grouped
 
-    def _create_package_hardlinks(
+    @staticmethod
+    def _safe_name(name: str) -> str:
+        """Neutralize path traversal in an upstream-controlled package name.
+
+        Debian package names never contain path separators; a hostile or broken
+        upstream ``Package:`` field must not be able to escape the pool via
+        ``/`` or ``..`` once it flows into a filesystem path.
+        """
+        safe = PurePosixPath(name).name
+        if not safe or safe.startswith("."):
+            safe = "_" + safe
+        return safe
+
+    @staticmethod
+    def _pool_prefix(name: str) -> str:
+        """Debian pool prefix: ``libx`` for lib* packages, else the first letter."""
+        if name.startswith("lib") and len(name) >= 4:
+            return name[:4]
+        return name[:1] or "_"
+
+    def _pool_relpath(self, component: str, name: str, filename: str) -> str:
+        """Repo-root-relative pool path: ``pool/<comp>/<prefix>/<name>/<file>``."""
+        safe = self._safe_name(name)
+        return f"pool/{self._safe_name(component)}/{self._pool_prefix(safe)}/{safe}/{Path(filename).name}"
+
+    def _pool_dir(self, component: str, name: str) -> str:
+        """Repo-root-relative pool directory (used as a source ``Directory:``)."""
+        safe = self._safe_name(name)
+        return f"pool/{self._safe_name(component)}/{self._pool_prefix(safe)}/{safe}"
+
+    def _link_packages_into_pool(
         self,
         packages: list[ContentItem],
-        component_arch_path: Path,
+        target_path: Path,
         component: str,
-        architecture: str,
     ) -> None:
-        """Create hardlinks for packages in component/arch directory.
+        """Hardlink packages into the content pool (``<root>/pool/...``).
 
-        Args:
-            packages: List of content items
-            component_arch_path: Path to component/architecture directory
-            component: Component name
-            architecture: Architecture name
+        Real apt repositories keep the actual .deb/source files in ``pool/`` at
+        the repository root (referenced by ``Filename:``/``Directory:`` from the
+        indices under ``dists/``), not inside ``dists/``. This makes the
+        published repo installable by a real apt client. Idempotent: an
+        ``Architecture: all`` package linked from several arch indices resolves
+        to one pool file.
         """
         import os
 
         for package in packages:
-            # Get pool path
             pool_file_path = self.storage.pool_path / package.pool_path
-
             if not pool_file_path.exists():
                 print(f"Warning: Pool file not found: {pool_file_path}")
                 continue
 
-            # Target path: dists/SUITE/COMPONENT/binary-ARCH/FILENAME
-            target_file_path = component_arch_path / package.filename
-
-            # Create hardlink
+            target_file_path = target_path / self._pool_relpath(
+                component, package.name, package.filename
+            )
+            # Defense in depth: never write outside the publish root.
+            if not target_file_path.resolve().is_relative_to(target_path.resolve()):
+                print(f"Warning: skipping package with unsafe pool path: {package.name!r}")
+                continue
+            target_file_path.parent.mkdir(parents=True, exist_ok=True)
             if target_file_path.exists():
                 target_file_path.unlink()
-
             os.link(pool_file_path, target_file_path)
 
     def _generate_packages_file(
@@ -392,7 +422,7 @@ class AptPublisher(PublisherPlugin):
                 stanza.append(f"Description: {description}")
 
             # Filename (relative to dists/)
-            filename = f"{component}/binary-{architecture}/{package.filename}"
+            filename = self._pool_relpath(component, package.name, package.filename)
             stanza.append(f"Filename: {filename}")
 
             # Size
@@ -484,7 +514,7 @@ class AptPublisher(PublisherPlugin):
                 lines.append(f"Priority: {meta['priority']}")
             if meta.get("section"):
                 lines.append(f"Section: {meta['section']}")
-            lines.append(f"Directory: {component}/source")
+            lines.append(f"Directory: {self._pool_dir(component, src_name)}")
 
             files_lines = []
             sha1_lines = []

--- a/tests/e2e/test_apt_pool_layout_e2e.py
+++ b/tests/e2e/test_apt_pool_layout_e2e.py
@@ -1,0 +1,93 @@
+"""
+End-to-end test: published APT repos use a real ``pool/`` layout.
+
+Package files must live under ``pool/`` at the repository root (not inside
+``dists/``), and each ``Filename:`` in Packages must resolve to the actual file
+— otherwise a real apt client cannot download/install packages. (Validated
+against real apt separately; this locks the layout invariant in CI.)
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _build_apt_upstream(root: Path) -> None:
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    (root / deb_rel).write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo\n"
+        "\n"
+    ).encode()
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    sha = hashlib.sha256
+    release = (
+        f"Origin: Upstream\nSuite: {DIST}\nCodename: {DIST}\n"
+        f"Components: {COMP}\nArchitectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\nSHA256:\n"
+        f" {sha(packages).hexdigest()} {len(packages)} {COMP}/binary-{ARCH}/Packages\n"
+        f" {sha(packages_gz).hexdigest()} {len(packages_gz)} {COMP}/binary-{ARCH}/Packages.gz\n"
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def test_apt_pool_layout(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt-pool",
+            "name": "Demo APT pool",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {"distribution": DIST, "components": [COMP], "architectures": [ARCH]},
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt-pool")
+
+    # The .deb lives under pool/, not under dists/.
+    pool_debs = list((target / "pool").rglob("*.deb"))
+    assert pool_debs, "no .deb under pool/"
+    assert not list((target / "dists").rglob("*.deb")), ".deb must not live under dists/"
+
+    # Every Filename in Packages is pool-relative AND resolves to a real file.
+    packages = (target / "dists" / DIST / COMP / f"binary-{ARCH}" / "Packages").read_text()
+    filenames = [
+        line.split(": ", 1)[1].strip()
+        for line in packages.splitlines()
+        if line.startswith("Filename:")
+    ]
+    assert filenames, "no Filename entries in Packages"
+    for fn in filenames:
+        assert fn.startswith("pool/"), f"Filename not pool-relative: {fn}"
+        # The key invariant: Filename (repo-root-relative) must resolve.
+        assert (target / fn).is_file(), f"Filename does not resolve: {fn}"

--- a/tests/e2e/test_apt_sources_e2e.py
+++ b/tests/e2e/test_apt_sources_e2e.py
@@ -128,14 +128,16 @@ def test_apt_sources_sync_and_publish(tmp_path, serve, chantal_env):
 
     target = chantal_env.sync_and_publish("demo-apt-src")
 
-    source_dir = target / "dists" / DIST / COMP / "source"
-    # The regenerated Sources index exists and lists all three artifacts.
-    sources_index = source_dir / "Sources"
+    # The regenerated Sources index stays under dists/ and lists all artifacts.
+    sources_index = target / "dists" / DIST / COMP / "source" / "Sources"
     assert sources_index.exists(), "regenerated Sources index missing"
     text = sources_index.read_text()
     for name in ("demo_1.0.dsc", "demo_1.0.orig.tar.gz", "demo_1.0.debian.tar.xz"):
         assert name in text, f"{name} missing from regenerated Sources"
-        assert (source_dir / name).exists(), f"{name} not published"
+        # Artifacts live in the content pool (referenced by Directory:).
+        assert list(target.rglob(name)), f"{name} not published"
+    # Directory points into the pool (where the artifacts actually are).
+    assert f"Directory: pool/{COMP}/" in text, "source Directory not pool-relative"
     # The Format field is preserved (apt-get source needs it).
     assert "Format: 3.0 (quilt)" in text, "Format field not preserved"
 
@@ -168,10 +170,9 @@ def test_apt_sources_checksum_mismatch_rejected(tmp_path, serve, chantal_env):
     )
 
     target = chantal_env.sync_and_publish("demo-apt-src-bad")
-    source_dir = target / "dists" / DIST / COMP / "source"
-    # The corrupt .dsc is rejected; the well-formed artifacts still publish.
-    assert not (source_dir / "demo_1.0.dsc").exists(), "artifact with bad checksum was published"
-    assert (source_dir / "demo_1.0.orig.tar.gz").exists(), "valid artifact missing"
+    # The corrupt .dsc is rejected; the well-formed artifacts still publish (pool).
+    assert not list(target.rglob("demo_1.0.dsc")), "artifact with bad checksum was published"
+    assert list(target.rglob("demo_1.0.orig.tar.gz")), "valid artifact missing"
 
 
 def _build_shared_artifact_upstream(root: Path) -> None:
@@ -235,10 +236,10 @@ def test_apt_sources_shared_artifact_dedup(tmp_path, serve, chantal_env):
     )
 
     target = chantal_env.sync_and_publish("demo-apt-src-shared")
-    source_dir = target / "dists" / DIST / COMP / "source"
-    assert (source_dir / "shared_1.0.orig.tar.gz").exists(), "shared artifact missing"
-    assert (source_dir / "alpha_1.0.dsc").exists()
-    assert (source_dir / "beta_1.0.dsc").exists()
-    # The shared artifact lives once in the pool (content-addressed).
+    # All artifacts published (under the pool); the shared one appears once.
+    assert list(target.rglob("shared_1.0.orig.tar.gz")), "shared artifact missing"
+    assert list(target.rglob("alpha_1.0.dsc"))
+    assert list(target.rglob("beta_1.0.dsc"))
+    # The shared artifact lives once in the content pool (content-addressed).
     pooled = list(chantal_env.pool.rglob("*shared_1.0.orig.tar.gz"))
     assert len(pooled) == 1, f"shared artifact should be pooled once, got {len(pooled)}"

--- a/tests/test_apt_publisher.py
+++ b/tests/test_apt_publisher.py
@@ -206,8 +206,8 @@ class TestPackagesFileGeneration:
         # Should contain size
         assert f"Size: {test_package.size_bytes}" in content
 
-        # Should contain filename
-        assert "Filename: main/binary-amd64/test-package_1.0-1_amd64.deb" in content
+        # Should contain a pool-relative filename (so it resolves for real apt)
+        assert "Filename: pool/main/t/test-package/test-package_1.0-1_amd64.deb" in content
 
     def test_generate_packages_file_multiple_packages(
         self, db_session, temp_storage, apt_config, test_repository
@@ -582,3 +582,19 @@ class TestPackagesCompression:
         assert "main/binary-amd64/Packages" in content
         assert "main/binary-amd64/Packages.zst" in content
         assert "main/binary-amd64/Packages.gz" not in content
+
+
+class TestPoolPath:
+    """Tests for the content-pool path helpers (Filename resolution + safety)."""
+
+    def test_pool_prefix(self):
+        assert AptPublisher._pool_prefix("docker-ce") == "d"
+        assert AptPublisher._pool_prefix("libssl3") == "libs"
+        assert AptPublisher._pool_prefix("lib") == "l"  # too short for lib-prefix
+
+    def test_safe_name_neutralizes_traversal(self):
+        assert AptPublisher._safe_name("docker-ce") == "docker-ce"
+        assert AptPublisher._safe_name("../../etc/passwd") == "passwd"
+        assert AptPublisher._safe_name("a/b") == "b"
+        # A name that resolves to empty/dotted is prefixed so it can't traverse.
+        assert not AptPublisher._safe_name("..").startswith("..")


### PR DESCRIPTION
## The bug (found by testing with real apt)

Published APT repos were **not installable by a real apt client**. Package files were placed under `dists/<suite>/<comp>/binary-<arch>/`, but `Filename:` was `<comp>/binary-<arch>/<file>` (repo-root-relative, missing `dists/<suite>/`). apt resolves `Filename` against the repo root → 404:

```
Err: File not found - /repo/main/binary-amd64/demo_1.0_amd64.deb
```

## The fix

Standard Debian **`pool/` layout**: package and source files now live at `pool/<comp>/<prefix>/<name>/<file>` at the repo root; `Filename:` / source `Directory:` point there; `dists/` holds only indices. This matches what the plugin docs already describe. `Filename` and on-disk placement use the same helper, so they always agree.

## Validated with real apt (Docker)

Built a genuine `.deb` (`dpkg-deb`), synced + published with chantal, then in a `debian:bookworm` container:
```
apt-get install -y hello-chantal   # ✓ installs
hello-chantal                       # -> hello-from-chantal-mirror
dpkg -s hello-chantal               # Status: install ok installed
```
(Previously this 404'd.) Also confirmed item 3's `NotAutomatic` shows priority 100 in `apt-cache policy`.

## Security

The upstream-controlled package name now flows into a filesystem path. `_safe_name()` neutralizes traversal (basename + leading-dot guard) and `_link_packages_into_pool` confines writes under the publish root. Unit-tested.

## Tests

- E2E: `.deb` under `pool/` (not `dists/`); **every `Filename` resolves** to a real file.
- Unit: pool-path helpers + traversal sanitization; existing publisher/source tests updated to the pool layout.

## Scope

Targets the **filtered-mode** path (verified end-to-end with real apt). **Mirror mode** has a separate, deeper consistency issue (verbatim upstream indices/signatures vs regenerated ones) tracked in **#77** — not a regression (it 404'd before too).