### PR TITLE
fix(apt): make Architecture: all packages visible to per-arch clients

### DIFF
--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -235,19 +235,31 @@ class AptPublisher(PublisherPlugin):
 
         Returns:
             Dictionary mapping (component, architecture) to list of packages
+
+        ``Architecture: all`` packages are fanned out into every configured
+        per-arch index, because apt clients only read
+        ``binary-<their-arch>/Packages`` — a lone ``binary-all`` index would
+        leave arch-independent packages invisible to them.
         """
         grouped: dict[tuple[str, str], list[ContentItem]] = {}
+        configured_arches = [a for a in self.apt_config.architectures if a != "all"]
 
         for package in packages:
             # Use `or` so an explicit None in the metadata still falls back.
             component = package.content_metadata.get("component") or "main"
             architecture = package.content_metadata.get("architecture") or "amd64"
 
-            key = (component, architecture)
-            if key not in grouped:
-                grouped[key] = []
+            if architecture == "source":
+                targets = ["source"]
+            elif architecture == "all":
+                # Duplicate into each real arch (fall back to binary-all only if
+                # no concrete architecture is configured).
+                targets = configured_arches or ["all"]
+            else:
+                targets = [architecture]
 
-            grouped[key].append(package)
+            for arch in targets:
+                grouped.setdefault((component, arch), []).append(package)
 
         return grouped
 

--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -240,11 +240,18 @@ class AptSyncPlugin:
                     pkg_url = urljoin(self.config.feed + "/", pkg.filename)
                     pkg_size_mb = pkg.size / 1024 / 1024 if pkg.size else 0
                     self.output.downloading(pkg_name, pkg_size_mb, i, len(all_packages))
-                    downloaded_bytes = self._download_package(pkg_url, pkg, session, repository)
+                    downloaded_bytes, item = self._download_package(
+                        pkg_url, pkg, session, repository
+                    )
+                    # Record in-run so a duplicate sha256 later in the same set
+                    # (e.g. an Architecture: all package listed in every per-arch
+                    # index) links instead of re-inserting (sha256 is unique).
+                    existing_packages[pkg.sha256] = item
                     packages_downloaded += 1
                     bytes_downloaded += downloaded_bytes
                     self.output.downloaded(downloaded_bytes / 1024 / 1024)
                 except Exception as e:
+                    session.rollback()
                     logger.error(f"Failed to download {pkg_name}: {e}")
                     self.output.error(f"{pkg_name}: {e}")
 
@@ -752,7 +759,7 @@ class AptSyncPlugin:
         pkg_meta: DebMetadata,
         session: Session,
         repository: Repository,
-    ) -> int:
+    ) -> tuple[int, ContentItem]:
         """Download .deb package and add to storage pool.
 
         Args:
@@ -762,7 +769,7 @@ class AptSyncPlugin:
             repository: Repository model instance
 
         Returns:
-            Number of bytes downloaded
+            Tuple of (bytes downloaded, the created ContentItem).
 
         Raises:
             Exception: On download or storage errors
@@ -814,7 +821,7 @@ class AptSyncPlugin:
                 content_item.repositories.append(repository)
                 session.commit()
 
-                return bytes_downloaded
+                return bytes_downloaded, content_item
 
             finally:
                 # Clean up temp file

--- a/tests/e2e/test_apt_arch_all_e2e.py
+++ b/tests/e2e/test_apt_arch_all_e2e.py
@@ -1,0 +1,114 @@
+"""
+End-to-end test: ``Architecture: all`` packages.
+
+An arch-independent package is listed in every per-arch ``Packages`` index by
+Debian convention, and apt clients only read ``binary-<their-arch>/Packages``.
+chantal must therefore (a) download the shared .deb once (no crash on the
+duplicate sha256) and (b) publish it into every configured per-arch index, not
+a lone ``binary-all``.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCHES = ["amd64", "arm64"]
+
+
+def _build_upstream(root: Path) -> None:
+    # One Architecture: all package (shared across both arch indices) + one
+    # regular amd64 package.
+    alldeb_rel = f"pool/{COMP}/d/demo-doc/demo-doc_1.0_all.deb"
+    (root / alldeb_rel).parent.mkdir(parents=True, exist_ok=True)
+    alldeb = b"arch-all doc payload" * 16
+    (root / alldeb_rel).write_bytes(alldeb)
+
+    amd_rel = f"pool/{COMP}/d/demo/demo_1.0_amd64.deb"
+    (root / amd_rel).parent.mkdir(parents=True, exist_ok=True)
+    amddeb = b"amd64 payload" * 16
+    (root / amd_rel).write_bytes(amddeb)
+
+    def _stanza(pkg, ver, arch, rel, data):
+        return (
+            f"Package: {pkg}\nVersion: {ver}\nArchitecture: {arch}\n"
+            f"Filename: {rel}\nSize: {len(data)}\n"
+            f"SHA256: {hashlib.sha256(data).hexdigest()}\nDescription: {pkg}\n\n"
+        )
+
+    all_stanza = _stanza("demo-doc", "1.0", "all", alldeb_rel, alldeb)
+    indices = {}  # rel-path -> (packages bytes, packages.gz bytes)
+    for arch in ARCHES:
+        pkgs = all_stanza  # arch:all appears in EVERY arch index
+        if arch == "amd64":
+            pkgs += _stanza("demo", "1.0", "amd64", amd_rel, amddeb)
+        pkgs_b = pkgs.encode()
+        comp_dir = root / "dists" / DIST / COMP / f"binary-{arch}"
+        comp_dir.mkdir(parents=True, exist_ok=True)
+        (comp_dir / "Packages").write_bytes(pkgs_b)
+        gz = gzip.compress(pkgs_b)
+        (comp_dir / "Packages.gz").write_bytes(gz)
+        indices[f"{COMP}/binary-{arch}/Packages"] = pkgs_b
+        indices[f"{COMP}/binary-{arch}/Packages.gz"] = gz
+
+    sha = hashlib.sha256
+    lines = "".join(
+        f" {sha(data).hexdigest()} {len(data)} {path}\n" for path, data in indices.items()
+    )
+    release = (
+        f"Origin: Upstream\nSuite: {DIST}\nCodename: {DIST}\nComponents: {COMP}\n"
+        f"Architectures: {' '.join(ARCHES)}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\nSHA256:\n" + lines
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def test_apt_arch_all_fanned_into_every_arch(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt-all",
+            "name": "Demo APT arch:all",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {"distribution": DIST, "components": [COMP], "architectures": ARCHES},
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt-all")
+    dist = target / "dists" / DIST / COMP
+
+    # The arch:all package appears in EVERY per-arch index...
+    for arch in ARCHES:
+        packages = (dist / f"binary-{arch}" / "Packages").read_text()
+        assert "Package: demo-doc" in packages, f"arch:all missing from binary-{arch}"
+        assert "Architecture: all" in packages
+
+    # ...and there is no lone binary-all index.
+    assert not (dist / "binary-all").exists(), "arch:all must be fanned out, not binary-all"
+
+    # The shared .deb is pooled once and its Filename resolves.
+    pooled = list((target / "pool").rglob("demo-doc_1.0_all.deb"))
+    assert len(pooled) == 1, f"arch:all .deb should be pooled once, got {len(pooled)}"
+    amd_packages = (dist / "binary-amd64" / "Packages").read_text()
+    for line in amd_packages.splitlines():
+        if line.startswith("Filename:") and "demo-doc" in line:
+            fn = line.split(": ", 1)[1].strip()
+            assert (target / fn).is_file(), f"arch:all Filename does not resolve: {fn}"
+
+    # Release lists only real arches (not 'all').
+    release = (target / "dists" / DIST / "Release").read_text()
+    arch_line = next(line for line in release.splitlines() if line.startswith("Architectures:"))
+    assert "all" not in arch_line.split()[1:], "Architectures must not list 'all'"


### PR DESCRIPTION
## Summary

#75 item 2. Two fixes for `Architecture: all` (arch-independent) packages.

- **Publish fan-out**: arch:all packages were grouped under `(component, "all")` → written to a lone `binary-all/Packages`, which apt clients never read (they read only `binary-<their-arch>/Packages`). Now fanned into **every configured per-arch index**, keeping `Architecture: all` in each stanza and out of the Release `Architectures:` line. Pooled once (same `Filename` across arches).
- **Sync dedup/robustness**: an arch:all .deb appears in every per-arch `Packages` with the same sha256. The in-run dedup dict was seeded once and never updated → the 2nd occurrence re-downloaded and hit the unique-sha256 `IntegrityError` with **no rollback** (poisoned session). `_download_package` now returns the ContentItem, the loop registers it, and the except `session.rollback()`s.

## Validated with real apt (Docker)
A shared arch:all `.deb` is downloaded **once** and published into both `binary-amd64` and `binary-arm64`; an **amd64 client `apt-get install`ed** the arch:all package successfully (`dpkg -s` = installed). Previously it lived in `binary-all/` only — invisible to per-arch clients.

## Tests
E2E: fan-out into every arch, dedup downloads once, `Filename` resolves to one pooled file, no `binary-all`, Release excludes `all`. Fresh-context review: no blockers/SHOULD-FIX.

## #75 status
With this, #75 is: item 2 ✅, item 3 ✅ (#76), item 1 (pdiffs) descoped as not-worth-it. The pool-layout prerequisite shipped in #78.

Part of #75