### PR TITLE
fix(apt): make mirror mode a true byte-for-byte 1:1 copy

### DIFF
--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -356,14 +356,24 @@ Publishing uses hardlinks (zero-copy) from the pool to the published directory.
 
 ### MIRROR Mode
 
-Preserves original repository structure and metadata exactly as upstream.
+Byte-for-byte 1:1 copy of upstream: packages keep their upstream `pool/` paths,
+and the `Packages`/`Sources`/`Contents`/`Translation` indices plus the signed
+`InRelease`/`Release`/`Release.gpg` are republished **verbatim**. Nothing is
+regenerated or re-signed, so the upstream signatures remain valid (and will
+eventually expire along with upstream — expected for a true mirror; any `gpg`
+signing config is ignored in mirror mode).
 
 **Behavior:**
-- Downloads InRelease/Release files directly from upstream
-- Downloads Packages files directly from upstream
-- No metadata regeneration
-- Preserves GPG signatures
+- Stores and republishes InRelease/Release/Packages exactly as upstream (no
+  regeneration, no re-signing)
+- Packages served at their upstream `Filename:`/`Directory:` paths
+- Preserves the original upstream GPG signatures
 - Ideal for exact repository mirrors
+
+> **Switching modes:** mirror is only meaningful for a mirror-*synced* repo.
+> Don't sync in `filtered` and then publish as `mirror` (the verbatim upstream
+> indices would reference packages that filtering removed). When changing a
+> repo's mode, re-sync and publish to a clean target (`unpublish` first).
 
 **Use Cases:**
 - Air-gapped environments requiring exact upstream copies

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -141,6 +141,13 @@ class AptPublisher(PublisherPlugin):
         dists_path = target_path / "dists" / self.apt_config.distribution
         dists_path.mkdir(parents=True, exist_ok=True)
 
+        # Mirror mode is a byte-for-byte copy: place every package at its
+        # upstream path and republish every metadata file (incl. the signed
+        # Release/InRelease) verbatim. Nothing is regenerated or re-signed.
+        if mode == RepositoryMode.MIRROR:
+            self._publish_verbatim(packages, target_path, repository_files, dists_path)
+            return
+
         # Group packages by component and architecture
         packages_by_component_arch = self._group_packages_by_component_arch(packages)
 
@@ -181,19 +188,10 @@ class AptPublisher(PublisherPlugin):
                 }
             )
 
-        # In mirror mode, publish all metadata files (Release, InRelease, etc.)
-        # and the verbatim Contents/Translation indices (filtered mode drops
-        # them entirely).
-        passthrough_files: list[tuple[str, Path]] = []
-        if mode == RepositoryMode.MIRROR:
-            self._publish_metadata_files(repository_files, dists_path)
-            passthrough_files = self._publish_passthrough_files(
-                repository_files, dists_path, ("Contents", "Translation")
-            )
-
-        # Generate Release file (always generated, even in mirror mode for completeness)
+        # Generate Release from the regenerated indices (filtered/hosted mode;
+        # mirror mode returned early with verbatim metadata).
         release_file = self._generate_release_file(
-            dists_path, published_metadata, repository_files, mode, extra_files=passthrough_files
+            dists_path, published_metadata, repository_files, mode
         )
 
         # In filtered mode the regenerated Release invalidates upstream signatures.
@@ -327,6 +325,81 @@ class AptPublisher(PublisherPlugin):
             if target_file_path.exists():
                 target_file_path.unlink()
             os.link(pool_file_path, target_file_path)
+
+    def _upstream_rel_path(self, package: ContentItem) -> str | None:
+        """Repo-root-relative path a package occupied upstream (for verbatim mirror).
+
+        Returns None when the upstream path is unknown (legacy rows without the
+        captured ``Filename:``); the caller then skips it rather than placing it
+        at a guessed path the verbatim index would not reference.
+        """
+        meta = package.content_metadata or {}
+        if package.content_type == "deb-source":
+            directory = meta.get("directory") or ""
+            return f"{directory}/{package.filename}" if directory else package.filename
+        upstream = meta.get("filename")
+        return str(upstream) if upstream else None
+
+    @staticmethod
+    def _link_verbatim(src: Path, dest: Path) -> None:
+        """Hardlink ``src`` to ``dest`` (replacing any existing file)."""
+        import os
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists():
+            dest.unlink()
+        os.link(src, dest)
+
+    def _publish_verbatim(
+        self,
+        packages: list[ContentItem],
+        target_path: Path,
+        repository_files: list[RepositoryFile],
+        dists_path: Path,
+    ) -> None:
+        """Publish a byte-for-byte 1:1 mirror.
+
+        Each package is placed at the upstream path it occupied (from the stored
+        ``Filename:``/``Directory:``), and every stored metadata file — including
+        the signed ``Release``/``InRelease`` — is republished verbatim. Nothing
+        is regenerated or re-signed, so the upstream signatures stay valid (and
+        may eventually expire, which is expected for a true mirror).
+        """
+        # Packages at their upstream paths.
+        for package in packages:
+            pool_file = self.storage.pool_path / package.pool_path
+            if not pool_file.exists():
+                print(f"Warning: Pool file not found: {pool_file}")
+                continue
+            rel = self._upstream_rel_path(package)
+            if rel is None:
+                print(f"Warning: no upstream path for {package.name!r}; skipping (verbatim)")
+                continue
+            dest = target_path / rel
+            if not dest.resolve().is_relative_to(target_path.resolve()):
+                print(f"Warning: skipping package with unsafe path: {package.name!r}")
+                continue
+            self._link_verbatim(pool_file, dest)
+
+        # Every metadata/signature file verbatim under dists/<suite>/.
+        for repo_file in repository_files:
+            if repo_file.file_category not in ("metadata", "signature"):
+                continue
+            pool_file = self.storage.pool_path / repo_file.pool_path
+            if not pool_file.exists():
+                print(f"Warning: Pool file not found: {pool_file}")
+                continue
+            dest = dists_path / repo_file.original_path
+            if not dest.resolve().is_relative_to(dists_path.resolve()):
+                print(f"Warning: skipping metadata with unsafe path: {repo_file.original_path!r}")
+                continue
+            self._link_verbatim(pool_file, dest)
+
+        gpg_config = self.config.gpg
+        if gpg_config is not None and gpg_config.enabled:
+            print("  ℹ Mirror mode: GPG signing skipped (upstream signatures preserved verbatim).")
+
+        print(f"  ✓ Published verbatim mirror ({len(packages)} packages)")
 
     def _generate_packages_file(
         self,
@@ -573,106 +646,6 @@ class AptPublisher(PublisherPlugin):
 
         return generated
 
-    def _publish_metadata_files(
-        self, repository_files: list[RepositoryFile], dists_path: Path
-    ) -> None:
-        """Create hardlinks for repository metadata files.
-
-        Args:
-            repository_files: List of RepositoryFile instances
-            dists_path: Path to dists/SUITE directory
-        """
-        import os
-
-        for repo_file in repository_files:
-            # Only publish metadata files
-            if repo_file.file_category != "metadata":
-                continue
-
-            # Contents/Translation indices are placed by
-            # _publish_passthrough_files at their full dists-relative path (this
-            # method flattens nested paths).
-            if repo_file.file_type in ("Contents", "Translation"):
-                continue
-
-            # Get pool path
-            pool_file_path = self.storage.pool_path / repo_file.pool_path
-
-            if not pool_file_path.exists():
-                print(f"Warning: Pool file not found: {pool_file_path}")
-                continue
-
-            # Determine target path based on original_path
-            # original_path is like "dists/jammy/Release" or "dists/jammy/main/binary-amd64/Packages.gz"
-            # We need to extract the path relative to dists/SUITE/
-
-            original_path = Path(repo_file.original_path)
-
-            # Remove "dists/SUITE/" prefix to get relative path
-            # Example: "dists/jammy/Release" -> "Release"
-            # Example: "dists/jammy/main/binary-amd64/Packages.gz" -> "main/binary-amd64/Packages.gz"
-            parts = original_path.parts
-
-            if len(parts) >= 3 and parts[0] == "dists":
-                # Skip "dists" and suite name
-                relative_parts = parts[2:]
-                relative_path = Path(*relative_parts) if relative_parts else Path(".")
-            else:
-                # Fallback: just use the filename
-                relative_path = Path(original_path.name)
-
-            # Target path
-            target_path = dists_path / relative_path
-
-            # Create parent directories
-            target_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Create hardlink
-            if target_path.exists():
-                target_path.unlink()
-
-            os.link(pool_file_path, target_path)
-
-            print(f"  ✓ Published {repo_file.file_type}: {relative_path}")
-
-    def _publish_passthrough_files(
-        self,
-        repository_files: list[RepositoryFile],
-        dists_path: Path,
-        file_types: tuple[str, ...],
-    ) -> list[tuple[str, Path]]:
-        """Publish verbatim metadata indices at their dists-relative location.
-
-        Used for Contents and i18n/Translation indices, which are stored with a
-        dists-relative ``original_path`` (e.g. ``main/Contents-amd64.gz`` or
-        ``main/i18n/Translation-en.gz``) and republished verbatim. Returns
-        ``(relative_path, published_path)`` tuples so the regenerated Release
-        can reference them.
-        """
-        import os
-
-        published: list[tuple[str, Path]] = []
-        for repo_file in repository_files:
-            if repo_file.file_type not in file_types:
-                continue
-
-            pool_file_path = self.storage.pool_path / repo_file.pool_path
-            if not pool_file_path.exists():
-                print(f"Warning: Pool file not found: {pool_file_path}")
-                continue
-
-            relative_path = repo_file.original_path
-            target_path = dists_path / relative_path
-            target_path.parent.mkdir(parents=True, exist_ok=True)
-            if target_path.exists():
-                target_path.unlink()
-            os.link(pool_file_path, target_path)
-
-            published.append((relative_path, target_path))
-            print(f"  ✓ Published {repo_file.file_type}: {relative_path}")
-
-        return published
-
     def _emit_by_hash(
         self, file_path: Path, sha256_hex: str, emitted: dict[Path, set[str]]
     ) -> None:
@@ -710,7 +683,6 @@ class AptPublisher(PublisherPlugin):
         published_metadata: list[dict],
         repository_files: list[RepositoryFile],
         mode: str,
-        extra_files: list[tuple[str, Path]] | None = None,
     ) -> Path:
         """Generate Release file for the distribution.
 
@@ -719,8 +691,6 @@ class AptPublisher(PublisherPlugin):
             published_metadata: List of metadata info dicts
             repository_files: List of repository files
             mode: Repository mode
-            extra_files: Additional (dists-relative path, file) entries to
-                checksum into Release (e.g. Contents indices).
 
         Returns:
             Path to generated Release file
@@ -811,18 +781,6 @@ class AptPublisher(PublisherPlugin):
                 sha256sums.append(f" {sha} {size:8} {rel}")
                 if by_hash:
                     self._emit_by_hash(variant_path, sha, by_hash_emitted)
-
-        # Extra metadata files (e.g. Contents indices) referenced by their
-        # dists-relative path.
-        for rel, file_path in extra_files or []:
-            data = file_path.read_bytes()
-            size = len(data)
-            sha = hashlib.sha256(data).hexdigest()
-            md5sums.append(f" {hashlib.md5(data).hexdigest()} {size:8} {rel}")
-            sha1sums.append(f" {hashlib.sha1(data).hexdigest()} {size:8} {rel}")
-            sha256sums.append(f" {sha} {size:8} {rel}")
-            if by_hash:
-                self._emit_by_hash(file_path, sha, by_hash_emitted)
 
         if by_hash:
             self._prune_by_hash(by_hash_emitted)

--- a/tests/e2e/test_apt_byhash_e2e.py
+++ b/tests/e2e/test_apt_byhash_e2e.py
@@ -120,7 +120,7 @@ def test_apt_byhash_publishing(tmp_path, serve, chantal_env):
     _build_plain_upstream(upstream)
     base_url = serve(upstream)
 
-    chantal_env.write_config(_config("demo-apt-byhash-pub", base_url, "mirror", True))
+    chantal_env.write_config(_config("demo-apt-byhash-pub", base_url, "filtered", True))
     target = chantal_env.sync_and_publish("demo-apt-byhash-pub")
 
     comp_dir = target / "dists" / DIST / COMP / f"binary-{ARCH}"
@@ -163,7 +163,7 @@ def test_apt_byhash_prune_stale(tmp_path, serve, chantal_env):
     _build_plain_upstream(upstream)
     base_url = serve(upstream)
 
-    chantal_env.write_config(_config("demo-apt-byhash-prune", base_url, "mirror", True))
+    chantal_env.write_config(_config("demo-apt-byhash-prune", base_url, "filtered", True))
     target = chantal_env.sync_and_publish("demo-apt-byhash-prune")
 
     comp_dir = target / "dists" / DIST / COMP / f"binary-{ARCH}"
@@ -186,7 +186,7 @@ def test_apt_byhash_disabled_no_dirs(tmp_path, serve, chantal_env):
     _build_plain_upstream(upstream)
     base_url = serve(upstream)
 
-    chantal_env.write_config(_config("demo-apt-byhash-none", base_url, "mirror", False))
+    chantal_env.write_config(_config("demo-apt-byhash-none", base_url, "filtered", False))
     target = chantal_env.sync_and_publish("demo-apt-byhash-none")
 
     assert not list(target.rglob("by-hash")), "no by-hash dirs when disabled"

--- a/tests/e2e/test_apt_contents_e2e.py
+++ b/tests/e2e/test_apt_contents_e2e.py
@@ -1,8 +1,9 @@
 """
 End-to-end test: APT Contents-<arch> index mirroring.
 
-With ``include_contents: true`` in MIRROR mode the Contents index is downloaded,
-republished at its component path, and referenced in the regenerated Release.
+With ``include_contents: true`` in MIRROR mode the Contents index is downloaded
+and republished verbatim at its component path; the (verbatim upstream) Release
+references it.
 In FILTERED mode Contents are dropped (regenerating one would need per-.deb file
 lists chantal does not extract).
 """

--- a/tests/e2e/test_apt_mirror_verbatim_e2e.py
+++ b/tests/e2e/test_apt_mirror_verbatim_e2e.py
@@ -1,0 +1,112 @@
+"""
+End-to-end test: mirror mode is a byte-for-byte 1:1 copy.
+
+In ``mode: mirror`` the published repo must reproduce upstream exactly: the
+signed ``InRelease`` and the ``Packages``/``Contents`` indices byte-identical,
+packages at their upstream pool paths, and nothing regenerated or re-signed.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+
+def _build_upstream(root: Path) -> dict[str, bytes]:
+    """Build an InRelease-signed upstream; return the verbatim bytes to compare."""
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    deb = b"dummy deb payload" * 16
+    (root / deb_rel).write_bytes(deb)
+
+    packages = (
+        "Package: demo\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: demo\n"
+        "\n"
+    ).encode()
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    contents = b"usr/bin/demo    main/demo\n"
+    contents_gz = gzip.compress(contents)
+    (root / "dists" / DIST / COMP / f"Contents-{ARCH}.gz").write_bytes(contents_gz)
+
+    sha = hashlib.sha256
+    release_body = (
+        f"Origin: Upstream\nLabel: Upstream\nSuite: {DIST}\nCodename: {DIST}\n"
+        f"Components: {COMP}\nArchitectures: {ARCH}\n"
+        "Date: Thu, 01 Jan 2026 00:00:00 UTC\nSHA256:\n"
+        f" {sha(packages_gz).hexdigest()} {len(packages_gz)} {COMP}/binary-{ARCH}/Packages.gz\n"
+        f" {sha(contents_gz).hexdigest()} {len(contents_gz)} {COMP}/Contents-{ARCH}.gz\n"
+    )
+    # A clearsigned InRelease (fake signature; verification is off in this test).
+    inrelease = (
+        "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA256\n\n"
+        + release_body
+        + "-----BEGIN PGP SIGNATURE-----\n\nFAKE-SIGNATURE-BLOCK\n-----END PGP SIGNATURE-----\n"
+    ).encode()
+    (root / "dists" / DIST / "InRelease").write_bytes(inrelease)
+
+    return {
+        "InRelease": inrelease,
+        f"{COMP}/binary-{ARCH}/Packages.gz": packages_gz,
+        f"{COMP}/Contents-{ARCH}.gz": contents_gz,
+        deb_rel: deb,
+    }
+
+
+def test_apt_mirror_is_byte_for_byte(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    verbatim = _build_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt-mirror",
+            "name": "Demo APT mirror",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "mirror",
+            "apt": {
+                "distribution": DIST,
+                "components": [COMP],
+                "architectures": [ARCH],
+                "include_contents": True,
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apt-mirror")
+
+    # InRelease, Packages.gz and Contents are byte-identical to upstream.
+    assert (target / "dists" / DIST / "InRelease").read_bytes() == verbatim["InRelease"]
+    pkgs = target / "dists" / DIST / COMP / f"binary-{ARCH}" / "Packages.gz"
+    assert pkgs.read_bytes() == verbatim[f"{COMP}/binary-{ARCH}/Packages.gz"]
+    contents = target / "dists" / DIST / COMP / f"Contents-{ARCH}.gz"
+    assert contents.read_bytes() == verbatim[f"{COMP}/Contents-{ARCH}.gz"]
+
+    # The package sits at its upstream pool path (Filename resolves).
+    deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
+    assert (target / deb_rel).read_bytes() == verbatim[deb_rel]
+
+    # Nothing regenerated: no chantal Release, no stray suite-root Packages.gz.
+    assert not (target / "dists" / DIST / "Release").exists(), "mirror must not regenerate Release"
+    assert not (target / "dists" / DIST / "Packages.gz").exists(), "stray suite-root index"
+    assert b"Origin: Chantal" not in (target / "dists" / DIST / "InRelease").read_bytes()

--- a/tests/e2e/test_apt_translation_e2e.py
+++ b/tests/e2e/test_apt_translation_e2e.py
@@ -2,8 +2,8 @@
 End-to-end test: APT i18n Translation mirroring.
 
 With ``include_translations: true`` in MIRROR mode the Translation files and the
-``i18n/Index`` are downloaded, republished at their component i18n path, and
-referenced in the regenerated Release. FILTERED mode drops them.
+``i18n/Index`` are downloaded and republished verbatim at their component i18n
+path; the (verbatim upstream) Release references them. FILTERED mode drops them.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Closes **#77**. Mirror mode previously regenerated `Release`/`Packages` while also publishing the verbatim upstream `InRelease`, so the InRelease checksums never matched the regenerated indices → apt "Hash Sum mismatch" / unusable mirror.

Mirror mode is now **verbatim**: packages keep their upstream `pool/` paths (from the stored `Filename:`/`Directory:`), and every stored metadata file — `Packages`/`Sources`/`Contents`/`Translation` and the signed `InRelease`/`Release`/`Release.gpg` — is republished byte-for-byte. Nothing is regenerated or re-signed, so upstream signatures stay valid (and may eventually expire, as expected for a true mirror; `gpg` config is ignored in mirror mode). Filtered/hosted modes unchanged.

## Validated with real apt (Docker)
A **gpg-signed** upstream mirrored in mirror mode → `apt-get update` **verified the verbatim InRelease** against the trusted upstream key, and `apt-get install` succeeded (binary ran). Combined with the pool-layout fix (#78), chantal APT mirrors are now genuinely apt-installable in both filtered and mirror modes.

## Changes
- New `_publish_verbatim` / `_upstream_rel_path` / `_link_verbatim`; mode-branch in `_publish_packages`. Path-traversal confinement for upstream-controlled paths; unknown upstream path (legacy rows) → skip-with-warning (never misplace).
- Removed the now-dead `_publish_metadata_files`/`_publish_passthrough_files` and the unreachable `extra_files` param.
- Tests: byte-identity e2e (InRelease/Packages.gz/Contents verbatim, packages at upstream paths, nothing regenerated); by-hash *publishing* tests moved to filtered mode (by-hash emission is a regenerate feature). Docs: mirror-mode section + mode-switch caveat.

Fresh-context review: no blockers; SHOULD-FIX items (skip-on-unknown-path, mode-switch doc) addressed.

Closes #77