### PR TITLE
feat(rpm): custom package upload into hosted repositories

### DIFF
--- a/docs/configuration/repositories.md
+++ b/docs/configuration/repositories.md
@@ -64,7 +64,7 @@ repositories:
 
 - **`filtered`** (default): Filters packages based on patterns/rules, regenerates metadata to match. Updateinfo filtered to include only relevant errata.
 - **`mirror`**: Full mirror of upstream repository. All metadata types downloaded and published unchanged. No filtering applied.
-- **`hosted`**: For self-hosted packages (future feature).
+- **`hosted`**: Upload-only repository with no upstream feed. Packages are added with `chantal package upload` and published like any other repo. `sync` is a no-op for hosted repos.
 
 See [RPM Plugin Documentation - Repository Modes](../plugins/rpm-plugin.md) for detailed mode explanations.
 

--- a/docs/plugins/rpm-plugin.md
+++ b/docs/plugins/rpm-plugin.md
@@ -15,7 +15,7 @@ The RPM plugin consists of:
 **Repository Modes:**
 - ✅ **Mirror Mode** - Full metadata mirroring (all repomd.xml types)
 - ✅ **Filtered Mode** - Smart metadata regeneration for filtered repos
-- ✅ **Hosted Mode** - For self-hosted packages (future)
+- ✅ **Hosted Mode** - Upload-only repositories for self-hosted packages (`chantal package upload`)
 
 **Package Management:**
 - ✅ Repomd.xml/primary.xml.gz parsing
@@ -263,7 +263,9 @@ Upstream has 1000 security advisories, but you only mirror nginx packages:
 
 ### Hosted Mode
 
-**Self-hosted packages** - For future use (uploading custom RPMs).
+**Self-hosted packages** - an upload-only repository with no upstream feed.
+Custom-built RPMs are added with `chantal package upload`; there is nothing to
+sync, so `chantal sync` skips hosted repositories.
 
 ```yaml
 repositories:
@@ -272,9 +274,32 @@ repositories:
     type: rpm
     mode: hosted
     enabled: true
+    # note: no 'feed' - hosted repos hold only uploaded packages
 ```
 
-**Status:** Planned feature for uploading custom-built RPMs.
+Upload one or more local RPMs and publish:
+
+```bash
+# A single file
+chantal package upload --repo-id custom-rpms --file ./nginx-1.20.1-1.el9.x86_64.rpm
+
+# A whole directory (optionally recursive)
+chantal package upload --repo-id custom-rpms --directory ./rpms/ --recursive
+
+# Replace an existing package with the same NEVRA but different content
+chantal package upload --repo-id custom-rpms --file ./nginx-1.20.1-1.el9.x86_64.rpm --force
+
+# Regenerate repodata so clients can install
+chantal publish repo --repo-id custom-rpms --target /srv/repos/custom-rpms
+```
+
+Package metadata (NEVRA, summary, ...) is parsed from the RPM header in pure
+Python - no `rpm` binary is required. Uploads are content-addressed and
+deduplicated by SHA-256; re-uploading identical bytes just links the existing
+pool entry. Uploading a different build of an NEVRA already in the repo
+requires `--force`.
+
+**Status:** ✅ Available (RPM).
 
 ## Upstream Signature Verification
 

--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -895,6 +895,7 @@
           "type": "string"
         },
         "feed": {
+          "default": "",
           "title": "Feed",
           "type": "string"
         },
@@ -1085,8 +1086,7 @@
       },
       "required": [
         "id",
-        "type",
-        "feed"
+        "type"
       ],
       "title": "RepositoryConfig",
       "type": "object"

--- a/src/chantal/cli/main.py
+++ b/src/chantal/cli/main.py
@@ -16,6 +16,7 @@ from chantal import __version__
 from chantal.cli.cache_commands import create_cache_group
 from chantal.cli.content_commands import create_content_group
 from chantal.cli.db_commands import create_db_group
+from chantal.cli.package_commands import create_package_group
 from chantal.cli.pool_commands import create_pool_group
 from chantal.cli.publish_commands import create_publish_group
 from chantal.cli.repo_commands import create_repo_group
@@ -130,6 +131,7 @@ create_view_group(cli)
 create_content_group(cli)
 create_pool_group(cli)
 create_publish_group(cli)
+create_package_group(cli)
 
 
 # ============================================================================

--- a/src/chantal/cli/package_commands.py
+++ b/src/chantal/cli/package_commands.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+"""
+CLI for uploading custom (local) packages into a repository's content pool.
+
+Phase 1 supports RPM uploads into a hosted (upload-only) or hybrid repository.
+Uploaded packages are added to the content-addressed pool and linked to the
+repository as ContentItems, so the existing publisher includes them when it
+regenerates the repository metadata.
+"""
+
+from pathlib import Path
+
+import click
+from sqlalchemy.orm import Session
+
+from chantal.core.config import GlobalConfig, RepositoryConfig
+from chantal.core.storage import StorageManager
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import ContentItem, Repository
+from chantal.plugins.rpm.models import RpmMetadata
+from chantal.plugins.rpm.rpm_header import parse_main_header
+
+
+def _get_or_create_repository(session: Session, repo_config: RepositoryConfig) -> Repository:
+    """Return the DB Repository for ``repo_config``, creating it if needed."""
+    repository: Repository | None = (
+        session.query(Repository).filter_by(repo_id=repo_config.id).first()
+    )
+    if repository is None:
+        repository = Repository(
+            repo_id=repo_config.id,
+            name=repo_config.name or repo_config.id,
+            type=repo_config.type,
+            feed=repo_config.feed or "",  # hosted repos have no upstream feed
+            enabled=repo_config.enabled,
+            mode=repo_config.mode.upper(),
+        )
+        session.add(repository)
+        session.commit()
+    return repository
+
+
+def _upload_rpm(
+    session: Session, storage: StorageManager, repository: Repository, path: Path, force: bool
+) -> str:
+    """Add one local .rpm to the pool and link it to the repo.
+
+    Returns "uploaded", "linked" (already in pool) or "replaced".
+    """
+    meta = parse_main_header(path.read_bytes())  # RpmFormatError if not an RPM
+    name = meta.get("name")
+    version = meta.get("version")
+    release = meta.get("release")
+    arch = meta.get("arch")
+    if not (name and version and release and arch):
+        raise ValueError("could not extract NEVRA (name/version/release/arch) from RPM header")
+
+    epoch = meta.get("epoch")
+    rpm_metadata = RpmMetadata(
+        epoch=str(epoch) if epoch is not None else None,
+        release=release,
+        arch=arch,
+        summary=meta.get("summary"),
+        description=meta.get("description"),
+        provides=None,
+        requires=None,
+        conflicts=None,
+        obsoletes=None,
+    )
+
+    filename = path.name
+    sha256, pool_path, size_bytes = storage.add_package(path, filename, verify_checksum=True)
+
+    # Same NEVRA but different content already linked to this repo -> conflict.
+    # Checked regardless of pool state, so re-uploading a differing build whose
+    # bytes happen to already be pooled still requires --force (no silent dupe).
+    conflict = next(
+        (
+            item
+            for item in repository.content_items
+            if item.content_type == "rpm"
+            and item.name == name
+            and item.version == version
+            and (item.content_metadata or {}).get("release") == release
+            and (item.content_metadata or {}).get("arch") == arch
+            and item.sha256 != sha256
+        ),
+        None,
+    )
+    nevra = rpm_metadata.get_nevra(name, version)
+    if conflict is not None and not force:
+        raise ValueError(
+            f"{nevra} already present in the repo with different content (use --force to replace)"
+        )
+
+    # Apply the unlink (force-replace) and the (re)link in a single transaction
+    # so a failure can never leave the repo with the old item dropped and no
+    # replacement.
+    if conflict is not None:
+        conflict.repositories.remove(repository)
+
+    # Identical content already pooled -> reuse the existing ContentItem.
+    existing = session.query(ContentItem).filter_by(sha256=sha256).first()
+    if existing is not None:
+        if repository not in existing.repositories:
+            existing.repositories.append(repository)
+        session.commit()
+        return "replaced" if conflict is not None else "linked"
+
+    content_item = ContentItem(
+        content_type="rpm",
+        name=name,
+        version=version,
+        sha256=sha256,
+        size_bytes=size_bytes,
+        pool_path=pool_path,
+        filename=filename,
+        content_metadata=rpm_metadata.model_dump(exclude_none=False),
+    )
+    content_item.repositories.append(repository)
+    session.add(content_item)
+    session.commit()
+    return "replaced" if conflict is not None else "uploaded"
+
+
+def create_package_group(cli: click.Group) -> None:
+    """Register the ``package`` command group."""
+
+    @cli.group("package")
+    def package() -> None:
+        """Manage custom (uploaded) packages."""
+
+    @package.command("upload")
+    @click.option(
+        "--file",
+        "file_path",
+        type=click.Path(exists=True, dir_okay=False, path_type=Path),
+        help="A single package file to upload.",
+    )
+    @click.option(
+        "--directory",
+        "directory",
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+        help="A directory of packages to upload.",
+    )
+    @click.option("--recursive", is_flag=True, help="Recurse into --directory.")
+    @click.option("--repo-id", required=True, help="Target repository id.")
+    @click.option("--force", is_flag=True, help="Replace a conflicting same-NEVRA package.")
+    @click.pass_context
+    def upload(
+        ctx: click.Context,
+        file_path: Path | None,
+        directory: Path | None,
+        recursive: bool,
+        repo_id: str,
+        force: bool,
+    ) -> None:
+        """Upload local package file(s) into a repository's content pool."""
+        config: GlobalConfig = ctx.obj["config"]
+        repo_config = config.get_repository(repo_id)
+        if repo_config is None:
+            click.echo(f"Error: repository '{repo_id}' not found in configuration", err=True)
+            raise click.Abort()
+        if repo_config.type != "rpm":
+            click.echo(
+                f"Error: package upload currently supports only 'rpm' repositories "
+                f"(repository '{repo_id}' is '{repo_config.type}')",
+                err=True,
+            )
+            raise click.Abort()
+        if not file_path and not directory:
+            click.echo("Error: provide --file or --directory", err=True)
+            raise click.Abort()
+
+        files: list[Path] = []
+        if file_path:
+            files.append(file_path)
+        if directory:
+            files.extend(sorted(directory.rglob("*.rpm") if recursive else directory.glob("*.rpm")))
+        if not files:
+            click.echo("No .rpm files found to upload.")
+            return
+
+        storage = StorageManager(config.storage)
+        db_manager = DatabaseManager(config.database.url)
+        uploaded = linked = replaced = failed = 0
+        with db_manager.session() as session:
+            repository = _get_or_create_repository(session, repo_config)
+            for f in files:
+                try:
+                    result = _upload_rpm(session, storage, repository, f, force)
+                except Exception as e:  # noqa: BLE001 - report per-file, continue
+                    session.rollback()
+                    failed += 1
+                    click.echo(f"  ✗ {f.name}: {e}", err=True)
+                    continue
+                if result == "uploaded":
+                    uploaded += 1
+                    click.echo(f"  ✓ {f.name}")
+                elif result == "replaced":
+                    replaced += 1
+                    click.echo(f"  ✓ {f.name} (replaced existing)")
+                else:
+                    linked += 1
+                    click.echo(f"  → {f.name} (already in pool, linked)")
+
+        click.echo(
+            f"\nUploaded {uploaded}, replaced {replaced}, linked {linked}, failed {failed} "
+            f"into '{repo_id}'."
+        )
+        click.echo(
+            "Run 'chantal publish repo --repo-id <id> --target <dir>' to regenerate metadata."
+        )

--- a/src/chantal/cli/repo_commands.py
+++ b/src/chantal/cli/repo_commands.py
@@ -1050,12 +1050,18 @@ def _sync_single_repository(
             repo_id=repo_config.id,
             name=repo_config.name or repo_config.id,
             type=repo_config.type,
-            feed=repo_config.feed,
+            feed=repo_config.feed or "",  # hosted repos have no upstream feed
             enabled=repo_config.enabled,
             mode=repo_config.mode.upper(),  # Convert to uppercase for enum (MIRROR, FILTERED, HOSTED)
         )
         session.add(repository)
         session.commit()
+
+    # Hosted repos hold only uploaded packages (see `chantal package upload`);
+    # there is no upstream to sync from.
+    if repo_config.mode == "hosted":
+        click.echo(f"Skipping '{repo_config.id}': hosted repository (no upstream to sync)")
+        return repository
 
     # Merge proxy and SSL config: repo-specific overrides global
     effective_proxy = repo_config.proxy if repo_config.proxy is not None else global_config.proxy

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -501,7 +501,7 @@ class RepositoryConfig(BaseModel):
     id: str
     name: str | None = None
     type: str  # rpm, apt
-    feed: str  # upstream URL
+    feed: str = ""  # upstream URL (empty for hosted repos; required otherwise)
     enabled: bool = True
 
     # Repository mode (mirror, filtered, hosted)
@@ -560,11 +560,18 @@ class RepositoryConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_mode_and_filters(self) -> RepositoryConfig:
-        """Validate that mirror mode is not used with filters."""
+        """Validate mode/filters and the feed requirement."""
         if self.mode == "mirror" and self.filters is not None:
             raise ValueError(
                 f"Repository '{self.id}': mode='mirror' cannot be used with filters. "
                 "Use mode='filtered' to apply filters, or remove filters for true mirror mode."
+            )
+        # Hosted repos hold only uploaded packages and need no upstream feed;
+        # mirror/filtered repos sync from a feed and require one.
+        if self.mode != "hosted" and not self.feed:
+            raise ValueError(
+                f"Repository '{self.id}': a 'feed' is required for mode='{self.mode}'. "
+                "Use mode='hosted' for an upload-only repository with no upstream."
             )
         return self
 

--- a/src/chantal/plugins/rpm/rpm_header.py
+++ b/src/chantal/plugins/rpm/rpm_header.py
@@ -38,6 +38,22 @@ _Buffer = bytes | mmap.mmap
 RPMTAG_RSAHEADER = 268
 RPMTAG_DSAHEADER = 267
 
+# Main-header value tags (package metadata) and their RPM type codes.
+_RPM_TYPE_INT32 = 4
+_RPM_TYPE_STRING = 6
+_RPM_TYPE_STRING_ARRAY = 8
+_RPM_TYPE_I18NSTRING = 9
+_MAIN_HEADER_TAGS = {
+    1000: "name",
+    1001: "version",
+    1002: "release",
+    1003: "epoch",
+    1004: "summary",
+    1005: "description",
+    1022: "arch",
+    1044: "sourcerpm",
+}
+
 _LEAD_MAGIC = b"\xed\xab\xee\xdb"
 _HEADER_MAGIC = b"\x8e\xad\xe8\x01"
 _LEAD_SIZE = 96
@@ -113,3 +129,43 @@ def extract_header_signature(data: _Buffer) -> tuple[bytes, bytes] | None:
             return signature_packet, main_header_blob
 
     return None
+
+
+def _read_cstring(store: bytes, offset: int) -> str:
+    """Read a NUL-terminated string from the header store at ``offset``."""
+    end = store.find(b"\x00", offset)
+    if end == -1:
+        end = len(store)
+    return store[offset:end].decode("utf-8", "replace")
+
+
+def parse_main_header(data: _Buffer) -> dict:
+    """Extract package metadata (NEVRA, summary, ...) from an RPM's main header.
+
+    Pure-Python: reuses the same header parsing as the signature path, so no
+    ``rpm`` binary is required. Returns a dict with any of the keys: ``name``,
+    ``version``, ``release``, ``epoch`` (int), ``arch``, ``summary``,
+    ``description``, ``sourcerpm``.
+
+    Raises:
+        RpmFormatError: If the bytes are not a parseable RPM.
+    """
+    if len(data) < _LEAD_SIZE + _INTRO_SIZE or data[:4] != _LEAD_MAGIC:
+        raise RpmFormatError("not an RPM file (bad lead magic)")
+
+    _sig_entries, _sig_store, sig_end = _parse_header(data, _LEAD_SIZE)
+    main_offset = sig_end + (-sig_end % 8)
+    entries, store, _ = _parse_header(data, main_offset)
+
+    result: dict = {}
+    for tag, rpm_type, store_offset, _count in entries:
+        key = _MAIN_HEADER_TAGS.get(tag)
+        if key is None:
+            continue
+        if rpm_type in (_RPM_TYPE_STRING, _RPM_TYPE_I18NSTRING, _RPM_TYPE_STRING_ARRAY):
+            # I18NSTRING/STRING_ARRAY: take the first entry.
+            result[key] = _read_cstring(store, store_offset)
+        elif rpm_type == _RPM_TYPE_INT32:
+            (value,) = struct.unpack(">I", store[store_offset : store_offset + 4])
+            result[key] = value
+    return result

--- a/tests/e2e/test_rpm_real_client_e2e.py
+++ b/tests/e2e/test_rpm_real_client_e2e.py
@@ -1,0 +1,118 @@
+"""
+End-to-end test with a REAL dnf client (Docker): custom RPM upload (#16).
+
+Builds a genuine .rpm, uploads it into a HOSTED (upload-only) repo via
+`chantal package upload`, publishes, then `dnf install`s it from the published
+repo in an almalinux container. Proves the whole custom-upload chain: pure-Python
+RPM metadata extraction, hosted mode, repodata generation, and real dnf install.
+
+Docker-gated: skipped where docker is unavailable; runs on the CI rpm e2e leg.
+Self-contained: the .rpm is built in-container (rpmbuild) and the published repo
+is streamed into the dnf container as a tar over stdin (no bind-mounts).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_DOCKER = shutil.which("docker") is not None
+_IMAGE = "almalinux:9"
+requires_docker = pytest.mark.skipif(not _HAVE_DOCKER, reason="docker not available")
+
+_SPEC = """\
+Name: demo-hosted
+Version: 1.0
+Release: 1
+Summary: chantal hosted test
+License: MIT
+BuildArch: noarch
+
+%description
+test package
+
+%install
+mkdir -p %{buildroot}/usr/share/demo-hosted
+echo hello-from-hosted > %{buildroot}/usr/share/demo-hosted/README
+
+%files
+/usr/share/demo-hosted/README
+"""
+
+
+def _build_rpm() -> bytes:
+    """Build a real noarch .rpm in a container; return its bytes."""
+    spec_b64 = base64.b64encode(_SPEC.encode()).decode()
+    script = (
+        "set -e; dnf install -y rpm-build >/dev/null 2>&1; mkdir -p /root/rpmbuild/SPECS; "
+        f"echo {spec_b64} | base64 -d > /root/rpmbuild/SPECS/demo.spec; "
+        "rpmbuild -bb /root/rpmbuild/SPECS/demo.spec >/dev/null 2>&1; "
+        "base64 -w0 /root/rpmbuild/RPMS/noarch/demo-hosted-1.0-1.noarch.rpm"
+    )
+    out = subprocess.run(
+        ["docker", "run", "--rm", _IMAGE, "bash", "-c", script],
+        capture_output=True,
+        timeout=600,
+    )
+    assert out.returncode == 0, f"rpm build failed: {out.stderr.decode()[-600:]}"
+    return base64.b64decode(out.stdout)
+
+
+def _dnf_install(published: Path) -> subprocess.CompletedProcess:
+    """Stream the published repo into a container and dnf-install from it."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(published, arcname=".")
+    script = (
+        "set -e; mkdir -p /repo && tar -xf - -C /repo; "
+        'printf "[hosted]\\nname=hosted\\nbaseurl=file:///repo\\nenabled=1\\ngpgcheck=0\\n"'
+        " > /etc/yum.repos.d/hosted.repo; "
+        "dnf install -y demo-hosted >/dev/null; "
+        "cat /usr/share/demo-hosted/README"
+    )
+    return subprocess.run(
+        ["docker", "run", "--rm", "-i", _IMAGE, "bash", "-c", script],
+        input=buf.getvalue(),
+        capture_output=True,
+        timeout=600,
+    )
+
+
+@requires_docker
+def test_rpm_hosted_upload_installs_with_real_dnf(tmp_path, chantal_env):
+    rpm_bytes = _build_rpm()
+    rpm_file = tmp_path / "demo-hosted-1.0-1.noarch.rpm"
+    rpm_file.write_bytes(rpm_bytes)
+
+    chantal_env.write_config(
+        {
+            "id": "internal-rpm",
+            "name": "Internal RPM",
+            "type": "rpm",
+            "enabled": True,
+            "mode": "hosted",  # no feed; upload-only
+        }
+    )
+
+    # Upload the local RPM, then publish (no sync — hosted has no upstream).
+    chantal_env.run("package", "upload", "--file", str(rpm_file), "--repo-id", "internal-rpm")
+    target = chantal_env.published / "internal-rpm"
+    chantal_env.run("publish", "repo", "--repo-id", "internal-rpm", "--target", str(target))
+
+    # The uploaded package is in the published repodata + pool.
+    assert list(target.rglob("demo-hosted-1.0-1.noarch.rpm")), "uploaded rpm not published"
+
+    result = _dnf_install(target)
+    assert result.returncode == 0, (
+        f"real dnf install failed:\nstdout={result.stdout.decode()[-800:]}\n"
+        f"stderr={result.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-hosted" in result.stdout, "installed package file missing"

--- a/tests/test_package_upload.py
+++ b/tests/test_package_upload.py
@@ -1,0 +1,136 @@
+"""Unit tests for `chantal package upload` core logic (_upload_rpm).
+
+Covers the dedup / same-NEVRA-conflict / --force matrix without docker, using
+synthetic RPMs (same builder as test_rpm_header_metadata) so the metadata
+extraction, sha256 dedup and conflict resolution are exercised end to end.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from chantal.cli.package_commands import _upload_rpm
+from chantal.core.config import StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.models import Base, ContentItem, Repository
+
+_HEADER_MAGIC = b"\x8e\xad\xe8\x01"
+_LEAD = b"\xed\xab\xee\xdb" + b"\x00" * 92
+_T_STRING = 6
+
+
+def _build_header(items: list[tuple[int, int, bytes]]) -> bytes:
+    index = b""
+    store = b""
+    for tag, rpm_type, raw in items:
+        index += struct.pack(">IIII", tag, rpm_type, len(store), 1)
+        store += raw
+    intro = _HEADER_MAGIC + b"\x00" * 4 + struct.pack(">II", len(items), len(store))
+    return intro + index + store
+
+
+def _rpm(name: str, version: str, release: str, arch: str, summary: str) -> bytes:
+    sig = _build_header([(1000, _T_STRING, b"x\x00")])
+    pad = b"\x00" * (-(96 + len(sig)) % 8)
+    main = _build_header(
+        [
+            (1000, _T_STRING, name.encode() + b"\x00"),
+            (1001, _T_STRING, version.encode() + b"\x00"),
+            (1002, _T_STRING, release.encode() + b"\x00"),
+            (1022, _T_STRING, arch.encode() + b"\x00"),
+            (1004, _T_STRING, summary.encode() + b"\x00"),
+        ]
+    )
+    return _LEAD + sig + pad + main
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    sess = sessionmaker(bind=engine)()
+    yield sess
+    sess.close()
+
+
+@pytest.fixture
+def storage(tmp_path):
+    (tmp_path / "pool").mkdir()
+    return StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(tmp_path / "pool"),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+
+
+@pytest.fixture
+def repository(session):
+    repo = Repository(repo_id="internal", name="Internal", type="rpm", feed="", mode="HOSTED")
+    session.add(repo)
+    session.commit()
+    return repo
+
+
+def _rpm_items(repository: Repository) -> list[ContentItem]:
+    return [i for i in repository.content_items if i.content_type == "rpm"]
+
+
+def test_upload_then_link_same_bytes(session, storage, repository, tmp_path):
+    f = tmp_path / "demo-1.0-1.noarch.rpm"
+    f.write_bytes(_rpm("demo", "1.0", "1", "noarch", "first"))
+
+    assert _upload_rpm(session, storage, repository, f, force=False) == "uploaded"
+    # Re-uploading the identical bytes just links (no duplicate ContentItem).
+    assert _upload_rpm(session, storage, repository, f, force=False) == "linked"
+    assert len(_rpm_items(repository)) == 1
+
+
+def test_same_nevra_different_content_requires_force(session, storage, repository, tmp_path):
+    a = tmp_path / "a.rpm"
+    a.write_bytes(_rpm("demo", "1.0", "1", "noarch", "summary-a"))
+    b = tmp_path / "b.rpm"
+    b.write_bytes(_rpm("demo", "1.0", "1", "noarch", "summary-b"))  # same NEVRA, diff bytes
+
+    assert _upload_rpm(session, storage, repository, a, force=False) == "uploaded"
+    with pytest.raises(ValueError, match="already present"):
+        _upload_rpm(session, storage, repository, b, force=False)
+    # The rejected upload left exactly the original item linked.
+    assert len(_rpm_items(repository)) == 1
+    assert _rpm_items(repository)[0].content_metadata["summary"] == "summary-a"
+
+    # --force replaces it atomically: still exactly one NEVRA, now the new one.
+    assert _upload_rpm(session, storage, repository, b, force=True) == "replaced"
+    items = _rpm_items(repository)
+    assert len(items) == 1
+    assert items[0].content_metadata["summary"] == "summary-b"
+
+
+def test_pooled_conflict_still_requires_force(session, storage, repository, tmp_path):
+    """A differing build whose bytes are already pooled (via another repo) must
+    still require --force, not silently link a second same-NEVRA item."""
+    other = Repository(repo_id="other", name="Other", type="rpm", feed="", mode="HOSTED")
+    session.add(other)
+    session.commit()
+
+    a = tmp_path / "a.rpm"
+    a.write_bytes(_rpm("demo", "1.0", "1", "noarch", "summary-a"))
+    b = tmp_path / "b.rpm"
+    b.write_bytes(_rpm("demo", "1.0", "1", "noarch", "summary-b"))
+
+    _upload_rpm(session, storage, repository, a, force=False)  # repo: NEVRA sha-a
+    _upload_rpm(session, storage, other, b, force=False)  # pool now also has sha-b
+
+    # Uploading b into repo: bytes are pooled, but it's a different sha for the
+    # same NEVRA already in repo -> conflict, not a silent link.
+    with pytest.raises(ValueError, match="already present"):
+        _upload_rpm(session, storage, repository, b, force=False)
+    assert len(_rpm_items(repository)) == 1
+
+    assert _upload_rpm(session, storage, repository, b, force=True) == "replaced"
+    assert len(_rpm_items(repository)) == 1

--- a/tests/test_rpm_header_metadata.py
+++ b/tests/test_rpm_header_metadata.py
@@ -1,0 +1,71 @@
+"""Unit tests for RPM main-header metadata extraction (parse_main_header)."""
+
+from __future__ import annotations
+
+import struct
+
+from chantal.plugins.rpm.rpm_header import parse_main_header
+
+_HEADER_MAGIC = b"\x8e\xad\xe8\x01"
+_LEAD = b"\xed\xab\xee\xdb" + b"\x00" * 92  # 96-byte lead
+
+# RPM type codes
+_T_INT32 = 4
+_T_STRING = 6
+_T_I18NSTRING = 9
+
+
+def _build_header(items: list[tuple[int, int, bytes]]) -> bytes:
+    """Serialize an RPM header from (tag, type, raw_value) items."""
+    index = b""
+    store = b""
+    for tag, rpm_type, raw in items:
+        index += struct.pack(">IIII", tag, rpm_type, len(store), 1)
+        store += raw
+    intro = _HEADER_MAGIC + b"\x00" * 4 + struct.pack(">II", len(items), len(store))
+    return intro + index + store
+
+
+def _build_rpm(main_items: list[tuple[int, int, bytes]]) -> bytes:
+    """Assemble lead + a minimal signature header + padding + main header."""
+    sig_header = _build_header([(1000, _T_STRING, b"x\x00")])
+    sig_end = 96 + len(sig_header)
+    pad = b"\x00" * (-sig_end % 8)
+    return _LEAD + sig_header + pad + _build_header(main_items)
+
+
+def test_parse_main_header_nevra():
+    rpm = _build_rpm(
+        [
+            (1000, _T_STRING, b"nginx\x00"),
+            (1001, _T_STRING, b"1.20.1\x00"),
+            (1002, _T_STRING, b"1.el9\x00"),
+            (1003, _T_INT32, struct.pack(">I", 1)),
+            (1004, _T_I18NSTRING, b"High performance web server\x00"),
+            (1022, _T_STRING, b"x86_64\x00"),
+            (1044, _T_STRING, b"nginx-1.20.1-1.el9.src.rpm\x00"),
+        ]
+    )
+    meta = parse_main_header(rpm)
+    assert meta["name"] == "nginx"
+    assert meta["version"] == "1.20.1"
+    assert meta["release"] == "1.el9"
+    assert meta["epoch"] == 1  # INT32 decoded as int
+    assert meta["arch"] == "x86_64"
+    assert meta["summary"] == "High performance web server"
+    assert meta["sourcerpm"] == "nginx-1.20.1-1.el9.src.rpm"
+
+
+def test_parse_main_header_noarch_no_epoch():
+    rpm = _build_rpm(
+        [
+            (1000, _T_STRING, b"demo\x00"),
+            (1001, _T_STRING, b"1.0\x00"),
+            (1002, _T_STRING, b"1\x00"),
+            (1022, _T_STRING, b"noarch\x00"),
+        ]
+    )
+    meta = parse_main_header(rpm)
+    assert meta["name"] == "demo"
+    assert meta["arch"] == "noarch"
+    assert "epoch" not in meta  # no EPOCH tag -> absent


### PR DESCRIPTION
Implements the RPM phase of #16 (custom package upload).

## What

A new `chantal package upload` command adds local `.rpm` files into a **hosted** (upload-only) repository's content pool. The existing publisher then regenerates repodata so real clients can install them.

```bash
chantal package upload --repo-id custom-rpms --file ./nginx-1.20.1-1.el9.x86_64.rpm
chantal package upload --repo-id custom-rpms --directory ./rpms/ --recursive
chantal publish repo --repo-id custom-rpms --target /srv/repos/custom-rpms
```

## How

- **Pure-Python RPM metadata extraction** — new `parse_main_header()` reads NEVRA, summary, description and sourcerpm straight from the RPM main header (reusing the same header/signature alignment as the verified signature path). No `rpm` binary required.
- **Content-addressed + deduplicated** — identical bytes link the existing pool entry; a differing build of an NEVRA already in the repo requires `--force`. The unlink + relink happen in a single transaction, so a failure can never drop the old package without a replacement.
- **Hosted mode** — `feed` is now optional; the config validator requires it only for `mirror`/`filtered` modes, and `sync` is a no-op for hosted repos.

## Tests

- `tests/test_rpm_header_metadata.py` — header extraction (NEVRA, INT32 epoch, I18NSTRING, no-epoch/noarch).
- `tests/test_package_upload.py` — dedup / same-NEVRA-conflict / `--force` matrix, including the pooled-conflict regression (a differing build whose bytes are already pooled still requires `--force`).
- `tests/e2e/test_rpm_real_client_e2e.py` — Docker e2e that builds a real RPM, uploads it, publishes, and installs it with **real `dnf`** from the published repo. Runs on the CI `rpm` e2e leg.

Full gate green locally: ruff, black, mypy, yamllint, unit suite, and the dnf e2e.

Part of #16.