### PR TITLE
feat(apt): custom .deb upload into hosted repositories

### DIFF
--- a/docs/configuration/repositories.md
+++ b/docs/configuration/repositories.md
@@ -23,7 +23,7 @@ repositories:
 - `enabled`: Whether to include in `--all` operations
 
 **Optional Fields:**
-- `mode`: Repository operation mode (`mirror`, `filtered`, `hosted`) - RPM only, defaults to `filtered`
+- `mode`: Repository operation mode (`mirror`, `filtered`, `hosted`) - RPM and APT, defaults to `filtered`
 
 ## Repository Types
 

--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -15,7 +15,7 @@ The APT plugin consists of:
 **Repository Modes:**
 - ✅ **Mirror Mode** - Full metadata mirroring (InRelease, Release, Packages)
 - ✅ **Filtered Mode** - Smart metadata regeneration for filtered repos (with optional GPG signing)
-- ⏳ **Hosted Mode** - For self-hosted packages (future)
+- ✅ **Hosted Mode** - Upload-only repositories for self-hosted `.deb` packages (`chantal package upload`)
 
 **Package Management:**
 - ✅ InRelease/Release file parsing
@@ -527,6 +527,62 @@ See [Filters Configuration](../configuration/filters.md) for complete documentat
 | Metadata Source | Upstream | Regenerated |
 | Client Trust | Automatic (GPG) | GPG (signed-by) or manual (trusted=yes) |
 | Use Case | Exact mirrors | Curated subsets |
+
+### HOSTED Mode
+
+**Status:** ✅ Available
+
+An upload-only repository with **no upstream feed**. Custom-built `.deb`
+packages are added with `chantal package upload`; there is nothing to sync, so
+`chantal sync` skips hosted repositories. Publishing regenerates the
+`Packages`/`Release` indices and pool layout exactly like filtered mode, so the
+result installs with stock `apt`.
+
+```yaml
+repositories:
+  - id: internal-debs
+    name: Internal Debian Packages
+    type: apt
+    enabled: true
+    mode: hosted
+    # note: no 'feed' - hosted repos hold only uploaded packages
+    apt:
+      distribution: jammy
+      components: [main]
+      architectures: [amd64]
+```
+
+**Uploading and publishing:**
+
+```bash
+# A single .deb (defaults to component 'main')
+chantal package upload --repo-id internal-debs --file ./demo_1.0_amd64.deb
+
+# Choose the component
+chantal package upload --repo-id internal-debs --file ./demo_1.0_amd64.deb --component contrib
+
+# A whole directory (optionally recursive)
+chantal package upload --repo-id internal-debs --directory ./debs/ --recursive
+
+# Replace an existing same name/version/arch package with different content
+chantal package upload --repo-id internal-debs --file ./demo_1.0_amd64.deb --force
+
+# Regenerate metadata so clients can install
+chantal publish repo --repo-id internal-debs --target /srv/repos/internal-debs
+```
+
+Package metadata is parsed from the `.deb` control file in **pure Python** (the
+`ar` container plus a `control.tar.{gz,xz,zst}`) - no `dpkg-deb` binary is
+required. Uploads are content-addressed and deduplicated by SHA-256:
+re-uploading identical bytes just links the existing pool entry, while a
+different build of a name/version/architecture already present requires
+`--force`. The package's `architecture` must be one the repo's
+`apt.architectures` lists (or `all`) and its `--component` one the consumer
+requests, so it lands in the matching `binary-<arch>` index.
+
+**Client configuration** is the same as filtered mode: configure a `gpg`
+section to publish a signed `Release` (hosted Release files are signed when GPG
+is configured), otherwise clients must use `[trusted=yes]`.
 
 ## Upstream Signature Verification
 

--- a/src/chantal/cli/package_commands.py
+++ b/src/chantal/cli/package_commands.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 """
 CLI for uploading custom (local) packages into a repository's content pool.
 
-Phase 1 supports RPM uploads into a hosted (upload-only) or hybrid repository.
-Uploaded packages are added to the content-addressed pool and linked to the
-repository as ContentItems, so the existing publisher includes them when it
-regenerates the repository metadata.
+Supports RPM (.rpm) and APT (.deb) uploads into a hosted (upload-only)
+repository. Uploaded packages are added to the content-addressed pool and
+linked to the repository as ContentItems, so the existing publisher includes
+them when it regenerates the repository metadata.
 """
 
 from pathlib import Path
+from typing import Any
 
 import click
 from sqlalchemy.orm import Session
@@ -18,6 +19,8 @@ from chantal.core.config import GlobalConfig, RepositoryConfig
 from chantal.core.storage import StorageManager
 from chantal.db.connection import DatabaseManager
 from chantal.db.models import ContentItem, Repository
+from chantal.plugins.apt.deb import parse_deb_control
+from chantal.plugins.apt.models import DebMetadata
 from chantal.plugins.rpm.models import RpmMetadata
 from chantal.plugins.rpm.rpm_header import parse_main_header
 
@@ -124,6 +127,137 @@ def _upload_rpm(
     return "replaced" if conflict is not None else "uploaded"
 
 
+# Debian control field -> DebMetadata field (= content_metadata key the APT
+# publisher reads). Package/Version/Architecture are handled explicitly.
+_DEB_CONTROL_MAP = {
+    "Maintainer": "maintainer",
+    "Original-Maintainer": "original_maintainer",
+    "Section": "section",
+    "Priority": "priority",
+    "Homepage": "homepage",
+    "Source": "source",
+    "Depends": "depends",
+    "Pre-Depends": "pre_depends",
+    "Recommends": "recommends",
+    "Suggests": "suggests",
+    "Enhances": "enhances",
+    "Breaks": "breaks",
+    "Conflicts": "conflicts",
+    "Replaces": "replaces",
+    "Provides": "provides",
+    "Built-Using": "built_using",
+    "Essential": "essential",
+    "Multi-Arch": "multi_arch",
+}
+
+
+def _upload_deb(
+    session: Session,
+    storage: StorageManager,
+    repository: Repository,
+    path: Path,
+    force: bool,
+    component: str,
+) -> str:
+    """Add one local .deb to the pool and link it to the repo.
+
+    Returns "uploaded", "linked" (already in pool) or "replaced".
+    """
+    control = parse_deb_control(path.read_bytes())  # DebFormatError if not a .deb
+    name = control.get("Package")
+    version = control.get("Version")
+    arch = control.get("Architecture")
+    if not (name and version and arch):
+        raise ValueError("could not extract Package/Version/Architecture from .deb control")
+
+    filename = path.name
+    sha256, pool_path, size_bytes = storage.add_package(path, filename, verify_checksum=True)
+
+    # The APT publisher emits Description as a single line; keep only the synopsis
+    # there and stash the extended description (which it ignores) separately.
+    description = control.get("Description")
+    synopsis = long_description = None
+    if description is not None:
+        synopsis, _, rest = description.partition("\n")
+        long_description = rest or None
+
+    installed_size = control.get("Installed-Size")
+    data: dict[str, Any] = {
+        "package": name,
+        "version": version,
+        "architecture": arch,
+        "filename": filename,
+        "size": size_bytes,
+        "sha256": sha256,
+        "component": component,
+        "description": synopsis,
+        "long_description": long_description,
+        "installed_size": (
+            int(installed_size) if installed_size and installed_size.isdigit() else None
+        ),
+    }
+    for src, dest in _DEB_CONTROL_MAP.items():
+        if control.get(src):
+            data[dest] = control[src]
+    deb_metadata = DebMetadata.model_validate(data)
+
+    # Same identity (name, version, arch, component) but different content -> conflict.
+    conflict = next(
+        (
+            item
+            for item in repository.content_items
+            if item.content_type == "deb"
+            and item.name == name
+            and item.version == version
+            and (item.content_metadata or {}).get("architecture") == arch
+            and ((item.content_metadata or {}).get("component") or "main") == component
+            and item.sha256 != sha256
+        ),
+        None,
+    )
+    ident = f"{name}_{version}_{arch}"
+    if conflict is not None and not force:
+        raise ValueError(
+            f"{ident} already present in the repo with different content (use --force to replace)"
+        )
+
+    if conflict is not None:
+        conflict.repositories.remove(repository)
+
+    existing = session.query(ContentItem).filter_by(sha256=sha256).first()
+    if existing is not None:
+        # Content is globally deduplicated by checksum, but a ContentItem carries
+        # a single component. Linking identical bytes whose pooled item lives in a
+        # different component would silently file the package into the wrong
+        # component, so reject it explicitly rather than no-op.
+        existing_component = (existing.content_metadata or {}).get("component") or "main"
+        if existing_component != component:
+            raise ValueError(
+                f"{ident}: identical package content is already pooled under component "
+                f"'{existing_component}'; the same bytes cannot also be published under "
+                f"'{component}' (content is deduplicated by checksum)"
+            )
+        if repository not in existing.repositories:
+            existing.repositories.append(repository)
+        session.commit()
+        return "replaced" if conflict is not None else "linked"
+
+    content_item = ContentItem(
+        content_type="deb",
+        name=name,
+        version=version,
+        sha256=sha256,
+        size_bytes=size_bytes,
+        pool_path=pool_path,
+        filename=filename,
+        content_metadata=deb_metadata.model_dump(exclude_none=False),
+    )
+    content_item.repositories.append(repository)
+    session.add(content_item)
+    session.commit()
+    return "replaced" if conflict is not None else "uploaded"
+
+
 def create_package_group(cli: click.Group) -> None:
     """Register the ``package`` command group."""
 
@@ -146,7 +280,13 @@ def create_package_group(cli: click.Group) -> None:
     )
     @click.option("--recursive", is_flag=True, help="Recurse into --directory.")
     @click.option("--repo-id", required=True, help="Target repository id.")
-    @click.option("--force", is_flag=True, help="Replace a conflicting same-NEVRA package.")
+    @click.option("--force", is_flag=True, help="Replace a conflicting same-version package.")
+    @click.option(
+        "--component",
+        default="main",
+        show_default=True,
+        help="APT component for uploaded .deb packages (ignored for rpm).",
+    )
     @click.pass_context
     def upload(
         ctx: click.Context,
@@ -155,6 +295,7 @@ def create_package_group(cli: click.Group) -> None:
         recursive: bool,
         repo_id: str,
         force: bool,
+        component: str,
     ) -> None:
         """Upload local package file(s) into a repository's content pool."""
         config: GlobalConfig = ctx.obj["config"]
@@ -162,9 +303,9 @@ def create_package_group(cli: click.Group) -> None:
         if repo_config is None:
             click.echo(f"Error: repository '{repo_id}' not found in configuration", err=True)
             raise click.Abort()
-        if repo_config.type != "rpm":
+        if repo_config.type not in ("rpm", "apt"):
             click.echo(
-                f"Error: package upload currently supports only 'rpm' repositories "
+                f"Error: package upload supports only 'rpm' and 'apt' repositories "
                 f"(repository '{repo_id}' is '{repo_config.type}')",
                 err=True,
             )
@@ -173,13 +314,14 @@ def create_package_group(cli: click.Group) -> None:
             click.echo("Error: provide --file or --directory", err=True)
             raise click.Abort()
 
+        ext = "*.rpm" if repo_config.type == "rpm" else "*.deb"
         files: list[Path] = []
         if file_path:
             files.append(file_path)
         if directory:
-            files.extend(sorted(directory.rglob("*.rpm") if recursive else directory.glob("*.rpm")))
+            files.extend(sorted(directory.rglob(ext) if recursive else directory.glob(ext)))
         if not files:
-            click.echo("No .rpm files found to upload.")
+            click.echo(f"No {ext} files found to upload.")
             return
 
         storage = StorageManager(config.storage)
@@ -189,7 +331,10 @@ def create_package_group(cli: click.Group) -> None:
             repository = _get_or_create_repository(session, repo_config)
             for f in files:
                 try:
-                    result = _upload_rpm(session, storage, repository, f, force)
+                    if repo_config.type == "rpm":
+                        result = _upload_rpm(session, storage, repository, f, force)
+                    else:
+                        result = _upload_deb(session, storage, repository, f, force, component)
                 except Exception as e:  # noqa: BLE001 - report per-file, continue
                     session.rollback()
                     failed += 1

--- a/src/chantal/plugins/apt/deb.py
+++ b/src/chantal/plugins/apt/deb.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""
+Pure-Python reader for the control metadata of a Debian ``.deb`` package.
+
+A ``.deb`` is an ``ar`` archive containing ``debian-binary``, a
+``control.tar.{gz,xz,zst}`` (the package metadata) and a ``data.tar.*`` (the
+payload). The Python standard library has no ``ar`` reader, so we parse the
+small, fixed ``ar`` header format directly, then decompress the control tarball
+and read its ``./control`` member. No ``dpkg-deb`` binary is required.
+"""
+
+import tarfile
+from collections.abc import Iterator
+from io import BytesIO
+
+from chantal.plugins.apt.parsers import parse_rfc822_stanza
+from chantal.plugins.rpm.modules import decompress_bytes
+
+_AR_MAGIC = b"!<arch>\n"
+_AR_HEADER_SIZE = 60
+
+
+class DebFormatError(Exception):
+    """Raised when the bytes are not a parseable ``.deb`` package."""
+
+
+def _iter_ar_members(data: bytes) -> Iterator[tuple[str, bytes]]:
+    """Yield ``(name, payload)`` for each member of an ``ar`` archive."""
+    if data[: len(_AR_MAGIC)] != _AR_MAGIC:
+        raise DebFormatError("not a .deb file (bad ar magic)")
+    offset = len(_AR_MAGIC)
+    while offset + _AR_HEADER_SIZE <= len(data):
+        header = data[offset : offset + _AR_HEADER_SIZE]
+        if header[58:60] != b"`\n":
+            raise DebFormatError("corrupt ar header (bad terminator)")
+        # GNU ar pads names to 16 bytes and may append a trailing '/'.
+        name = header[0:16].decode("ascii", "replace").rstrip().rstrip("/")
+        try:
+            size = int(header[48:58].decode("ascii").strip())
+        except ValueError as exc:
+            raise DebFormatError("corrupt ar header (bad size)") from exc
+        start = offset + _AR_HEADER_SIZE
+        payload = data[start : start + size]
+        yield name, payload
+        # Member data is padded to an even byte boundary.
+        offset = start + size + (size & 1)
+
+
+def _control_suffix(name: str) -> str:
+    """Map a ``control.tar*`` member name to a ``decompress_bytes`` suffix."""
+    if name.endswith(".gz"):
+        return ".gz"
+    if name.endswith(".xz"):
+        return ".xz"
+    if name.endswith(".zst"):
+        return ".zst"
+    if name.endswith(".bz2"):
+        return ".bz2"
+    return ""  # plain control.tar
+
+
+def parse_deb_control(data: bytes) -> dict[str, str]:
+    """Extract the control fields (``Package``, ``Version``, ...) from a ``.deb``.
+
+    Args:
+        data: The full ``.deb`` file bytes.
+
+    Returns:
+        The RFC822 control stanza as a field -> value dict.
+
+    Raises:
+        DebFormatError: If the bytes are not a parseable ``.deb``.
+    """
+    control_name: str | None = None
+    control_bytes = b""
+    for name, payload in _iter_ar_members(data):
+        if name.startswith("control.tar"):
+            control_name = name
+            control_bytes = payload
+            break
+    if control_name is None:
+        raise DebFormatError("no control.tar member found in .deb")
+
+    try:
+        tar_bytes = decompress_bytes(control_bytes, _control_suffix(control_name))
+        with tarfile.open(fileobj=BytesIO(tar_bytes)) as tar:
+            member = next(
+                (m for m in tar.getmembers() if m.name in ("./control", "control")),
+                None,
+            )
+            if member is None:
+                raise DebFormatError("no control file in control.tar")
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                raise DebFormatError("could not read control file from control.tar")
+            text = extracted.read().decode("utf-8", "replace")
+    except DebFormatError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - normalize any decode/tar error
+        raise DebFormatError(f"could not read .deb control archive: {exc}") from exc
+
+    fields = parse_rfc822_stanza(text)
+    if not fields.get("Package"):
+        raise DebFormatError("control file has no Package field")
+    return fields

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -194,15 +194,15 @@ class AptPublisher(PublisherPlugin):
             dists_path, published_metadata, repository_files, mode
         )
 
-        # In filtered mode the regenerated Release invalidates upstream signatures.
-        # Sign it ourselves when a GPG key is configured, otherwise warn the user.
-        if mode == RepositoryMode.FILTERED:
+        # In filtered/hosted mode the regenerated Release has no upstream
+        # signature. Sign it ourselves when a GPG key is configured, else warn.
+        if mode in (RepositoryMode.FILTERED, RepositoryMode.HOSTED):
             gpg_config = self.config.gpg
             if gpg_config is not None and gpg_config.enabled:
                 self._sign_release(release_file, target_path, gpg_config)
             else:
-                print("\n⚠️  WARNING: Filtered mode - Publishing without GPG signatures!")
-                print("    Regenerating metadata based on filtered packages.")
+                print(f"\n⚠️  WARNING: {mode} mode - Publishing without GPG signatures!")
+                print("    Regenerating metadata based on the repository's packages.")
                 print("    Clients must use [trusted=yes] or Acquire::AllowInsecureRepositories=1")
                 print(
                     "    Example: deb [trusted=yes] http://mirror/ubuntu jammy main restricted universe multiverse"

--- a/tests/e2e/test_deb_real_client_e2e.py
+++ b/tests/e2e/test_deb_real_client_e2e.py
@@ -1,0 +1,109 @@
+"""
+End-to-end test with a REAL apt client (Docker): custom .deb upload (#16).
+
+Builds a genuine .deb, uploads it into a HOSTED (upload-only) apt repo via
+`chantal package upload`, publishes, then `apt-get install`s it from the
+published repo in a debian container. Proves the whole custom-upload chain for
+APT: pure-Python ar/control extraction, hosted mode, Packages/Release
+generation, real pool layout, and real apt install.
+
+Docker-gated: skipped where docker is unavailable; runs on the CI apt e2e leg.
+Self-contained: the .deb is built in-container (dpkg-deb) and the published repo
+is streamed into the apt container as a tar over stdin (no bind-mounts).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_DOCKER = shutil.which("docker") is not None
+_IMAGE = "debian:bookworm"
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+requires_docker = pytest.mark.skipif(not _HAVE_DOCKER, reason="docker not available")
+
+
+def _build_real_deb() -> bytes:
+    """Build a genuine .deb in a debian container; return its bytes."""
+    script = (
+        "set -e; mkdir -p /pkg/DEBIAN /pkg/usr/bin; "
+        'printf "Package: demo-hosted\\nVersion: 1.0\\nArchitecture: amd64\\n'
+        'Maintainer: t <t@e.x>\\nDescription: chantal hosted deb test\\n"'
+        " > /pkg/DEBIAN/control; "
+        'printf "#!/bin/sh\\necho hello-from-hosted-deb\\n" > /pkg/usr/bin/demo-hosted; '
+        "chmod +x /pkg/usr/bin/demo-hosted; "
+        "dpkg-deb --build /pkg /out.deb >/dev/null; base64 -w0 /out.deb"
+    )
+    out = subprocess.run(
+        ["docker", "run", "--rm", _IMAGE, "bash", "-c", script],
+        capture_output=True,
+        timeout=300,
+    )
+    assert out.returncode == 0, f"deb build failed: {out.stderr.decode()[-500:]}"
+    return base64.b64decode(out.stdout)
+
+
+def _apt_install(published: Path) -> subprocess.CompletedProcess:
+    """Stream the published repo into a debian container and apt-install from it."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(published, arcname=".")
+    script = (
+        "set -e; mkdir -p /repo && tar -xf - -C /repo; "
+        "rm -f /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true; "
+        f'echo "deb [trusted=yes] file:/repo {DIST} {COMP}" > /etc/apt/sources.list.d/c.list; '
+        "apt-get update >/dev/null; "
+        "apt-get install -y demo-hosted >/dev/null; "
+        "demo-hosted"
+    )
+    return subprocess.run(
+        ["docker", "run", "--rm", "-i", _IMAGE, "bash", "-c", script],
+        input=buf.getvalue(),
+        capture_output=True,
+        timeout=600,
+    )
+
+
+@requires_docker
+def test_deb_hosted_upload_installs_with_real_apt(tmp_path, chantal_env):
+    deb_bytes = _build_real_deb()
+    deb_file = tmp_path / "demo-hosted_1.0_amd64.deb"
+    deb_file.write_bytes(deb_bytes)
+
+    chantal_env.write_config(
+        {
+            "id": "internal-deb",
+            "name": "Internal DEB",
+            "type": "apt",
+            "enabled": True,
+            "mode": "hosted",  # no feed; upload-only
+            "apt": {"distribution": DIST, "components": [COMP], "architectures": [ARCH]},
+        }
+    )
+
+    # Upload the local .deb, then publish (no sync — hosted has no upstream).
+    chantal_env.run("package", "upload", "--file", str(deb_file), "--repo-id", "internal-deb")
+    target = chantal_env.published / "internal-deb"
+    chantal_env.run("publish", "repo", "--repo-id", "internal-deb", "--target", str(target))
+
+    # The uploaded package is in the published pool.
+    assert list(target.rglob("demo-hosted_1.0_amd64.deb")), "uploaded deb not published"
+
+    result = _apt_install(target)
+    assert result.returncode == 0, (
+        f"real apt install failed:\nstdout={result.stdout.decode()[-800:]}\n"
+        f"stderr={result.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-hosted-deb" in result.stdout, "installed binary did not run"

--- a/tests/test_deb_upload.py
+++ b/tests/test_deb_upload.py
@@ -1,0 +1,199 @@
+"""Unit tests for .deb control parsing and `chantal package upload` (deb path).
+
+Builds synthetic .deb files (an ar archive with a control.tar.{gz,xz,zst})
+so the pure-Python ar/control parser, metadata mapping, and the dedup /
+conflict / --force matrix are exercised without dpkg or docker.
+"""
+
+from __future__ import annotations
+
+import io
+import lzma
+import tarfile
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from chantal.cli.package_commands import _upload_deb
+from chantal.core.config import StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.models import Base, ContentItem, Repository
+from chantal.plugins.apt.deb import DebFormatError, parse_deb_control
+
+_CONTROL = (
+    "Package: demo\n"
+    "Version: 1.0\n"
+    "Architecture: amd64\n"
+    "Maintainer: Simon Lauger <simon@lauger.de>\n"
+    "Installed-Size: 42\n"
+    "Depends: libc6 (>= 2.34)\n"
+    "Section: utils\n"
+    "Priority: optional\n"
+    "Description: a demo package\n"
+    " This is the extended description.\n"
+    " It spans multiple lines.\n"
+)
+
+
+def _ar_member(name: str, data: bytes) -> bytes:
+    header = (
+        name.ljust(16).encode()
+        + b"0".ljust(12)  # mtime
+        + b"0".ljust(6)  # uid
+        + b"0".ljust(6)  # gid
+        + b"100644".ljust(8)  # mode
+        + str(len(data)).ljust(10).encode()  # size
+        + b"`\n"
+    )
+    out = header + data
+    if len(data) % 2:
+        out += b"\n"  # pad to even length
+    return out
+
+
+def _control_tar(control_text: str, compression: str) -> tuple[str, bytes]:
+    """Return (member_name, bytes) for a control.tar.<compression>."""
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tar:
+        data = control_text.encode()
+        info = tarfile.TarInfo("./control")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    tar_bytes = raw.getvalue()
+
+    if compression == "gz":
+        import gzip
+
+        return "control.tar.gz", gzip.compress(tar_bytes)
+    if compression == "xz":
+        return "control.tar.xz", lzma.compress(tar_bytes)
+    if compression == "zst":
+        import zstandard as zstd
+
+        return "control.tar.zst", zstd.ZstdCompressor().compress(tar_bytes)
+    raise ValueError(compression)
+
+
+def _build_deb(control_text: str = _CONTROL, compression: str = "gz") -> bytes:
+    name, control_archive = _control_tar(control_text, compression)
+    return b"!<arch>\n" + _ar_member("debian-binary", b"2.0\n") + _ar_member(name, control_archive)
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    sess = sessionmaker(bind=engine)()
+    yield sess
+    sess.close()
+
+
+@pytest.fixture
+def storage(tmp_path):
+    (tmp_path / "pool").mkdir()
+    return StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(tmp_path / "pool"),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+
+
+@pytest.fixture
+def repository(session):
+    repo = Repository(repo_id="internal", name="Internal", type="apt", feed="", mode="HOSTED")
+    session.add(repo)
+    session.commit()
+    return repo
+
+
+def _deb_items(repository: Repository) -> list[ContentItem]:
+    return [i for i in repository.content_items if i.content_type == "deb"]
+
+
+@pytest.mark.parametrize("compression", ["gz", "xz", "zst"])
+def test_parse_deb_control_all_compressions(compression):
+    fields = parse_deb_control(_build_deb(compression=compression))
+    assert fields["Package"] == "demo"
+    assert fields["Version"] == "1.0"
+    assert fields["Architecture"] == "amd64"
+    # Multi-line Description is joined with newlines by the RFC822 parser.
+    assert fields["Description"].startswith("a demo package\n")
+
+
+def test_parse_deb_control_rejects_non_deb():
+    with pytest.raises(DebFormatError, match="bad ar magic"):
+        parse_deb_control(b"not a deb at all")
+
+
+def test_upload_maps_control_fields(session, storage, repository, tmp_path):
+    f = tmp_path / "demo_1.0_amd64.deb"
+    f.write_bytes(_build_deb())
+    assert _upload_deb(session, storage, repository, f, force=False, component="main") == "uploaded"
+
+    item = _deb_items(repository)[0]
+    meta = item.content_metadata
+    assert item.name == "demo"
+    assert item.version == "1.0"
+    assert meta["architecture"] == "amd64"
+    assert meta["component"] == "main"
+    assert meta["maintainer"] == "Simon Lauger <simon@lauger.de>"
+    assert meta["depends"] == "libc6 (>= 2.34)"
+    assert meta["installed_size"] == 42
+    # Synopsis only in description; extended text kept out of the Packages line.
+    assert meta["description"] == "a demo package"
+    assert "extended description" in meta["long_description"]
+
+
+def test_upload_then_link_same_bytes(session, storage, repository, tmp_path):
+    f = tmp_path / "demo_1.0_amd64.deb"
+    f.write_bytes(_build_deb())
+    assert _upload_deb(session, storage, repository, f, force=False, component="main") == "uploaded"
+    assert _upload_deb(session, storage, repository, f, force=False, component="main") == "linked"
+    assert len(_deb_items(repository)) == 1
+
+
+def test_same_identity_different_content_requires_force(session, storage, repository, tmp_path):
+    a = tmp_path / "a.deb"
+    a.write_bytes(_build_deb(_CONTROL))
+    b = tmp_path / "b.deb"
+    b.write_bytes(_build_deb(_CONTROL.replace("Section: utils", "Section: net")))  # diff bytes
+
+    assert _upload_deb(session, storage, repository, a, force=False, component="main") == "uploaded"
+    with pytest.raises(ValueError, match="already present"):
+        _upload_deb(session, storage, repository, b, force=False, component="main")
+    assert len(_deb_items(repository)) == 1
+    assert _deb_items(repository)[0].content_metadata["section"] == "utils"
+
+    assert _upload_deb(session, storage, repository, b, force=True, component="main") == "replaced"
+    items = _deb_items(repository)
+    assert len(items) == 1
+    assert items[0].content_metadata["section"] == "net"
+
+
+def test_distinct_content_different_component_coexist(session, storage, repository, tmp_path):
+    """Different bytes, same name/version/arch but a different component coexist."""
+    a = tmp_path / "a.deb"
+    a.write_bytes(_build_deb(_CONTROL))
+    b = tmp_path / "b.deb"
+    b.write_bytes(_build_deb(_CONTROL.replace("Section: utils", "Section: net")))
+
+    assert _upload_deb(session, storage, repository, a, force=False, component="main") == "uploaded"
+    # Different component AND different bytes -> no conflict, both kept.
+    assert (
+        _upload_deb(session, storage, repository, b, force=False, component="contrib") == "uploaded"
+    )
+    assert len(_deb_items(repository)) == 2
+
+
+def test_identical_bytes_different_component_rejected(session, storage, repository, tmp_path):
+    """The same bytes can't be filed under two components (global sha256 dedup)."""
+    f = tmp_path / "demo.deb"
+    f.write_bytes(_build_deb(_CONTROL))
+
+    assert _upload_deb(session, storage, repository, f, force=False, component="main") == "uploaded"
+    with pytest.raises(ValueError, match="already pooled under component 'main'"):
+        _upload_deb(session, storage, repository, f, force=False, component="contrib")
+    assert len(_deb_items(repository)) == 1


### PR DESCRIPTION
Implements the **APT phase** of #16 (custom package upload). Follows the same shape as the merged RPM phase (#82).

## What

`chantal package upload` now accepts local `.deb` files into a **hosted** (upload-only) APT repository, and gains a `--component` option (default `main`). The existing publisher regenerates `Packages`/`Release` + pool layout so the result installs with stock `apt`.

```bash
chantal package upload --repo-id internal-debs --file ./demo_1.0_amd64.deb
chantal package upload --repo-id internal-debs --directory ./debs/ --recursive --component contrib
chantal publish repo --repo-id internal-debs --target /srv/repos/internal-debs
```

## How

- **Pure-Python `.deb` parsing** — new `src/chantal/plugins/apt/deb.py` reads the `ar` container and decompresses `control.tar.{gz,xz,zst}` (reusing the existing `decompress_bytes` and the RFC822 `parse_rfc822_stanza`). No `dpkg-deb` / `python-debian` dependency.
- **Field mapping** — control fields are mapped to exactly the `content_metadata` keys the APT publisher reads; the extended description is split out of the single-line `Packages` `Description:`.
- **Dedup / conflict** — content-addressed, SHA-256 deduplicated. Identical bytes link; a differing build of a name/version/arch already in the repo requires `--force` (unlink + relink in one transaction). Re-uploading identical bytes under a *different* component is rejected explicitly (global checksum dedup + single-component `ContentItem` can't represent it) rather than silently mis-filed.
- **Hosted signing** — the regenerated `Release` for hosted repos is now signed when a `gpg` section is configured (previously only filtered mode signed).

## Tests

- `tests/test_deb_upload.py` — synthetic `.deb` builder; control parsing across **gz/xz/zst**, field mapping, dedup / conflict / `--force` / component matrix, and the identical-bytes-different-component rejection.
- `tests/e2e/test_deb_real_client_e2e.py` — Docker e2e that builds a real `.deb`, uploads it, publishes, and installs it with **real `apt-get`** from the published hosted repo. Runs on the CI `apt` e2e leg.

Full gate green locally: ruff, black, mypy, yamllint, unit suite, and the apt e2e.

Part of #16.