### PR TITLE
feat(helm): custom chart upload into hosted repositories

### DIFF
--- a/docs/plugins/helm-plugin.md
+++ b/docs/plugins/helm-plugin.md
@@ -21,6 +21,7 @@ The Helm plugin consists of:
 - ✅ Chart deduplication via content-addressed storage
 - ✅ Snapshot support
 - ✅ **Mirror Mode** - Byte-for-byte identical repositories with snapshot versioning
+- ✅ **Hosted Mode** - Upload-only repositories for self-hosted charts (`chantal package upload`)
 - ✅ OCI registry support (`oci://` chart repositories)
 - ℹ️ Charts are served unmodified; Chantal does not sign or re-sign charts (upstream Helm provenance `.prov` files are preserved if present)
 
@@ -82,6 +83,54 @@ This mode:
 - Supports post-processing (e.g., only latest versions)
 
 **Note:** For filtered repositories (pattern-based chart selection), dynamic generation is used automatically.
+
+### Hosted Mode
+
+An upload-only repository with **no upstream feed**. Custom-built charts are
+added with `chantal package upload`; there is nothing to sync, so `chantal sync`
+skips hosted repositories. Publishing generates `index.yaml` from the uploaded
+charts (the dynamic-generation path above), so the result is consumable by a
+real `helm` client.
+
+```yaml
+repositories:
+  - id: internal-charts
+    name: Internal Helm Charts
+    type: helm
+    enabled: true
+    mode: hosted
+    # note: no 'feed' - hosted repos hold only uploaded charts
+```
+
+Upload one or more local chart `.tgz` files and publish:
+
+```bash
+# A single chart
+chantal package upload --repo-id internal-charts --file ./demo-0.1.0.tgz
+
+# A whole directory (optionally recursive)
+chantal package upload --repo-id internal-charts --directory ./charts/ --recursive
+
+# Replace an existing chart of the same name/version with different content
+chantal package upload --repo-id internal-charts --file ./demo-0.1.0.tgz --force
+
+# Regenerate index.yaml so clients can pull
+chantal publish repo --repo-id internal-charts --target /srv/repos/internal-charts
+```
+
+Chart metadata is read from the chart's top-level `Chart.yaml` in **pure
+Python** (the gzipped tar is opened directly) - no `helm` binary is required.
+Uploads are content-addressed and deduplicated by SHA-256: re-uploading
+identical bytes just links the existing pool entry, while a different build of a
+chart name/version already present requires `--force`.
+
+Clients consume it like any other Helm HTTP repository:
+
+```bash
+helm repo add internal http://mirror.example.com/repos/internal-charts
+helm repo update
+helm pull internal/demo --version 0.1.0
+```
 
 ## Configuration
 

--- a/src/chantal/cli/package_commands.py
+++ b/src/chantal/cli/package_commands.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 """
 CLI for uploading custom (local) packages into a repository's content pool.
 
-Supports RPM (.rpm) and APT (.deb) uploads into a hosted (upload-only)
-repository. Uploaded packages are added to the content-addressed pool and
-linked to the repository as ContentItems, so the existing publisher includes
-them when it regenerates the repository metadata.
+Supports RPM (.rpm), APT (.deb) and Helm (.tgz) uploads into a hosted
+(upload-only) repository. Uploaded packages are added to the content-addressed
+pool and linked to the repository as ContentItems, so the existing publisher
+includes them when it regenerates the repository metadata.
 """
 
 from pathlib import Path
@@ -21,6 +21,8 @@ from chantal.db.connection import DatabaseManager
 from chantal.db.models import ContentItem, Repository
 from chantal.plugins.apt.deb import parse_deb_control
 from chantal.plugins.apt.models import DebMetadata
+from chantal.plugins.helm.chart import parse_chart_metadata
+from chantal.plugins.helm.models import HelmMetadata
 from chantal.plugins.rpm.models import RpmMetadata
 from chantal.plugins.rpm.rpm_header import parse_main_header
 
@@ -258,6 +260,66 @@ def _upload_deb(
     return "replaced" if conflict is not None else "uploaded"
 
 
+def _upload_helm(
+    session: Session, storage: StorageManager, repository: Repository, path: Path, force: bool
+) -> str:
+    """Add one local Helm chart .tgz to the pool and link it to the repo.
+
+    Returns "uploaded", "linked" (already in pool) or "replaced".
+    """
+    chart = parse_chart_metadata(path)  # ChartFormatError if not a chart archive
+    # digest/urls/created are index.yaml-only; the publisher fills them itself.
+    meta = HelmMetadata(**chart)
+    name = meta.name
+    version = meta.version
+
+    filename = path.name
+    sha256, pool_path, size_bytes = storage.add_package(path, filename, verify_checksum=True)
+
+    # Same chart name+version but different content -> conflict.
+    conflict = next(
+        (
+            item
+            for item in repository.content_items
+            if item.content_type == "helm"
+            and item.name == name
+            and item.version == version
+            and item.sha256 != sha256
+        ),
+        None,
+    )
+    ident = f"{name}-{version}"
+    if conflict is not None and not force:
+        raise ValueError(
+            f"{ident} already present in the repo with different content (use --force to replace)"
+        )
+
+    if conflict is not None:
+        conflict.repositories.remove(repository)
+
+    existing = session.query(ContentItem).filter_by(sha256=sha256).first()
+    if existing is not None:
+        if repository not in existing.repositories:
+            existing.repositories.append(repository)
+        session.commit()
+        return "replaced" if conflict is not None else "linked"
+
+    content_item = ContentItem(
+        content_type="helm",
+        name=name,
+        version=version,
+        sha256=sha256,
+        size_bytes=size_bytes,
+        pool_path=pool_path,
+        filename=filename,
+        content_metadata=meta.model_dump(mode="json"),
+    )
+    content_item.repositories.append(repository)
+    session.add(content_item)
+    session.commit()
+    return "replaced" if conflict is not None else "uploaded"
+
+
 def create_package_group(cli: click.Group) -> None:
     """Register the ``package`` command group."""
 
@@ -285,7 +347,7 @@ def create_package_group(cli: click.Group) -> None:
         "--component",
         default="main",
         show_default=True,
-        help="APT component for uploaded .deb packages (ignored for rpm).",
+        help="APT component for uploaded .deb packages (ignored for rpm/helm).",
     )
     @click.pass_context
     def upload(
@@ -303,9 +365,9 @@ def create_package_group(cli: click.Group) -> None:
         if repo_config is None:
             click.echo(f"Error: repository '{repo_id}' not found in configuration", err=True)
             raise click.Abort()
-        if repo_config.type not in ("rpm", "apt"):
+        if repo_config.type not in ("rpm", "apt", "helm"):
             click.echo(
-                f"Error: package upload supports only 'rpm' and 'apt' repositories "
+                f"Error: package upload supports only 'rpm', 'apt' and 'helm' repositories "
                 f"(repository '{repo_id}' is '{repo_config.type}')",
                 err=True,
             )
@@ -314,7 +376,7 @@ def create_package_group(cli: click.Group) -> None:
             click.echo("Error: provide --file or --directory", err=True)
             raise click.Abort()
 
-        ext = "*.rpm" if repo_config.type == "rpm" else "*.deb"
+        ext = {"rpm": "*.rpm", "apt": "*.deb", "helm": "*.tgz"}[repo_config.type]
         files: list[Path] = []
         if file_path:
             files.append(file_path)
@@ -333,8 +395,10 @@ def create_package_group(cli: click.Group) -> None:
                 try:
                     if repo_config.type == "rpm":
                         result = _upload_rpm(session, storage, repository, f, force)
-                    else:
+                    elif repo_config.type == "apt":
                         result = _upload_deb(session, storage, repository, f, force, component)
+                    else:
+                        result = _upload_helm(session, storage, repository, f, force)
                 except Exception as e:  # noqa: BLE001 - report per-file, continue
                     session.rollback()
                     failed += 1

--- a/src/chantal/plugins/helm/chart.py
+++ b/src/chantal/plugins/helm/chart.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""
+Pure-Python reader for the ``Chart.yaml`` metadata of a Helm chart archive.
+
+A packaged Helm chart is a gzipped tarball containing ``<chart>/Chart.yaml``
+(plus ``templates/``, ``values.yaml`` and optionally ``charts/<dep>/...`` for
+bundled subcharts). We read the top-level ``Chart.yaml`` directly with the
+standard library; no ``helm`` binary is required.
+"""
+
+import tarfile
+from pathlib import Path
+
+import yaml
+
+
+class ChartFormatError(Exception):
+    """Raised when the bytes are not a parseable Helm chart archive."""
+
+
+def parse_chart_metadata(path: Path) -> dict:
+    """Extract the ``Chart.yaml`` metadata from a packaged chart ``.tgz``.
+
+    Args:
+        path: Path to the ``.tgz`` chart archive.
+
+    Returns:
+        The parsed ``Chart.yaml`` as a dict.
+
+    Raises:
+        ChartFormatError: If the file is not a valid chart archive or has no
+            usable ``Chart.yaml``.
+    """
+    try:
+        with tarfile.open(path, "r:gz") as tar:
+            members = [
+                m for m in tar.getmembers() if m.isfile() and Path(m.name).name == "Chart.yaml"
+            ]
+            if not members:
+                raise ChartFormatError("no Chart.yaml found in chart archive")
+            # The top-level Chart.yaml is the shallowest ("<chart>/Chart.yaml");
+            # deeper ones belong to bundled subcharts (charts/<dep>/Chart.yaml).
+            member = min(members, key=lambda m: m.name.count("/"))
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                raise ChartFormatError("could not read Chart.yaml from chart archive")
+            data = yaml.safe_load(extracted.read())
+    except ChartFormatError:
+        raise
+    except tarfile.ReadError as exc:
+        raise ChartFormatError(f"not a valid gzipped chart archive (.tgz): {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 - normalize any tar/yaml error
+        raise ChartFormatError(f"could not read chart archive: {exc}") from exc
+
+    if not isinstance(data, dict) or not data.get("name") or not data.get("version"):
+        raise ChartFormatError("Chart.yaml is missing required 'name'/'version' fields")
+    return data

--- a/src/chantal/plugins/helm/models.py
+++ b/src/chantal/plugins/helm/models.py
@@ -75,7 +75,6 @@ class HelmMetadata(BaseModel):
     deprecated: bool | None = None
     annotations: dict[str, str] | None = None
     kube_version: str | None = Field(None, alias="kubeVersion")
-    app_version_field: str | None = Field(None, alias="appVersion")
 
     # Allow both 'appVersion' and 'app_version'
     model_config = ConfigDict(populate_by_name=True)

--- a/tests/e2e/test_helm_real_client_e2e.py
+++ b/tests/e2e/test_helm_real_client_e2e.py
@@ -1,0 +1,108 @@
+"""
+End-to-end test with a REAL helm client (Docker): custom chart upload (#16).
+
+Builds a genuine chart with `helm package`, uploads it into a HOSTED
+(upload-only) helm repo via `chantal package upload`, publishes, then adds the
+published repo with `helm repo add` and `helm pull`s the chart in an
+alpine/helm container. Proves the whole custom-upload chain for Helm:
+pure-Python Chart.yaml extraction, hosted mode, index.yaml generation, and a
+real helm client consuming the result.
+
+Docker-gated: skipped where docker is unavailable; runs on the CI helm e2e leg.
+`helm repo add` needs an http(s) URL, so the published repo is streamed into the
+container as a tar over stdin and served with `python3 -m http.server` locally.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_DOCKER = shutil.which("docker") is not None
+_IMAGE = "alpine/helm"
+
+requires_docker = pytest.mark.skipif(not _HAVE_DOCKER, reason="docker not available")
+
+
+def _build_chart() -> bytes:
+    """Build a real chart .tgz with `helm package`; return its bytes."""
+    script = (
+        "set -e; cd /tmp; helm create demo >/dev/null; "
+        "helm package demo >/dev/null; "
+        "base64 demo-0.1.0.tgz | tr -d '\\n'"
+    )
+    out = subprocess.run(
+        ["docker", "run", "--rm", "--entrypoint", "/bin/sh", _IMAGE, "-c", script],
+        capture_output=True,
+        timeout=300,
+    )
+    assert out.returncode == 0, f"helm package failed: {out.stderr.decode()[-600:]}"
+    return base64.b64decode(out.stdout)
+
+
+def _helm_pull(published: Path) -> subprocess.CompletedProcess:
+    """Stream the published repo into a container, serve it, and `helm pull`."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(published, arcname=".")
+    script = (
+        "set -e; apk add --no-cache python3 >/dev/null; "
+        "mkdir -p /repo && tar -xf - -C /repo; "
+        "cd /repo && python3 -m http.server 8879 >/dev/null 2>&1 & "
+        # wait for the server to accept connections
+        "for i in $(seq 1 30); do "
+        "  wget -q -O /dev/null http://127.0.0.1:8879/index.yaml && break; sleep 0.3; done; "
+        "cd /tmp; "
+        "helm repo add local http://127.0.0.1:8879 >/dev/null; "
+        "helm repo update >/dev/null; "
+        "helm pull local/demo --version 0.1.0; "
+        "ls demo-0.1.0.tgz; "
+        "helm show chart local/demo | grep '^name:'"
+    )
+    return subprocess.run(
+        ["docker", "run", "--rm", "-i", "--entrypoint", "/bin/sh", _IMAGE, "-c", script],
+        input=buf.getvalue(),
+        capture_output=True,
+        timeout=600,
+    )
+
+
+@requires_docker
+def test_helm_hosted_upload_pulls_with_real_helm(tmp_path, chantal_env):
+    chart_bytes = _build_chart()
+    chart_file = tmp_path / "demo-0.1.0.tgz"
+    chart_file.write_bytes(chart_bytes)
+
+    chantal_env.write_config(
+        {
+            "id": "internal-helm",
+            "name": "Internal Helm",
+            "type": "helm",
+            "enabled": True,
+            "mode": "hosted",  # no feed; upload-only
+        }
+    )
+
+    # Upload the local chart, then publish (no sync — hosted has no upstream).
+    chantal_env.run("package", "upload", "--file", str(chart_file), "--repo-id", "internal-helm")
+    target = chantal_env.published / "internal-helm"
+    chantal_env.run("publish", "repo", "--repo-id", "internal-helm", "--target", str(target))
+
+    # The uploaded chart is in the published repo alongside a generated index.yaml.
+    assert list(target.rglob("demo-0.1.0.tgz")), "uploaded chart not published"
+    assert list(target.rglob("index.yaml")), "generated index.yaml not found"
+
+    result = _helm_pull(target)
+    assert result.returncode == 0, (
+        f"real helm pull failed:\nstdout={result.stdout.decode()[-800:]}\n"
+        f"stderr={result.stderr.decode()[-800:]}"
+    )
+    assert b"name: demo" in result.stdout, "helm did not resolve the chart from the repo"

--- a/tests/test_helm_upload.py
+++ b/tests/test_helm_upload.py
@@ -1,0 +1,184 @@
+"""Unit tests for Helm Chart.yaml parsing and `chantal package upload` (helm path).
+
+Builds synthetic chart .tgz archives (gzipped tar with <chart>/Chart.yaml) so
+the pure-Python Chart.yaml extraction, metadata mapping, and the dedup /
+conflict / --force matrix are exercised without the helm binary or docker.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from chantal.cli.package_commands import _upload_helm
+from chantal.core.config import StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.models import Base, ContentItem, Repository
+from chantal.plugins.helm.chart import ChartFormatError, parse_chart_metadata
+
+_CHART = {
+    "apiVersion": "v2",
+    "name": "demo",
+    "version": "0.1.0",
+    "appVersion": "1.16.0",
+    "description": "A demo chart",
+    "type": "application",
+    "keywords": ["demo", "test"],
+    "maintainers": [{"name": "Simon Lauger", "email": "simon@lauger.de"}],
+}
+
+
+def _add(tar: tarfile.TarFile, name: str, content: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(content)
+    tar.addfile(info, io.BytesIO(content))
+
+
+def _build_chart(chart: dict | None = None, extra_files: dict[str, bytes] | None = None) -> bytes:
+    chart = chart if chart is not None else _CHART
+    root = chart["name"]
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        _add(tar, f"{root}/Chart.yaml", yaml.safe_dump(chart).encode())
+        _add(tar, f"{root}/values.yaml", b"replicaCount: 1\n")
+        for path, content in (extra_files or {}).items():
+            _add(tar, f"{root}/{path}", content)
+    return buf.getvalue()
+
+
+def _parse_bytes(data: bytes) -> dict:
+    """parse_chart_metadata takes a Path, so spill the bytes to a temp file."""
+    with tempfile.NamedTemporaryFile(suffix=".tgz", delete=False) as f:
+        f.write(data)
+        path = Path(f.name)
+    return parse_chart_metadata(path)
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    sess = sessionmaker(bind=engine)()
+    yield sess
+    sess.close()
+
+
+@pytest.fixture
+def storage(tmp_path):
+    (tmp_path / "pool").mkdir()
+    return StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(tmp_path / "pool"),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+
+
+@pytest.fixture
+def repository(session):
+    repo = Repository(repo_id="internal", name="Internal", type="helm", feed="", mode="HOSTED")
+    session.add(repo)
+    session.commit()
+    return repo
+
+
+def _helm_items(repository: Repository) -> list[ContentItem]:
+    return [i for i in repository.content_items if i.content_type == "helm"]
+
+
+def test_parse_chart_metadata():
+    meta = _parse_bytes(_build_chart())
+    assert meta["name"] == "demo"
+    assert meta["version"] == "0.1.0"
+    assert meta["appVersion"] == "1.16.0"
+
+
+def test_parse_chart_picks_toplevel_over_subchart():
+    """A bundled subchart's Chart.yaml must not shadow the top-level one."""
+    sub = yaml.safe_dump({"apiVersion": "v2", "name": "dep", "version": "9.9.9"}).encode()
+    data = _build_chart(extra_files={"charts/dep/Chart.yaml": sub})
+    meta = _parse_bytes(data)
+    assert meta["name"] == "demo"  # not "dep"
+    assert meta["version"] == "0.1.0"
+
+
+def test_parse_chart_rejects_non_gzip():
+    with pytest.raises(ChartFormatError):
+        _parse_bytes(b"not a gzip tarball")
+
+
+def test_parse_chart_rejects_archive_without_chart_yaml():
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        _add(tar, "demo/values.yaml", b"replicaCount: 1\n")
+    with pytest.raises(ChartFormatError, match="no Chart.yaml"):
+        _parse_bytes(buf.getvalue())
+
+
+def test_parse_chart_rejects_chart_yaml_missing_name_version():
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        _add(tar, "demo/Chart.yaml", yaml.safe_dump({"apiVersion": "v2"}).encode())
+    with pytest.raises(ChartFormatError, match="missing required"):
+        _parse_bytes(buf.getvalue())
+
+
+def test_parse_chart_rejects_non_dict_chart_yaml():
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        _add(tar, "demo/Chart.yaml", b"- just\n- a\n- list\n")
+    with pytest.raises(ChartFormatError, match="missing required"):
+        _parse_bytes(buf.getvalue())
+
+
+def test_upload_maps_chart_fields(session, storage, repository, tmp_path):
+    f = tmp_path / "demo-0.1.0.tgz"
+    f.write_bytes(_build_chart())
+    assert _upload_helm(session, storage, repository, f, force=False) == "uploaded"
+
+    item = _helm_items(repository)[0]
+    meta = item.content_metadata
+    assert item.name == "demo"
+    assert item.version == "0.1.0"
+    assert meta["app_version"] == "1.16.0"
+    assert meta["description"] == "A demo chart"
+    assert meta["keywords"] == ["demo", "test"]
+    # digest/urls are filled by the publisher, not the uploaded item.
+    assert meta.get("digest") is None
+    assert meta.get("urls") is None
+
+
+def test_upload_then_link_same_bytes(session, storage, repository, tmp_path):
+    f = tmp_path / "demo-0.1.0.tgz"
+    f.write_bytes(_build_chart())
+    assert _upload_helm(session, storage, repository, f, force=False) == "uploaded"
+    assert _upload_helm(session, storage, repository, f, force=False) == "linked"
+    assert len(_helm_items(repository)) == 1
+
+
+def test_same_name_version_different_content_requires_force(session, storage, repository, tmp_path):
+    a = tmp_path / "a.tgz"
+    a.write_bytes(_build_chart())
+    b = tmp_path / "b.tgz"
+    b.write_bytes(
+        _build_chart({**_CHART, "description": "changed"})
+    )  # same name/version, diff bytes
+
+    assert _upload_helm(session, storage, repository, a, force=False) == "uploaded"
+    with pytest.raises(ValueError, match="already present"):
+        _upload_helm(session, storage, repository, b, force=False)
+    assert len(_helm_items(repository)) == 1
+    assert _helm_items(repository)[0].content_metadata["description"] == "A demo chart"
+
+    assert _upload_helm(session, storage, repository, b, force=True) == "replaced"
+    items = _helm_items(repository)
+    assert len(items) == 1
+    assert items[0].content_metadata["description"] == "changed"


### PR DESCRIPTION
Implements the **Helm phase** of #16 (custom package upload) - the final package type. Follows the same shape as the merged RPM (#82) and APT (#83) phases.

## What

`chantal package upload` now accepts local Helm chart `.tgz` files into a **hosted** (upload-only) Helm repository. The publisher regenerates `index.yaml` so a real `helm` client can pull the charts.

```bash
chantal package upload --repo-id internal-charts --file ./demo-0.1.0.tgz
chantal publish repo --repo-id internal-charts --target /srv/repos/internal-charts
# then: helm repo add internal http://.../internal-charts && helm pull internal/demo
```

## How

- **Pure-Python Chart.yaml extraction** — new `src/chantal/plugins/helm/chart.py` opens the gzipped tar and parses the chart's top-level `Chart.yaml` (the shallowest one, so bundled subcharts under `charts/<dep>/` don't shadow it). No `helm` binary required.
- **Metadata** — `HelmMetadata(**chart)` (camelCase aliases handled); index.yaml-only fields (`digest`/`urls`/`created`) are left unset because the publisher fills them when regenerating `index.yaml`.
- **Dedup / conflict** — content-addressed, SHA-256 deduplicated. Identical bytes link; a differing build of a chart name/version already in the repo requires `--force` (unlink + relink in one transaction). Same ordering as the merged rpm/deb paths (no silent-duplicate, no data-loss window).
- **Cleanup** — dropped the unused duplicate `appVersion` alias from `HelmMetadata` so uploaded metadata no longer stores a redundant field.

## Tests

- `tests/test_helm_upload.py` — synthetic chart `.tgz` builder; Chart.yaml parsing, top-level-vs-subchart selection, malformed-archive error paths, and the dedup / conflict / `--force` matrix.
- `tests/e2e/test_helm_real_client_e2e.py` — Docker e2e that builds a real chart with `helm package`, uploads it, publishes, then `helm repo add` + `helm pull`s it from the published hosted repo (served over http in-container). Runs on the CI `helm` e2e leg.

Full gate green locally: ruff, black, mypy, yamllint, unit suite, and the helm e2e.

A fresh-context review came back clean (no blocking findings); its three NICE-TO-HAVE cleanups are applied.

Part of #16.