### PR TITLE
test(e2e): real-client validation for all plugins (#73)

### DIFF
--- a/tests/e2e/test_apk_real_client_e2e.py
+++ b/tests/e2e/test_apk_real_client_e2e.py
@@ -1,0 +1,166 @@
+"""
+End-to-end test with a REAL apk client (Docker): signed APKINDEX + filtering.
+
+chantal mirrors a small genuine Alpine package, regenerates and **RSA-signs**
+the APKINDEX in filtered mode, and publishes a public key at the repo root.
+A real `apk` client then installs from the published repo with signature
+verification ON (no `--allow-untrusted`) — proving the whole chain: APKINDEX
+regeneration, RSA index signing, key publication, and trust by stock apk.
+
+Docker-gated: skipped where docker is unavailable; runs on the CI apk e2e leg.
+Self-contained: the upstream (a real .apk + index) is built in-container with
+`apk fetch`/`apk index`, and the published repo is streamed into the client
+container as a tar over stdin (no bind-mounts).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_DOCKER = shutil.which("docker") is not None
+_IMAGE = "alpine:3.20"
+
+BRANCH = "v3.20"
+REPO = "main"
+ARCH = "x86_64"
+KEY_NAME = "chantal"  # -> published key file "chantal.rsa.pub"
+
+requires_docker = pytest.mark.skipif(not _HAVE_DOCKER, reason="docker not available")
+
+
+def _build_upstream(root: Path, packages: str) -> None:
+    """Build a genuine Alpine upstream (real .apk files + APKINDEX) in-container.
+
+    ``packages`` is a space-separated list fetched with their deps; the result
+    is unpacked into ``root/<branch>/<repo>/<arch>/``.
+    """
+    script = (
+        "set -e; apk update >/dev/null 2>&1; mkdir -p /out; "
+        f"apk fetch -R -o /out {packages} >/dev/null 2>&1; "
+        "cd /out && apk index -o APKINDEX.tar.gz *.apk >/dev/null 2>&1; "
+        "tar -cf - -C /out . | base64 | tr -d '\\n'"
+    )
+    out = subprocess.run(
+        ["docker", "run", "--rm", _IMAGE, "sh", "-c", script],
+        capture_output=True,
+        timeout=300,
+    )
+    assert out.returncode == 0, f"apk upstream build failed: {out.stderr.decode()[-600:]}"
+    arch_dir = root / BRANCH / REPO / ARCH
+    arch_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=io.BytesIO(base64.b64decode(out.stdout))) as tar:
+        tar.extractall(arch_dir)  # noqa: S202 - trusted, self-built tar
+
+
+def _apk_add(published: Path, pkg: str, *, install_key: bool = True) -> subprocess.CompletedProcess:
+    """Stream the published repo into a container and `apk add` from it."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(published, arcname=".")
+    key_step = (
+        f"cp /repo/{KEY_NAME}.rsa.pub /etc/apk/keys/{KEY_NAME}.rsa.pub; " if install_key else ""
+    )
+    script = (
+        "set -e; mkdir -p /repo && tar -xf - -C /repo; "
+        + key_step
+        + f"echo /repo/{BRANCH}/{REPO} > /etc/apk/repositories; "
+        "apk update; "
+        f"apk add {pkg}; "
+        f"apk info -e {pkg}"
+    )
+    return subprocess.run(
+        ["docker", "run", "--rm", "-i", _IMAGE, "sh", "-c", script],
+        input=buf.getvalue(),
+        capture_output=True,
+        timeout=300,
+    )
+
+
+def _write_apk_config(chantal_env, repo_id: str, feed: str, filters: dict | None = None) -> None:
+    repo: dict = {
+        "id": repo_id,
+        "name": "Internal APK",
+        "type": "apk",
+        "feed": feed,
+        "enabled": True,
+        "mode": "filtered",
+        "apk": {"branch": BRANCH, "repository": REPO, "architecture": ARCH},
+        "gpg": {"enabled": True, "generate_key": True, "key_name": KEY_NAME},
+    }
+    if filters is not None:
+        repo["filters"] = filters
+    chantal_env.write_config(repo)
+
+
+@requires_docker
+def test_apk_signed_repo_installs_with_real_apk(tmp_path, serve, chantal_env):
+    upstream = tmp_path / "upstream"
+    _build_upstream(upstream, "tzdata")
+    _write_apk_config(chantal_env, "internal-apk", serve(upstream))
+
+    target = chantal_env.sync_and_publish("internal-apk")
+
+    # The regenerated index is RSA-signed and a public key was published.
+    assert (target / f"{KEY_NAME}.rsa.pub").is_file(), "published apk public key not found"
+    index = target / BRANCH / REPO / ARCH / "APKINDEX.tar.gz"
+    assert index.is_file(), "published APKINDEX not found"
+    with tarfile.open(index) as tar:
+        names = tar.getnames()
+    assert any(
+        n == f".SIGN.RSA256.{KEY_NAME}.rsa.pub" for n in names
+    ), f"APKINDEX is not signed: {names}"
+
+    # Real apk installs from the signed repo WITH verification on (key trusted).
+    result = _apk_add(target, "tzdata", install_key=True)
+    assert result.returncode == 0, (
+        f"real apk add failed:\nstdout={result.stdout.decode()[-800:]}\n"
+        f"stderr={result.stderr.decode()[-800:]}"
+    )
+    assert b"tzdata" in result.stdout, "tzdata not reported installed"
+
+
+@requires_docker
+def test_apk_signed_repo_rejected_without_key(tmp_path, serve, chantal_env):
+    """Without the published key in /etc/apk/keys, apk must refuse the signed repo."""
+    upstream = tmp_path / "upstream"
+    _build_upstream(upstream, "tzdata")
+    _write_apk_config(chantal_env, "internal-apk", serve(upstream))
+
+    target = chantal_env.sync_and_publish("internal-apk")
+
+    result = _apk_add(target, "tzdata", install_key=False)
+    assert result.returncode != 0, "apk add should fail for an untrusted signed repo"
+    assert (
+        b"UNTRUSTED" in result.stderr.upper() or b"untrusted" in result.stderr.lower()
+    ), f"expected an untrusted-signature error, got:\nstderr={result.stderr.decode()[-800:]}"
+
+
+@requires_docker
+def test_apk_filtering_excludes_packages_from_real_client(tmp_path, serve, chantal_env):
+    """A package excluded by filters is not installable by a real apk client."""
+    upstream = tmp_path / "upstream"
+    _build_upstream(upstream, "tzdata tini")  # both fetched; only tzdata kept
+    _write_apk_config(
+        chantal_env,
+        "internal-apk",
+        serve(upstream),
+        filters={"patterns": {"include": ["^tzdata$"]}},
+    )
+
+    target = chantal_env.sync_and_publish("internal-apk")
+
+    # Kept package installs; excluded package is absent from the published repo.
+    ok = _apk_add(target, "tzdata", install_key=True)
+    assert ok.returncode == 0, f"kept package failed to install: {ok.stderr.decode()[-600:]}"
+
+    missing = _apk_add(target, "tini", install_key=True)
+    assert missing.returncode != 0, "excluded package 'tini' should not be installable"

--- a/tests/e2e/test_apt_features_real_client_e2e.py
+++ b/tests/e2e/test_apt_features_real_client_e2e.py
@@ -1,0 +1,301 @@
+"""
+End-to-end tests with a REAL apt client (Docker) covering APT repo features.
+
+Beyond the basic install tests (test_apt_real_client_e2e / test_deb_real_client),
+these prove the security- and feature-critical paths a real apt client observes:
+
+* **Authenticity** — chantal signs the regenerated ``Release`` (InRelease +
+  Release.gpg) with a generated key and exports the public key; a real apt
+  installs with ``signed-by=`` and **no** ``[trusted=yes]``, and a client
+  without the key is refused.
+* **by-hash** — apt fetches indices through ``by-hash/SHA256/`` even when the
+  plain index files are removed from the served tree.
+* **arch:all** — an ``Architecture: all`` package is installable on a
+  concrete-arch client from the regenerated per-arch index.
+
+Docker-gated; runs on the CI apt e2e leg (filename contains ``apt``).
+Self-contained: the upstream (real ``.deb``/source + indices) is built
+in-container with ``dpkg-deb``; the published repo is streamed into the apt
+container as a tar over stdin (no bind-mounts).
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_DOCKER = shutil.which("docker") is not None
+_HAVE_GPG = shutil.which("gpg") is not None
+_IMAGE = "debian:bookworm"
+
+DIST = "jammy"
+COMP = "main"
+ARCH = "amd64"
+
+requires_docker = pytest.mark.skipif(not _HAVE_DOCKER, reason="docker not available")
+requires_gpg = pytest.mark.skipif(not _HAVE_GPG, reason="gpg not available (chantal signs on host)")
+
+
+def _build_real_deb(name: str = "hello-chantal") -> bytes:
+    """Build a genuine .deb in a debian container; return its bytes."""
+    script = (
+        "set -e; mkdir -p /pkg/DEBIAN /pkg/usr/bin; "
+        f'printf "Package: {name}\\nVersion: 1.0\\nArchitecture: amd64\\n'
+        f'Maintainer: t <t@e.x>\\nDescription: chantal real-apt test\\n" > /pkg/DEBIAN/control; '
+        f'printf "#!/bin/sh\\necho hello-from-{name}\\n" > /pkg/usr/bin/{name}; '
+        f"chmod +x /pkg/usr/bin/{name}; "
+        "dpkg-deb --build /pkg /out.deb >/dev/null; base64 -w0 /out.deb"
+    )
+    out = subprocess.run(
+        ["docker", "run", "--rm", _IMAGE, "bash", "-c", script],
+        capture_output=True,
+        timeout=300,
+    )
+    assert out.returncode == 0, f"deb build failed: {out.stderr.decode()[-500:]}"
+    import base64
+
+    return base64.b64decode(out.stdout)
+
+
+def _build_binary_upstream(root: Path, deb: bytes, name: str = "hello-chantal") -> None:
+    """Write a minimal binary apt upstream (pool + Packages + Release)."""
+    import gzip
+    import hashlib
+
+    deb_rel = f"pool/{COMP}/h/{name}/{name}_1.0_{ARCH}.deb"
+    (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    (root / deb_rel).write_bytes(deb)
+
+    packages = (
+        f"Package: {name}\n"
+        "Version: 1.0\n"
+        f"Architecture: {ARCH}\n"
+        "Maintainer: t <t@e.x>\n"
+        f"Filename: {deb_rel}\n"
+        f"Size: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\n"
+        "Description: chantal real-apt test\n"
+        "\n"
+    ).encode()
+    comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    packages_gz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(packages_gz)
+
+    sha = hashlib.sha256
+    release = (
+        f"Origin: Upstream\nSuite: {DIST}\nCodename: {DIST}\nComponents: {COMP}\n"
+        f"Architectures: {ARCH}\nDate: Thu, 01 Jan 2026 00:00:00 UTC\nSHA256:\n"
+        f" {sha(packages).hexdigest()} {len(packages)} {COMP}/binary-{ARCH}/Packages\n"
+        f" {sha(packages_gz).hexdigest()} {len(packages_gz)} {COMP}/binary-{ARCH}/Packages.gz\n"
+    )
+    (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+
+def _client(published: Path, script: str) -> subprocess.CompletedProcess:
+    """Stream the published repo into a debian container and run ``script``."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(published, arcname=".")
+    prep = (
+        "set -e; mkdir -p /repo && tar -xf - -C /repo; "
+        "rm -f /etc/apt/sources.list /etc/apt/sources.list.d/* 2>/dev/null || true; "
+    )
+    return subprocess.run(
+        ["docker", "run", "--rm", "-i", _IMAGE, "bash", "-c", prep + script],
+        input=buf.getvalue(),
+        capture_output=True,
+        timeout=600,
+    )
+
+
+# --------------------------------------------------------------------------- #
+
+
+@requires_docker
+@requires_gpg
+def test_apt_signed_repo_installs_without_trusted(tmp_path, serve, chantal_env):
+    """chantal-signed Release verifies in a real apt via signed-by= (no
+    trusted=yes); a client without the key is refused."""
+    deb = _build_real_deb()
+    upstream = tmp_path / "upstream"
+    _build_binary_upstream(upstream, deb)
+
+    chantal_env.write_config(
+        {
+            "id": "signed-apt",
+            "name": "Signed apt",
+            "type": "apt",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {"distribution": DIST, "components": [COMP], "architectures": [ARCH]},
+            "gpg": {
+                "enabled": True,
+                "generate_key": True,
+                "key_email": "repo@chantal.local",
+                "public_key_name": "key.asc",
+            },
+        }
+    )
+    target = chantal_env.sync_and_publish("signed-apt")
+    assert (target / "key.asc").is_file(), "exported public key not published"
+    assert (target / "dists" / DIST / "InRelease").is_file(), "InRelease not signed"
+
+    # Install with signature verification ON (signed-by=, no trusted=yes).
+    ok = _client(
+        target,
+        "mkdir -p /etc/apt/keyrings; cp /repo/key.asc /etc/apt/keyrings/chantal.asc; "
+        f'echo "deb [signed-by=/etc/apt/keyrings/chantal.asc] file:/repo {DIST} {COMP}" '
+        "> /etc/apt/sources.list.d/c.list; "
+        "apt-get update; apt-get install -y hello-chantal; hello-chantal",
+    )
+    assert ok.returncode == 0, (
+        f"signed apt install failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-hello-chantal" in ok.stdout
+
+    # Without the key, apt-get update must fail (NO_PUBKEY / not signed).
+    bad = _client(
+        target,
+        f'echo "deb file:/repo {DIST} {COMP}" > /etc/apt/sources.list.d/c.list; ' "apt-get update",
+    )
+    assert (
+        bad.returncode != 0
+    ), f"unsigned-trust apt update should fail:\nstderr={bad.stderr.decode()[-800:]}"
+    combined = (bad.stdout + bad.stderr).upper()
+    assert (
+        b"NO_PUBKEY" in combined or b"NOT SIGNED" in combined or b"NOTSIGNED" in combined
+    ), f"failure should be a signature/key error, got:\n{bad.stderr.decode()[-800:]}"
+
+
+@requires_docker
+def test_apt_byhash_fetch_from_real_client(tmp_path, serve, chantal_env):
+    """apt retrieves indices via by-hash/SHA256 even when the plain Packages
+    files are removed from the published tree."""
+    deb = _build_real_deb()
+    upstream = tmp_path / "upstream"
+    _build_binary_upstream(upstream, deb)
+
+    chantal_env.write_config(
+        {
+            "id": "byhash-apt",
+            "name": "By-hash apt",
+            "type": "apt",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {
+                "distribution": DIST,
+                "components": [COMP],
+                "architectures": [ARCH],
+                "by_hash": True,
+            },
+        }
+    )
+    target = chantal_env.sync_and_publish("byhash-apt")
+    byhash_dir = target / "dists" / DIST / COMP / f"binary-{ARCH}" / "by-hash" / "SHA256"
+    assert byhash_dir.is_dir(), "by-hash dir not published"
+
+    # Remove the plain Packages indices so the client MUST use by-hash.
+    for p in (target / "dists" / DIST / COMP / f"binary-{ARCH}").glob("Packages*"):
+        p.unlink()
+
+    ok = _client(
+        target,
+        f'echo "deb [trusted=yes] file:/repo {DIST} {COMP}" > /etc/apt/sources.list.d/c.list; '
+        "apt-get -o Acquire::By-Hash=force update; "
+        "apt-get install -y hello-chantal; hello-chantal",
+    )
+    assert ok.returncode == 0, (
+        f"by-hash apt install failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-hello-chantal" in ok.stdout
+
+
+@requires_docker
+def test_apt_arch_all_visible_to_real_client(tmp_path, serve, chantal_env):
+    """An Architecture: all package is installable on a concrete-arch client
+    (fanned out into binary-<arch>/Packages)."""
+    import base64
+    import gzip
+    import hashlib
+
+    # Build an arch:all .deb in-container.
+    script = (
+        "set -e; mkdir -p /pkg/DEBIAN /pkg/usr/share/demo-doc; "
+        'printf "Package: demo-doc\\nVersion: 1.0\\nArchitecture: all\\n'
+        'Maintainer: t <t@e.x>\\nDescription: arch all doc\\n" > /pkg/DEBIAN/control; '
+        "echo archall-readme-marker > /pkg/usr/share/demo-doc/README; "
+        "dpkg-deb --build /pkg /out.deb >/dev/null; base64 -w0 /out.deb"
+    )
+    out = subprocess.run(
+        ["docker", "run", "--rm", _IMAGE, "bash", "-c", script],
+        capture_output=True,
+        timeout=300,
+    )
+    assert out.returncode == 0, f"arch:all deb build failed: {out.stderr.decode()[-500:]}"
+    deb = base64.b64decode(out.stdout)
+
+    upstream = tmp_path / "upstream"
+    deb_rel = f"pool/{COMP}/d/demo-doc/demo-doc_1.0_all.deb"
+    (upstream / deb_rel).parent.mkdir(parents=True, exist_ok=True)
+    (upstream / deb_rel).write_bytes(deb)
+    # An Architecture: all package is listed in each per-arch index by Debian
+    # convention (apt only reads binary-<its-arch>/Packages).
+    packages = (
+        "Package: demo-doc\nVersion: 1.0\nArchitecture: all\nMaintainer: t <t@e.x>\n"
+        f"Filename: {deb_rel}\nSize: {len(deb)}\n"
+        f"SHA256: {hashlib.sha256(deb).hexdigest()}\nDescription: arch all doc\n\n"
+    ).encode()
+    comp_dir = upstream / "dists" / DIST / COMP / f"binary-{ARCH}"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+    (comp_dir / "Packages").write_bytes(packages)
+    pgz = gzip.compress(packages)
+    (comp_dir / "Packages.gz").write_bytes(pgz)
+    sha = hashlib.sha256
+    release = (
+        f"Origin: Upstream\nSuite: {DIST}\nCodename: {DIST}\nComponents: {COMP}\n"
+        f"Architectures: {ARCH}\nDate: Thu, 01 Jan 2026 00:00:00 UTC\nSHA256:\n"
+        f" {sha(packages).hexdigest()} {len(packages)} {COMP}/binary-{ARCH}/Packages\n"
+        f" {sha(pgz).hexdigest()} {len(pgz)} {COMP}/binary-{ARCH}/Packages.gz\n"
+    )
+    (upstream / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
+
+    chantal_env.write_config(
+        {
+            "id": "archall-apt",
+            "name": "arch all apt",
+            "type": "apt",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {"distribution": DIST, "components": [COMP], "architectures": [ARCH]},
+        }
+    )
+    target = chantal_env.sync_and_publish("archall-apt")
+    # arch:all must be fanned out into the concrete binary-amd64 index.
+    assert (
+        target / "dists" / DIST / COMP / f"binary-{ARCH}" / "Packages"
+    ).is_file(), "binary-amd64 index missing for arch:all package"
+
+    ok = _client(
+        target,
+        f'echo "deb [trusted=yes] file:/repo {DIST} {COMP}" > /etc/apt/sources.list.d/c.list; '
+        "apt-get update; apt-get install -y demo-doc; cat /usr/share/demo-doc/README",
+    )
+    assert ok.returncode == 0, (
+        f"arch:all install on {ARCH} failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+    assert b"archall-readme-marker" in ok.stdout

--- a/tests/e2e/test_helm_features_real_client_e2e.py
+++ b/tests/e2e/test_helm_features_real_client_e2e.py
@@ -1,0 +1,215 @@
+"""
+End-to-end tests with a REAL helm client (Docker) covering Helm repo features.
+
+Beyond the basic hosted-upload pull (test_helm_real_client_e2e.py), these prove
+the sync-based paths a real helm client observes:
+
+* **Mirror mode** — an upstream chart repo mirrored 1:1; the published
+  ``index.yaml`` is byte-identical and real ``helm pull`` retrieves the chart.
+* **Multiple versions** — two versions of a chart are both visible via
+  ``helm search repo --versions`` and individually pullable.
+* **Filtered selection** — a chart excluded by filters is not pullable, the
+  kept one is.
+
+Docker-gated; runs on the CI helm e2e leg (filename contains ``helm``).
+A real upstream chart repo is built in-container with ``helm package``; the
+published repo is streamed into the helm container as a tar over stdin and
+served with ``python3 -m http.server`` (helm needs an http URL).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_DOCKER = shutil.which("docker") is not None
+_IMAGE = "alpine/helm"
+
+requires_docker = pytest.mark.skipif(not _HAVE_DOCKER, reason="docker not available")
+
+
+def _build_charts(specs: list[tuple[str, str]]) -> dict[tuple[str, str], bytes]:
+    """Build real chart .tgz files in-container.
+
+    ``specs`` is a list of (name, version); returns {(name, version): tgz bytes}.
+    """
+    cmds = ["set -e; cd /tmp"]
+    for name, version in specs:
+        cmds.append(f"helm create {name} >/dev/null 2>&1 || true")
+        cmds.append(f"helm package {name} --version {version} >/dev/null")
+    # Emit each tgz as "name version base64" lines.
+    for name, version in specs:
+        cmds.append(f"echo \"{name} {version} $(base64 {name}-{version}.tgz | tr -d '\\n')\"")
+    out = subprocess.run(
+        ["docker", "run", "--rm", "--entrypoint", "/bin/sh", _IMAGE, "-c", "; ".join(cmds)],
+        capture_output=True,
+        timeout=300,
+    )
+    assert out.returncode == 0, f"helm package failed: {out.stderr.decode()[-600:]}"
+    charts: dict[tuple[str, str], bytes] = {}
+    for line in out.stdout.decode().splitlines():
+        name, version, b64 = line.split(" ", 2)
+        charts[(name, version)] = base64.b64decode(b64)
+    return charts
+
+
+def _write_upstream(root: Path, charts: dict[tuple[str, str], bytes]) -> None:
+    """Write an upstream chart repo (the .tgz files + an index.yaml)."""
+    root.mkdir(parents=True, exist_ok=True)
+    entries: dict[str, list] = {}
+    for (name, version), data in charts.items():
+        fname = f"{name}-{version}.tgz"
+        (root / fname).write_bytes(data)
+        entries.setdefault(name, []).append(
+            {
+                "name": name,
+                "version": version,
+                "apiVersion": "v2",
+                "digest": hashlib.sha256(data).hexdigest(),
+                "urls": [fname],
+            }
+        )
+    index = {"apiVersion": "v1", "entries": entries, "generated": "2026-01-01T00:00:00Z"}
+    (root / "index.yaml").write_text(yaml.safe_dump(index), encoding="utf-8")
+
+
+def _helm(published: Path, helm_script: str) -> subprocess.CompletedProcess:
+    """Stream the published repo into a container, serve it, run ``helm_script``.
+
+    ``helm_script`` runs after ``helm repo add local http://127.0.0.1:8879`` and
+    ``helm repo update``.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(published, arcname=".")
+    script = (
+        "set -e; apk add --no-cache python3 >/dev/null; "
+        "mkdir -p /repo && tar -xf - -C /repo; "
+        "cd /repo && python3 -m http.server 8879 >/dev/null 2>&1 & "
+        "for i in $(seq 1 30); do "
+        "  wget -q -O /dev/null http://127.0.0.1:8879/index.yaml && break; sleep 0.3; done; "
+        "cd /tmp; "
+        "helm repo add local http://127.0.0.1:8879 >/dev/null; "
+        "helm repo update >/dev/null; " + helm_script
+    )
+    return subprocess.run(
+        ["docker", "run", "--rm", "-i", "--entrypoint", "/bin/sh", _IMAGE, "-c", script],
+        input=buf.getvalue(),
+        capture_output=True,
+        timeout=600,
+    )
+
+
+# --------------------------------------------------------------------------- #
+
+
+@requires_docker
+def test_helm_mirror_consumed_by_real_client(tmp_path, serve, chantal_env):
+    """A mirror-mode repo (verbatim index.yaml) is consumable by real helm."""
+    charts = _build_charts([("demo", "0.1.0")])
+    upstream = tmp_path / "upstream"
+    _write_upstream(upstream, charts)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-mirror",
+            "name": "Demo mirror",
+            "type": "helm",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "mirror",
+        }
+    )
+    target = chantal_env.sync_and_publish("demo-mirror")
+
+    # Mirror preserves the upstream index.yaml byte-for-byte.
+    assert (target / "index.yaml").read_bytes() == (
+        upstream / "index.yaml"
+    ).read_bytes(), "mirror index.yaml is not byte-identical to upstream"
+
+    ok = _helm(
+        target,
+        "helm pull local/demo --version 0.1.0; "
+        "test -f demo-0.1.0.tgz; "
+        "helm show chart local/demo | grep '^name: demo'",
+    )
+    assert ok.returncode == 0, (
+        f"real helm pull from mirror failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+
+
+@requires_docker
+def test_helm_multiple_versions_visible_to_real_client(tmp_path, serve, chantal_env):
+    """Both chart versions appear in `helm search repo --versions` and pull."""
+    charts = _build_charts([("demo", "0.1.0"), ("demo", "0.2.0")])
+    upstream = tmp_path / "upstream"
+    _write_upstream(upstream, charts)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-multi",
+            "name": "Demo multi",
+            "type": "helm",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",  # regenerates index.yaml from both versions
+        }
+    )
+    target = chantal_env.sync_and_publish("demo-multi")
+
+    ok = _helm(
+        target,
+        "helm search repo local/demo --versions | tee /tmp/s; "
+        "grep -q 0.1.0 /tmp/s && grep -q 0.2.0 /tmp/s; "
+        "helm pull local/demo --version 0.1.0 && test -f demo-0.1.0.tgz; "
+        "helm pull local/demo --version 0.2.0 && test -f demo-0.2.0.tgz",
+    )
+    assert ok.returncode == 0, (
+        f"multi-version helm consumption failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+
+
+@requires_docker
+def test_helm_filtering_excludes_chart_from_real_client(tmp_path, serve, chantal_env):
+    """A chart excluded by filters is not pullable; the kept one is."""
+    charts = _build_charts([("demo", "0.1.0"), ("other", "0.1.0")])
+    upstream = tmp_path / "upstream"
+    _write_upstream(upstream, charts)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-filt",
+            "name": "Demo filtered",
+            "type": "helm",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "filters": {"patterns": {"include": ["^demo$"]}},
+        }
+    )
+    target = chantal_env.sync_and_publish("demo-filt")
+
+    ok = _helm(
+        target,
+        "helm pull local/demo --version 0.1.0 && test -f demo-0.1.0.tgz && echo KEPT_OK; "
+        "if helm pull local/other --version 0.1.0 2>/dev/null; then echo OTHER_PRESENT; "
+        "else echo OTHER_ABSENT; fi",
+    )
+    assert ok.returncode == 0, (
+        f"filtered helm consumption failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+    assert b"KEPT_OK" in ok.stdout, "kept chart 'demo' not pullable"
+    assert b"OTHER_ABSENT" in ok.stdout, "excluded chart 'other' should not be pullable"

--- a/tests/e2e/test_rpm_features_real_client_e2e.py
+++ b/tests/e2e/test_rpm_features_real_client_e2e.py
@@ -1,0 +1,293 @@
+"""
+End-to-end tests with a REAL dnf client (Docker) covering RPM repo features.
+
+Beyond the basic hosted-upload install (test_rpm_real_client_e2e.py), these
+prove the security- and feature-critical paths a real `dnf`/`rpm` client
+observes:
+
+* **Authenticity** — a signed mirror installed with ``gpgcheck=1`` +
+  ``repo_gpgcheck=1`` against the upstream key chantal republishes
+  (``RPM-GPG-KEY-<id>``); a client lacking that key is refused.
+* **Metadata signing (filtered)** — chantal re-signs ``repomd.xml`` with its own
+  key; a client verifies it with ``repo_gpgcheck=1``; tampering is detected.
+* **Filtering** — an excluded package is not installable.
+* **Compression** — zstd-compressed regenerated metadata is consumed by dnf.
+
+Docker-gated; runs on the CI rpm e2e leg (filename contains ``rpm``).
+Self-contained: the signed upstream repo is built in-container with
+``rpmbuild``/``rpm --addsign``/``createrepo_c``/``gpg``; the published repo is
+streamed into the dnf container as a tar over stdin (no bind-mounts).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_HAVE_DOCKER = shutil.which("docker") is not None
+_HAVE_GPG = shutil.which("gpg") is not None or shutil.which("gpg2") is not None
+_IMAGE = "almalinux:9"
+_EMAIL = "rpm-test@chantal.local"
+
+requires_docker = pytest.mark.skipif(not _HAVE_DOCKER, reason="docker not available")
+requires_gpg = pytest.mark.skipif(not _HAVE_GPG, reason="gpg not available (chantal signs on host)")
+
+# Build N signed packages (demo-keep + demo-drop), createrepo_c, and detach-sign
+# repomd.xml with an ephemeral key. Emits a tar of the repo dir followed by a
+# marker and the ASCII-armored public key, all base64 over stdout.
+_BUILD_SCRIPT = r"""
+set -e
+dnf install -y rpm-build rpm-sign createrepo_c gnupg2 >/dev/null 2>&1
+export GNUPGHOME=/gpg; mkdir -p /gpg; chmod 700 /gpg
+printf '%%no-protection\nKey-Type: RSA\nKey-Length: 3072\nName-Real: Chantal Test\nName-Email: %s\nExpire-Date: 0\n%%commit\n' EMAIL > /key
+gpg --batch --gen-key /key >/dev/null 2>&1
+mkdir -p /rb/SPECS /up
+for name in demo-keep demo-drop; do
+  printf 'Name: %s\nVersion: 1.0\nRelease: 1\nSummary: %s\nLicense: MIT\nBuildArch: noarch\n%%description\n%s\n%%install\nmkdir -p %%{buildroot}/usr/share/%s\necho hello-from-%s > %%{buildroot}/usr/share/%s/README\n%%files\n/usr/share/%s/README\n' \
+    "$name" "$name" "$name" "$name" "$name" "$name" "$name" > /rb/SPECS/$name.spec
+  rpmbuild --define "_topdir /rb" -bb /rb/SPECS/$name.spec >/dev/null 2>&1
+done
+cp /rb/RPMS/noarch/*.rpm /up/
+rpm --define "_gpg_name EMAIL" --addsign /up/*.rpm >/dev/null 2>&1
+createrepo_c /up >/dev/null 2>&1
+gpg --batch --yes --detach-sign --armor -o /up/repodata/repomd.xml.asc /up/repodata/repomd.xml
+tar -cf - -C /up . | base64 | tr -d '\n'
+echo ===KEY===
+gpg --armor --export EMAIL | base64 | tr -d '\n'
+""".replace("EMAIL", _EMAIL)
+
+
+def _build_signed_upstream(root: Path) -> str:
+    """Build a signed upstream repo into ``root``; return the armored public key."""
+    out = subprocess.run(
+        ["docker", "run", "--rm", _IMAGE, "bash", "-c", _BUILD_SCRIPT],
+        capture_output=True,
+        timeout=600,
+    )
+    assert out.returncode == 0, f"rpm upstream build failed: {out.stderr.decode()[-800:]}"
+    repo_b64, _, key_b64 = out.stdout.partition(b"===KEY===")
+    root.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=io.BytesIO(base64.b64decode(repo_b64))) as tar:
+        tar.extractall(root)  # noqa: S202 - trusted, self-built tar
+    return base64.b64decode(key_b64).decode()
+
+
+def _dnf(published: Path, script: str) -> subprocess.CompletedProcess:
+    """Stream the published repo into a dnf container and run ``script``."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(published, arcname=".")
+    full = "set -e; mkdir -p /repo && tar -xf - -C /repo; " + script
+    return subprocess.run(
+        ["docker", "run", "--rm", "-i", _IMAGE, "bash", "-c", full],
+        input=buf.getvalue(),
+        capture_output=True,
+        timeout=600,
+    )
+
+
+def _repo_file(*, gpgcheck: int, repo_gpgcheck: int, gpgkey: str | None) -> str:
+    lines = [
+        "[demo]",
+        "name=demo",
+        "baseurl=file:///repo",
+        "enabled=1",
+        f"gpgcheck={gpgcheck}",
+        f"repo_gpgcheck={repo_gpgcheck}",
+    ]
+    if gpgkey:
+        lines.append(f"gpgkey=file:///repo/{gpgkey}")
+    body = "\\n".join(lines)
+    return f'printf "{body}\\n" > /etc/yum.repos.d/demo.repo; '
+
+
+# --------------------------------------------------------------------------- #
+
+
+@requires_docker
+@requires_gpg
+def test_rpm_signed_mirror_installs_with_gpgcheck(tmp_path, serve, chantal_env):
+    """A mirror republishes the upstream trust key (``RPM-GPG-KEY-<id>``); a real
+    client installs the (upstream-signed) package with ``gpgcheck=1``, and a
+    client that does not trust the key is refused."""
+    upstream = tmp_path / "upstream"
+    pubkey = _build_signed_upstream(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "secure",
+            "name": "Secure mirror",
+            "type": "rpm",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "mirror",
+            "verify": {
+                "enabled": True,
+                "gpgcheck": True,
+                "repo_gpgcheck": True,
+                "keys": [pubkey],
+                "client_key_name": "RPM-GPG-KEY-{repo_id}",
+            },
+        }
+    )
+    target = chantal_env.sync_and_publish("secure")
+    assert (target / "RPM-GPG-KEY-secure").is_file(), "upstream key not republished"
+
+    # Package authenticity: import the republished key, dnf verifies the
+    # upstream-retained package signature with gpgcheck=1.
+    ok = _dnf(
+        target,
+        "rpm --import /repo/RPM-GPG-KEY-secure; "
+        + _repo_file(gpgcheck=1, repo_gpgcheck=0, gpgkey="RPM-GPG-KEY-secure")
+        + "dnf install -y demo-keep >/dev/null; cat /usr/share/demo-keep/README",
+    )
+    assert ok.returncode == 0, (
+        f"signed install failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-demo-keep" in ok.stdout
+
+    # With gpgcheck=1 but no key available (none configured, none imported),
+    # dnf must refuse the signed package rather than install it unverified.
+    bad = _dnf(
+        target,
+        _repo_file(gpgcheck=1, repo_gpgcheck=0, gpgkey=None)
+        + "dnf install -y demo-keep </dev/null",
+    )
+    assert bad.returncode != 0, (
+        f"gpgcheck without a trusted key should refuse the package:\n"
+        f"{bad.stdout.decode()[-800:]}"
+    )
+    combined = (bad.stdout + bad.stderr).upper()
+    assert b"GPG" in combined or b"KEY" in combined or b"SIGNATURE" in combined, (
+        f"failure should be a GPG/key error, got:\n{bad.stdout.decode()[-800:]}\n"
+        f"{bad.stderr.decode()[-800:]}"
+    )
+
+
+@requires_docker
+@requires_gpg
+def test_rpm_filtered_metadata_signing_repo_gpgcheck(tmp_path, serve, chantal_env):
+    """Filtered mode re-signs repomd.xml with chantal's key; a client verifies it
+    with repo_gpgcheck=1, and a tampered repomd is rejected."""
+    upstream = tmp_path / "upstream"
+    pubkey = _build_signed_upstream(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "filt",
+            "name": "Filtered signed",
+            "type": "rpm",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "verify": {
+                "enabled": True,
+                "gpgcheck": False,
+                "repo_gpgcheck": False,
+                "keys": [pubkey],
+            },
+            "gpg": {"enabled": True, "generate_key": True, "public_key_name": "key.gpg"},
+            "filters": {"patterns": {"include": ["^demo-keep$"]}},
+        }
+    )
+    target = chantal_env.sync_and_publish("filt")
+    assert (target / "key.gpg").is_file(), "metadata signing key not published"
+    assert (target / "repodata" / "repomd.xml.asc").is_file(), "repomd not signed"
+
+    ok = _dnf(
+        target,
+        "rpm --import /repo/key.gpg; "
+        + _repo_file(gpgcheck=0, repo_gpgcheck=1, gpgkey="key.gpg")
+        + "dnf -y makecache >/dev/null && dnf install -y demo-keep >/dev/null; "
+        + "cat /usr/share/demo-keep/README",
+    )
+    assert ok.returncode == 0, (
+        f"repo_gpgcheck install failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-demo-keep" in ok.stdout
+
+    # Tampering with the signed repomd.xml must break metadata verification.
+    bad = _dnf(
+        target,
+        "rpm --import /repo/key.gpg; "
+        + "sed -i 's/<data/<DATA/' /repo/repodata/repomd.xml; "
+        + _repo_file(gpgcheck=0, repo_gpgcheck=1, gpgkey="key.gpg")
+        + "dnf -y makecache </dev/null",
+    )
+    assert (
+        bad.returncode != 0
+    ), f"tampered repomd should fail repo_gpgcheck:\n{bad.stdout.decode()[-800:]}"
+    combined = (bad.stdout + bad.stderr).upper()
+    assert b"SIGNATURE" in combined or b"GPG" in combined, (
+        f"tamper failure should be a signature error, got:\n"
+        f"{bad.stdout.decode()[-800:]}\n{bad.stderr.decode()[-800:]}"
+    )
+
+
+@requires_docker
+def test_rpm_filtered_excludes_package(tmp_path, serve, chantal_env):
+    """An excluded package is absent from the published repo for a real client."""
+    upstream = tmp_path / "upstream"
+    _build_signed_upstream(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "filt2",
+            "name": "Filtered",
+            "type": "rpm",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "filters": {"patterns": {"include": ["^demo-keep$"]}},
+        }
+    )
+    target = chantal_env.sync_and_publish("filt2")
+
+    res = _dnf(
+        target,
+        _repo_file(gpgcheck=0, repo_gpgcheck=0, gpgkey=None)
+        + "dnf install -y demo-keep >/dev/null && echo KEEP_OK; "
+        + "dnf list available demo-drop 2>/dev/null && echo DROP_PRESENT || echo DROP_ABSENT",
+    )
+    assert b"KEEP_OK" in res.stdout, f"kept package failed: {res.stderr.decode()[-600:]}"
+    assert b"DROP_ABSENT" in res.stdout, "excluded package should not be available"
+
+
+@requires_docker
+def test_rpm_zstd_metadata_installs(tmp_path, serve, chantal_env):
+    """zstd-compressed regenerated repodata is consumable by real dnf."""
+    upstream = tmp_path / "upstream"
+    _build_signed_upstream(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "zstd",
+            "name": "Zstd",
+            "type": "rpm",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "filters": {"patterns": {"include": ["^demo-keep$"]}},
+            "metadata": {"compression": "zstandard"},
+        }
+    )
+    target = chantal_env.sync_and_publish("zstd")
+    assert list(target.glob("repodata/*primary.xml.zst")), "primary.xml.zst not generated"
+
+    ok = _dnf(
+        target,
+        _repo_file(gpgcheck=0, repo_gpgcheck=0, gpgkey=None)
+        + "dnf install -y demo-keep >/dev/null; cat /usr/share/demo-keep/README",
+    )
+    assert ok.returncode == 0, f"zstd repo install failed: {ok.stderr.decode()[-800:]}"
+    assert b"hello-from-demo-keep" in ok.stdout


### PR DESCRIPTION
Closes #73 (real-world validation).

Adds container-based end-to-end tests that verify chantal-**published** repositories with the **real** package clients — `dnf`, `apt-get`, `apk`, `helm` — closing the gap where published repos were only checked by file-assertions, never consumed by a real client. The headline coverage is **authenticity with verification ON** (no `trusted=yes` / `gpgcheck=0` / `--allow-untrusted`), plus a negative control per signed path.

## What's covered

| Plugin | Tests |
|--------|-------|
| **apk** | RSA-signed APKINDEX installed by real `apk add` (verification ON); negative control without the key (asserts `UNTRUSTED`); pattern filtering |
| **rpm** | signed mirror installed with `gpgcheck=1` via the republished `RPM-GPG-KEY`; filtered-mode `repomd.xml` re-signing verified with `repo_gpgcheck=1` + tamper-detection; filtering; zstd metadata |
| **apt** | chantal-signed `Release` installed via `signed-by=` with **no** `[trusted=yes]` + negative control (`NO_PUBKEY`); `by-hash` index fetch; `Architecture: all` install |
| **helm** | mirror-mode byte-identical `index.yaml` consumed by real `helm pull`; multiple versions via `helm search repo --versions`; filtered selection |

13 new tests across the four plugins.

## How

- **Docker-gated** (`requires_docker`), `pytestmark = pytest.mark.e2e`; filenames carry the plugin keyword so the existing CI `e2e` matrix (`-k <plugin>`) selects them with no workflow change.
- **Self-contained**: upstreams are built in-container (`rpmbuild`+`rpm --addsign`+`createrepo_c`, `dpkg-deb`, `helm package`, `apk fetch`+`apk index`); the published repo is streamed into the client container as a tar over stdin (no bind-mounts, no host networking).
- The rpm/apt host-signing cases additionally gate on a `gpg` binary (chantal signs on the host during publish).

## Notes

While building these I confirmed chantal's RPM `repomd.xml` signing is **correct** — an early "Bad GPG signature" was a test artifact (`dnf` key-import prompt needs `-y`), not a chantal bug; verified independently with `gpg --verify`. RPM mirror mode regenerates (and does not sign) `repomd.xml`, so mirror authenticity is asserted via package-level `gpgcheck=1`, and metadata signing via `repo_gpgcheck=1` in filtered mode.

A fresh-context review of all four files was incorporated (added `requires_gpg` gating to the rpm signing tests; tightened every negative assertion to check the failure *reason*, not just a non-zero exit; unique content markers).