### PR TITLE
docs: overhaul documentation to match the 1.4.0 codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,48 +4,41 @@ First off, thank you for considering contributing to Chantal!
 
 ## Project Status
 
-**⚠️ Chantal is currently in the Research & Design phase.**
+**✅ Chantal is an actively maintained, released project (v1.4.0, available on [PyPI](https://pypi.org/project/chantal/)).**
 
-We're not ready for code contributions yet, but there are other valuable ways to contribute right now.
+Contributions are welcome - bug reports, feature requests, documentation improvements, and pull requests.
 
-## How to Contribute (Current Phase)
+## How to Contribute
 
-### 1. Share Your Experience
+### 1. Report Bugs and Request Features
 
-Have you worked with repository mirroring tools? We'd love to hear about:
+Found a bug or have an idea? Open an issue:
 
-- **Production experience** with apt-mirror, aptly, reposync, bandersnatch, or devpi
-- **Pain points** you've encountered
-- **Scale challenges** (repo size, package count, bandwidth)
-- **Use cases** we might not have considered
+- **Bug reports:** Include your Chantal version (`chantal --version`), repository type, config snippet (redact secrets), and the full error output.
+- **Feature requests:** Open an issue with the `enhancement` label describing the use case.
 
-**How:** Open a [GitHub Discussion](https://github.com/yourusername/chantal/discussions) in the "Experience Reports" category.
+**How:** Use the [GitHub Issues](https://github.com/slauger/chantal/issues) tracker.
 
-### 2. Review Design Documents
+### 2. Submit Pull Requests
 
-We're making architectural decisions right now. Your input is valuable:
+Code contributions are welcome. Good first areas include new plugins (package formats), additional repository types, test coverage, and documentation.
 
-- Read [CONTEXT.md](CONTEXT.md) for full requirements
-- Check [.planning/findings.md](.planning/findings.md) for our tool analysis
-- Review [ROADMAP.md](ROADMAP.md) for our roadmap
+1. Fork the repository and create a feature branch
+2. Make your change with tests and type annotations
+3. Run the local checks (`make lint`, `make pytest`) - see [Development Guidelines](#development-guidelines)
+4. Open a pull request referencing any related issue
 
-**How:** Comment on open issues tagged with `architecture` or `design`.
+### 3. Share Your Experience
 
-### 3. Suggest Improvements
+Have you worked with repository mirroring tools (apt-mirror, aptly, reposync, bandersnatch, devpi)? Production experience, pain points, scale challenges, and unusual use cases all help shape the roadmap.
 
-Have ideas about:
-- CLI design?
-- Configuration format?
-- Plugin architecture?
-- Storage strategy?
+**How:** Open a [GitHub Discussion](https://github.com/slauger/chantal/discussions) or an issue with the `research` label.
 
-**How:** Open an issue with the `enhancement` label.
+### 4. Improve the Documentation
 
-### 4. Report Issues with Existing Tools
+Documentation lives in `docs/` (Sphinx) and is published to [GitHub Pages](https://slauger.github.io/chantal/). Corrections and additions are very welcome.
 
-Found bugs or limitations in apt-mirror, aptly, reposync, etc. that Chantal should avoid?
-
-**How:** Open an issue with the `research` label.
+**How:** Edit the relevant files under `docs/` and open a pull request.
 
 ## Development Guidelines
 
@@ -221,6 +214,4 @@ By contributing to Chantal, you agree that your contributions will be licensed u
 
 ---
 
-**Current Focus:** Phase 1 - Research & Tool Analysis
-
-See [ROADMAP.md](ROADMAP.md) for current priorities.
+See [ROADMAP.md](ROADMAP.md) for current priorities and planned work.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ A Python-based CLI tool for offline repository mirroring, inspired by pulp-admin
 - 📁 **Static Output** - Serve with any webserver (Apache, NGINX)
 - 🔐 **RHEL CDN Support** - Client certificate authentication for Red Hat repos
 - 🎯 **Smart Filtering** - Pattern-based package filtering with post-processing
-- 🪞 **Mirror & Filtered Modes** - Full metadata mirroring or filtered repos with regenerated metadata
+- 🪞 **Mirror, Filtered & Hosted Modes** - Full metadata mirroring, filtered repos with regenerated metadata, or hosted repos built from your own uploaded packages
+- ⬆️ **Custom Package Upload** - Inject local packages into a repository's pool with `chantal package upload` (RPM, DEB/APT, Helm)
 - 🔏 **Metadata Signing** - Sign regenerated metadata in filtered mode: APT (InRelease/Release.gpg), RPM (repomd.xml.asc) and APK (RSA-signed APKINDEX) so clients can verify the repo
 - ⚡ **Fast Updates** - Check for updates without downloading (like `dnf check-update`)
 - 🚀 **Metadata Caching** - SHA256-based cache for RPM metadata (90-95% faster syncs for RHEL)
@@ -61,7 +62,13 @@ docker run --rm \
   ghcr.io/slauger/chantal:latest --help
 ```
 
-**Option 2: Python Package**
+**Option 2: PyPI (Recommended for Python users)**
+
+```bash
+pip install chantal
+```
+
+**Option 3: From Source**
 
 ```bash
 git clone https://github.com/slauger/chantal.git

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Chantal Development Roadmap
 
-**Last Updated:** 2026-06-19
-**Current Version:** 0.1.0 (unreleased changes on `main`)
+**Last Updated:** 2026-06-25
+**Current Version:** 1.4.0 (released, available on [PyPI](https://pypi.org/project/chantal/))
 
 ---
 
@@ -53,7 +53,7 @@
 | 21 | Helm OCI Registry Support | [#34](https://github.com/slauger/chantal/issues/34) |
 | 22 | SUSE/SLES Metadata Research | [#11](https://github.com/slauger/chantal/issues/11) |
 
-### Recent: Signing & Modernization (on `main`, unreleased)
+### Signing & Modernization
 
 - **APT GPG signing** for filtered mode (InRelease, Release.gpg) — [#30](https://github.com/slauger/chantal/issues/30)
 - **RPM GPG signing** of regenerated `repomd.xml` (repomd.xml.asc)
@@ -64,24 +64,20 @@
 - **Dropped Python 3.10/3.11, added 3.14**; modernized to `datetime.UTC` / `StrEnum`
 - **Bumped GitHub Actions** to Node 24 majors
 
+### Release Engineering & 1.0+ (shipped)
+
+- **Custom package injection / hosted upload** (`chantal package upload`) — [#16](https://github.com/slauger/chantal/issues/16):
+  upload local RPM/DEB/Helm packages into the pool and publish them (hosted mode),
+  independent of an upstream feed.
+- **1.0.0 release** — [#32](https://github.com/slauger/chantal/issues/32): hosted mode,
+  end-to-end smoke tests per plugin, documentation, production-grade stability.
+- **Release automation**: semantic-release with conventional commits, automatic
+  versioning, **PyPI publishing** (`pip install chantal`), TestPyPI prereleases,
+  and container images on GHCR.
+
 ---
 
 ## In Progress / Next
-
-### 🔄 Release 1.0.0 preparation — [#32](https://github.com/slauger/chantal/issues/32)
-
-Tracking issue for the 1.0.0 release. Remaining themes:
-
-- **End-to-end tests in CI** — minimal sync→publish smoke tests per plugin
-  (RPM/APT/Helm/APK), in format-native containers (matrix). *(no dedicated issue yet)*
-- Real-world testing (Vagrant-based), broader test coverage
-- Documentation review (README, Sphinx, troubleshooting, FAQ)
-- Release engineering (semantic-release, CHANGELOG, PyPI publishing)
-
-### 📋 Custom package injection / hosted upload — [#16](https://github.com/slauger/chantal/issues/16)
-
-Upload local RPM/DEB/APK/Helm packages into the pool and publish them
-(hosted mode), independent of an upstream feed.
 
 ### 📋 Advanced Errata & Advisory Management — [#21](https://github.com/slauger/chantal/issues/21)
 
@@ -126,18 +122,19 @@ webhook notifications, multi-tenancy.
 ## Release Timeline
 
 **v0.1.0** (released 2026-01-12)
-- RPM, Helm, Alpine APK support; mirror/filtered/hosted modes; snapshots; views
+- RPM, Helm, Alpine APK support; mirror/filtered modes; snapshots; views
 
-**Unreleased (on `main`)**
+**v1.0.0**
 - APT/DEB support (mirror + filtered)
 - Metadata signing for all formats (APT/RPM GPG, APK RSA)
 - Config JSON Schema; configurable APT compression
 - Python 3.12–3.14; deprecation-free; modernized tooling
+- End-to-end tests across all plugins; production-grade stability
+- Release automation (semantic-release, PyPI, container images)
 
-**v1.0.0** (target: see [#32](https://github.com/slauger/chantal/issues/32))
-- End-to-end tests across all plugins
-- Production-grade stability, comprehensive docs
-- Release automation (PyPI, container images)
+**v1.4.0** (current, on PyPI)
+- Custom package injection / hosted upload (`chantal package upload`) for RPM/APT/Helm
+- Hosted mode across plugins; continued stability and documentation improvements
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,13 @@ docs/
 ├── plugins/                     # Plugin documentation
 │   ├── overview.md
 │   ├── rpm-plugin.md
+│   ├── apt-plugin.md
+│   ├── helm-plugin.md
+│   ├── apk-plugin.md
 │   └── custom-plugins.md
+├── schema/                      # Generated config JSON Schema
+│   ├── chantal-config.schema.json
+│   └── README.md
 └── api/                         # API reference (auto-generated)
     └── modules.rst
 ```

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -44,6 +44,14 @@ Base Plugins
    :undoc-members:
    :show-inheritance:
 
+View Publisher
+~~~~~~~~~~~~~~
+
+.. automodule:: chantal.plugins.view_publisher
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 RPM Plugin
 ~~~~~~~~~~
 

--- a/docs/architecture/content-addressed-storage.md
+++ b/docs/architecture/content-addressed-storage.md
@@ -13,20 +13,31 @@ Instead of organizing packages by repository or path, Chantal stores them by the
 
 ## Storage Structure
 
-### 2-Level Directory Hierarchy
+### Two Pools + 2-Level Directory Hierarchy
 
-Packages are stored in a 2-level directory structure:
+The pool is split by **pool type** into two top-level subdirectories, and each is
+organized in a 2-level directory structure keyed on the SHA256:
+
+- `pool/content/` - packages (`ContentItem`)
+- `pool/files/` - metadata, signatures and installer files (`RepositoryFile`)
 
 ```
 pool/
-├── f2/                          # First 2 chars of SHA256
-│   └── 56/                      # Next 2 chars of SHA256
-│       └── f256abc...def789_nginx-1.20.2-1.el9.x86_64.rpm
-├── 95/
-│   └── 05/
-│       └── 9505484...1264_nginx-module-njs-1.24.0.rpm
-└── ...
+├── content/                         # Packages (ContentItem)
+│   ├── f2/                          # First 2 chars of SHA256
+│   │   └── 56/                      # Next 2 chars of SHA256
+│   │       └── f256abc...def789_nginx-1.20.2-1.el9.x86_64.rpm
+│   └── 95/
+│       └── 05/
+│           └── 9505484...1264_nginx-module-njs-1.24.0.rpm
+└── files/                           # Metadata/installer files (RepositoryFile)
+    └── 56/
+        └── 78/
+            └── 5678abc..._updateinfo.xml.gz
 ```
+
+`StorageManager.get_pool_path(sha256, filename, pool_type="content")` prepends the
+pool type (`content` or `files`) to the relative path.
 
 **Filename format:**
 ```
@@ -56,10 +67,11 @@ f256abcdef0123456789abcdef0123456789abcdef0123456789abcdef789_nginx-1.20.2-1.el9
 
 When syncing a package:
 
-1. Calculate SHA256 of package file
-2. Check if file exists in pool: `pool/{sha256[:2]}/{sha256[2:4]}/{sha256}_{filename}`
-3. If exists: Skip download, reference existing file
-4. If not exists: Download and store
+1. Download the package to a temporary file
+2. Calculate SHA256 of the file
+3. Compute the pool path: `pool/content/{sha256[:2]}/{sha256[2:4]}/{sha256}_{filename}`
+4. If it already exists: skip the copy, reference the existing file
+5. If not: copy into the pool and verify the checksum
 
 **Example:**
 
@@ -67,14 +79,11 @@ When syncing a package:
 # Package: nginx-1.20.2-1.el9.x86_64.rpm
 sha256 = "f256abcdef0123456789abcdef0123456789abcdef0123456789abcdef789"
 
-# Storage path
-pool_path = f"pool/f2/56/f256abc...def789_nginx-1.20.2-1.el9.x86_64.rpm"
+# Storage path (packages live under content/)
+pool_path = "pool/content/f2/56/f256abc...def789_nginx-1.20.2-1.el9.x86_64.rpm"
 
-# Check existence
-if pool_path.exists():
-    print("Package already in pool, skipping download")
-else:
-    download_package(url, pool_path)
+# StorageManager.add_package() handles dedup + checksum verification on a LOCAL file
+sha256, pool_path_rel, size_bytes = storage.add_package(source_path, filename)
 ```
 
 ### Cross-Repository Deduplication
@@ -86,7 +95,7 @@ Repository A: nginx-1.20.2-1.el9.x86_64.rpm (SHA256: f256abc...)
 Repository B: nginx-1.20.2-1.el9.x86_64.rpm (SHA256: f256abc...)
 Repository C: nginx-1.20.2-1.el9.x86_64.rpm (SHA256: f256abc...)
 
-Pool storage: 1 copy (f2/56/f256abc...rpm)
+Pool storage: 1 copy (content/f2/56/f256abc...rpm)
 Database: 3 repository associations
 ```
 
@@ -97,47 +106,57 @@ Database: 3 repository associations
 
 ## Database Integration
 
-### Package Model
+### ContentItem Model
+
+Packages of all types are stored in the generic `ContentItem` model. The SHA256
+is a **unique** column (the primary key is an integer `id`). See
+[Database Schema](database-schema.md) for the full definition.
 
 ```python
-class Package:
-    sha256: str           # Primary key (content address)
+class ContentItem:
+    id: int               # Primary key
+    sha256: str           # Content address (UNIQUE)
     filename: str         # Original filename
-    size: int             # File size in bytes
+    size_bytes: int       # File size in bytes
+    pool_path: str        # Relative pool path (e.g. "content/ab/cd/<sha>_file.rpm")
 
+    content_type: str     # "rpm", "helm", "apt", ...
     name: str             # Package name (e.g., "nginx")
     version: str          # Version
-    release: str          # Release
-    architecture: str     # arch (e.g., "x86_64")
+    content_metadata: dict  # JSON: release/arch/epoch/etc. (type-specific)
 
-    # Many-to-many with repositories
-    repositories: List[Repository]
+    # Many-to-many with repositories and snapshots
+    repositories: list[Repository]
+    snapshots: list[Snapshot]
 ```
+
+`RepositoryFile` mirrors this design for metadata/installer files, stored under
+`pool/files/` instead of `pool/content/`.
 
 ### Junction Table
 
-Packages can belong to multiple repositories:
+Content items can belong to multiple repositories:
 
 ```
-repository_packages (junction table)
-├── repository_id: str
-├── package_sha256: str
+repository_content_items (junction table)
+├── repository_id: int        (FK -> repositories.id)
+├── content_item_id: int      (FK -> content_items.id)
 └── added_at: datetime
 ```
 
 **Query examples:**
 
 ```python
-# Find all packages in a repository
-packages = repository.packages
+# Find all content items in a repository
+items = repository.content_items
 
-# Find all repositories containing a package
-repositories = package.repositories
+# Find all repositories containing a content item
+repositories = item.repositories
 
-# Check if package is in pool
-package = session.query(Package).filter_by(sha256=sha256).first()
-if package:
-    print(f"Package in pool, used by {len(package.repositories)} repos")
+# Check if a content item is in the pool
+item = session.query(ContentItem).filter_by(sha256=sha256).first()
+if item:
+    print(f"In pool, used by {len(item.repositories)} repos")
 ```
 
 ## Hardlink-Based Publishing
@@ -168,54 +187,62 @@ published/
 **How hardlinks work:**
 
 ```python
+import os
+
 # Create hardlink from pool to published directory
-pool_path = "pool/f2/56/f256abc...rpm"
+pool_path = "pool/content/f2/56/f256abc...rpm"
 published_path = "published/rhel9-baseos/latest/Packages/nginx-1.20.2-1.el9.x86_64.rpm"
 
-# Both paths point to same inode (same physical data)
-published_path.hardlink_to(pool_path)
+# Both paths point to the same inode (same physical data).
+# os.link() is used (not Path.hardlink_to()).
+os.link(pool_path, published_path)
 
-# Deleting one doesn't affect the other
-# Data is deleted only when all hardlinks are removed
+# Deleting one doesn't affect the other.
+# Data is deleted only when all hardlinks are removed.
 ```
 
 ## Storage Operations
 
 ### Add Package
 
+`add_package()` operates on a **local** file that has already been downloaded; it
+does not fetch from a URL. It hashes the file, copies it into `pool/content/`
+(unless an identical SHA256 is already present), optionally verifies the checksum,
+and returns `(sha256, pool_path, size_bytes)`.
+
 ```python
-def add_package(url: str, sha256: str, filename: str) -> Path:
-    """Add package to pool."""
-    # Compute storage path
-    dir1 = sha256[:2]
-    dir2 = sha256[2:4]
-    pool_path = pool_dir / dir1 / dir2 / f"{sha256}_{filename}"
+def add_package(
+    self, source_path: Path, filename: str, verify_checksum: bool = True
+) -> tuple[str, str, int]:
+    """Add a local package file to the content pool."""
+    sha256 = self.calculate_sha256(source_path)
+    pool_path_rel = self.get_pool_path(sha256, filename)        # "content/ab/cd/..."
+    pool_path_abs = self.pool_path / pool_path_rel
+    size_bytes = source_path.stat().st_size
 
-    # Check if exists
-    if pool_path.exists():
-        return pool_path  # Already in pool
+    if pool_path_abs.exists():
+        return sha256, pool_path_rel, size_bytes  # Already in pool (dedup)
 
-    # Download and verify
-    pool_path.parent.mkdir(parents=True, exist_ok=True)
-    download_file(url, pool_path)
-    verify_sha256(pool_path, sha256)
-
-    return pool_path
+    pool_path_abs.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, pool_path_abs)
+    # ... optional checksum verification ...
+    return sha256, pool_path_rel, size_bytes
 ```
+
+Metadata/installer files use the sibling method `add_repository_file()`, which is
+identical except it stores under `pool/files/`.
 
 ### Create Hardlink
 
 ```python
-def create_hardlink(sha256: str, filename: str, target_path: Path):
+def create_hardlink(self, sha256: str, filename: str, target_path: Path) -> None:
     """Create hardlink from pool to target."""
-    # Find in pool
-    pool_path = find_in_pool(sha256, filename)
-
-    # Create parent directories
+    source_path = self.get_absolute_pool_path(sha256, filename)
     target_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Create hardlink
-    target_path.hardlink_to(pool_path)
+    if target_path.exists():
+        target_path.unlink()
+    # os.link for compatibility (not Path.hardlink_to)
+    os.link(source_path, target_path)
 ```
 
 ### Verify Pool Integrity
@@ -236,19 +263,24 @@ def verify_pool():
 
 ### Cleanup Orphaned Files
 
-```python
-def cleanup_orphaned_files():
-    """Remove files in pool not referenced by database."""
-    # Get all SHA256s in database
-    db_sha256s = set(session.query(Package.sha256).all())
+Orphan detection unions the SHA256s from **both** content-addressed tables —
+`ContentItem` (packages) and `RepositoryFile` (metadata/installer files) — and
+scans both pool subdirectories (`content/` and `files/`).
 
-    # Scan pool
-    for pool_file in pool_dir.rglob("*"):
-        if pool_file.is_file():
-            sha256 = pool_file.name.split("_")[0]
-            if sha256 not in db_sha256s:
-                print(f"Orphaned: {pool_file}")
-                pool_file.unlink()  # Delete
+```python
+def get_orphaned_files(self, session):
+    """Find pool files not referenced by either content table."""
+    content_sha256s = {row.sha256 for row in session.query(ContentItem.sha256).all()}
+    file_sha256s = {row.sha256 for row in session.query(RepositoryFile.sha256).all()}
+    db_sha256s = content_sha256s | file_sha256s  # Union of both tables
+
+    orphaned = []
+    for pool_file in self.pool_path.rglob("*"):
+        if pool_file.is_file() and "_" in pool_file.name:
+            file_sha256 = pool_file.name.split("_", 1)[0]
+            if len(file_sha256) == 64 and file_sha256 not in db_sha256s:
+                orphaned.append(pool_file)
+    return orphaned
 ```
 
 ## Storage Statistics

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -5,238 +5,399 @@ Chantal uses SQLAlchemy ORM with support for PostgreSQL and SQLite.
 ## Overview
 
 The database stores:
-- Package metadata
+- Content item metadata (packages of any type)
+- Repository metadata/installer files
 - Repository state
 - Snapshots
-- Views (virtual repositories)
+- Views (virtual repositories) and view snapshots
 - Sync history
+
+All models are defined in `src/chantal/db/models.py`.
+
+## Design: Generic Content Items
+
+Chantal does **not** have a type-specific `Package` model. Instead, all package
+types (RPM, Helm, PyPI, APT/DEB, Alpine APK, etc.) are stored in a single generic
+`ContentItem` model. Type-specific attributes are kept in a JSON column
+(`content_metadata`) rather than as dedicated columns. This keeps the schema
+stable when new content types are added: a new plugin only needs to agree on the
+JSON layout for its `content_type`.
+
+For RPM, attributes like `epoch`, `release` and `arch` live inside
+`content_metadata` and are exposed through read-only `@property` accessors on the
+model (including a derived `nevra` string).
 
 ## Core Models
 
-### Package
+### ContentItem
 
-Stores package metadata with content-addressed storage (SHA256).
+Generic, content-addressed model for all package types (table `content_items`).
 
 ```python
-class Package(Base):
-    sha256: str           # Primary key (content address)
-    filename: str         # Original filename
-    size: int             # File size in bytes
+class ContentItem(Base):
+    id: int                  # Primary key (auto-increment)
 
-    # RPM metadata
-    name: str             # Package name (e.g., "nginx")
-    version: str          # Version
-    release: str          # Release
-    epoch: int            # Epoch (default: 0)
-    architecture: str     # Architecture (e.g., "x86_64")
+    content_type: str        # 'rpm', 'helm', 'pypi', 'apt', 'apk', ... (indexed)
 
-    # Timestamps
+    name: str                # Package name (e.g., "nginx"), indexed
+    version: str             # Version, indexed
+
+    sha256: str              # Content address - UNIQUE, indexed (NOT the PK)
+    size_bytes: int          # File size in bytes
+    pool_path: str           # Relative path in pool (e.g., "content/ab/cd/<sha>_file.rpm")
+    filename: str            # Original filename
+
+    content_metadata: dict   # JSON; type-specific fields (NOT called 'metadata'
+                             # because that name is reserved by SQLAlchemy)
+
     created_at: datetime
+    reference_count: int     # For garbage collection
 
-    # Relationships
-    repositories: List[Repository]  # Many-to-many
-    snapshots: List[Snapshot]       # Many-to-many
+    # Relationships (many-to-many)
+    repositories: list[Repository]   # via repository_content_items
+    snapshots: list[Snapshot]        # via snapshot_content_items
 ```
 
 **Key features:**
-- SHA256 as primary key (content-addressed)
-- Deduplication via unique SHA256
-- Many-to-many relationships with repositories and snapshots
+- Integer `id` is the primary key; `sha256` is a separate **unique** indexed column.
+- Deduplication is enforced by the unique `sha256` constraint.
+- Composite indexes: `(content_type, name)` and `(content_type, name, version)`.
+
+**RPM-specific properties** (read JSON from `content_metadata`):
+
+```python
+item.epoch     # content_metadata["epoch"]   (rpm only)
+item.release   # content_metadata["release"] (rpm only)
+item.arch      # content_metadata["arch"]    (rpm/deb)
+item.nevra     # "name-epoch:version-release.arch" (rpm only)
+```
 
 ### Repository
 
-Configured repositories from YAML.
+Configured repositories from YAML (table `repositories`).
 
 ```python
 class Repository(Base):
-    id: str               # Primary key (from config)
+    id: int               # Primary key (auto-increment)
+    repo_id: str          # Stable config identifier - UNIQUE
     name: str             # Human-readable name
     type: str             # Repository type (rpm, apt, helm, apk)
-    feed_url: str         # Upstream URL
-    enabled: bool         # Whether enabled
+    feed: str             # Upstream URL (Pulp terminology, NOT "feed_url")
+    enabled: bool
+    mode: RepositoryMode  # Enum: mirror / filtered / hosted (default: filtered)
+
+    # Paths
+    latest_path: str | None
+    snapshots_path: str | None
 
     # Timestamps
     created_at: datetime
     updated_at: datetime
-    last_sync_at: datetime
+
+    # Sync state
+    last_sync_at: datetime | None
+    last_sync_status: str | None   # success, failed, running
 
     # Relationships
-    packages: List[Package]       # Many-to-many
-    snapshots: List[Snapshot]     # One-to-many
-    sync_history: List[SyncHistory]  # One-to-many
+    snapshots: list[Snapshot]            # One-to-many
+    sync_history: list[SyncHistory]      # One-to-many
+    content_items: list[ContentItem]     # Many-to-many via repository_content_items
+    repository_files: list[RepositoryFile]  # Many-to-many via repository_repository_files
+```
+
+#### RepositoryMode
+
+```python
+class RepositoryMode(enum.StrEnum):
+    MIRROR = "mirror"      # Full mirror, no filtering, metadata unchanged
+    FILTERED = "filtered"  # Filtered packages with customized metadata (default)
+    HOSTED = "hosted"      # Self-hosted / uploaded packages (no upstream sync)
+```
+
+The `mode` column was added in the head migration `e190d159daac`.
+
+### ContentItem vs. RepositoryFile
+
+A repository is more than just its packages. Metadata files (`updateinfo.xml`,
+`filelists.xml`, `comps.xml`, `modules.yaml`), signatures, and installer/kickstart
+artifacts (`vmlinuz`, `initrd.img`, `.treeinfo`) are stored separately in the
+`RepositoryFile` model. Both `ContentItem` and `RepositoryFile` use
+content-addressed pool storage, but they live in different pool subdirectories
+(`pool/content/` vs. `pool/files/`).
+
+### RepositoryFile
+
+Non-package repository files: metadata, signatures, installer/kickstart artifacts
+(table `repository_files`). Added in migration `4ae7cc6b7243`.
+
+```python
+class RepositoryFile(Base):
+    id: int                # Primary key (auto-increment)
+
+    file_category: str     # "metadata", "signature", "kickstart", "debian-installer" (indexed)
+    file_type: str         # "updateinfo", "filelists", "comps", "modules",
+                           # "vmlinuz", "initrd", ".treeinfo", ... (indexed)
+
+    sha256: str            # Content address (indexed, not unique)
+    pool_path: str         # e.g. "files/ab/cd/<sha>_updateinfo.xml.gz"
+    size_bytes: int
+
+    original_path: str     # Exact upstream path to preserve when publishing
+                           # e.g. "repodata/<hash>-updateinfo.xml.gz", ".treeinfo"
+
+    file_metadata: dict | None  # JSON; type-specific info (reserved-name workaround)
+
+    created_at: datetime
+    updated_at: datetime
+
+    # Relationships (many-to-many, like ContentItem)
+    repositories: list[Repository]   # via repository_repository_files
+    snapshots: list[Snapshot]        # via snapshot_repository_files
 ```
 
 ### Snapshot
 
-Immutable point-in-time repository state.
+Immutable point-in-time repository state (table `snapshots`).
 
 ```python
 class Snapshot(Base):
     id: int               # Primary key (auto-increment)
-    repository_id: str    # Foreign key to Repository
+    repository_id: int    # Foreign key to Repository.id
     name: str             # Snapshot name (e.g., "2025-01")
-    description: str      # Optional description
+    description: str | None
 
-    # Timestamps
     created_at: datetime
+    is_published: bool
+    published_path: str | None
+
+    # Cached statistics
+    package_count: int
+    total_size_bytes: int
 
     # Relationships
     repository: Repository
-    packages: List[Package]  # Many-to-many
+    content_items: list[ContentItem]      # Many-to-many via snapshot_content_items
+    repository_files: list[RepositoryFile] # Many-to-many via snapshot_repository_files
 ```
 
-**Unique constraint:** (repository_id, name)
+**Unique constraint:** `(repository_id, name)` (`uq_snapshot_name`).
 
 ### View
 
-Virtual repository combining multiple repositories.
+Virtual repository combining multiple repositories (table `views`).
 
 ```python
 class View(Base):
-    name: str             # Primary key (from config)
-    description: str      # Human-readable description
+    id: int               # Primary key (auto-increment)
+    name: str             # UNIQUE, indexed
+    description: str | None
+    repo_type: str        # All repos in a view must share this type (rpm, apt)
 
-    # Timestamps
     created_at: datetime
     updated_at: datetime
 
+    is_published: bool
+    published_at: datetime | None
+    published_path: str | None
+
     # Relationships
-    repositories: List[Repository]   # Many-to-many via ViewRepository
-    snapshots: List[ViewSnapshot]    # One-to-many
+    view_repositories: list[ViewRepository]  # One-to-many (ordered membership)
+    view_snapshots: list[ViewSnapshot]       # One-to-many
 ```
+
+### ViewRepository
+
+Membership of repositories in a view, with ordering. This is a full ORM model
+(table `view_repositories`), not a plain association table.
+
+```python
+class ViewRepository(Base):
+    id: int               # Primary key (auto-increment)
+    view_id: int          # Foreign key to View.id
+    repository_id: int    # Foreign key to Repository.id
+    order: int            # Precedence for metadata merging (lower = higher priority)
+    added_at: datetime
+
+    # Relationships
+    view: View
+    repository: Repository
+```
+
+**Unique constraint:** `(view_id, repository_id)` (`uq_view_repository`).
 
 ### ViewSnapshot
 
-Snapshot of a view (references multiple repository snapshots).
+Atomic snapshot of all repositories in a view (table `view_snapshots`). It does
+**not** use a junction table; instead it stores the included repository snapshot
+IDs directly in a JSON array.
 
 ```python
 class ViewSnapshot(Base):
     id: int               # Primary key (auto-increment)
-    view_name: str        # Foreign key to View
-    name: str             # Snapshot name (e.g., "2025-01")
-    description: str      # Optional description
+    view_id: int          # Foreign key to View.id
+    name: str             # Snapshot name, indexed
+    description: str | None
 
-    # Timestamps
     created_at: datetime
+
+    snapshot_ids: list[int]  # JSON array of Snapshot.id values (e.g. [12, 45, 67])
+
+    is_published: bool
+    published_at: datetime | None
+    published_path: str | None
+
+    # Cached statistics
+    package_count: int
+    total_size_bytes: int
 
     # Relationships
     view: View
-    snapshots: List[Snapshot]  # Many-to-many
 ```
+
+**Unique constraint:** `(view_id, name)` (`uq_view_snapshot_name`).
 
 ### SyncHistory
 
-Tracks sync operations for audit and debugging.
+Tracks sync operations for audit and debugging (table `sync_history`).
 
 ```python
 class SyncHistory(Base):
     id: int               # Primary key (auto-increment)
-    repository_id: str    # Foreign key to Repository
+    repository_id: int    # Foreign key to Repository.id
 
-    # Sync details
+    # Sync timing
     started_at: datetime
-    completed_at: datetime
-    status: str           # success, failed, partial
-    error_message: str    # Error details (if failed)
+    completed_at: datetime | None
+
+    # Result
+    status: str           # running, success, failed
+    error_message: str | None
 
     # Statistics
-    packages_total: int
-    packages_downloaded: int
-    packages_skipped: int
-    bytes_transferred: int
+    packages_added: int
+    packages_removed: int
+    packages_updated: int
+    bytes_downloaded: int
+
+    # Snapshot created during this sync (optional)
+    snapshot_id: int | None   # Foreign key to Snapshot.id
 
     # Relationships
     repository: Repository
+    snapshot: Snapshot | None
 ```
+
+`duration_seconds` is a derived `@property` (`completed_at - started_at`).
 
 ## Junction Tables
 
-### repository_packages
+The following are plain SQLAlchemy association `Table`s (no ORM class):
 
-Many-to-many relationship between repositories and packages.
+### repository_content_items
+
+Many-to-many between repositories and content items (the "latest" state).
 
 ```python
-repository_packages = Table(
-    'repository_packages',
-    Column('repository_id', ForeignKey('repositories.id')),
-    Column('package_sha256', ForeignKey('packages.sha256')),
-    Column('added_at', DateTime),
-    PrimaryKey('repository_id', 'package_sha256')
+repository_content_items = Table(
+    "repository_content_items",
+    Column("repository_id", ForeignKey("repositories.id"), primary_key=True),
+    Column("content_item_id", ForeignKey("content_items.id"), primary_key=True),
+    Column("added_at", DateTime),
 )
 ```
 
-### snapshot_packages
+### snapshot_content_items
 
-Many-to-many relationship between snapshots and packages.
+Many-to-many between snapshots and content items.
 
 ```python
-snapshot_packages = Table(
-    'snapshot_packages',
-    Column('snapshot_id', ForeignKey('snapshots.id')),
-    Column('package_sha256', ForeignKey('packages.sha256')),
-    PrimaryKey('snapshot_id', 'package_sha256')
+snapshot_content_items = Table(
+    "snapshot_content_items",
+    Column("snapshot_id", ForeignKey("snapshots.id"), primary_key=True),
+    Column("content_item_id", ForeignKey("content_items.id"), primary_key=True),
 )
 ```
 
-### view_repositories
+### repository_repository_files
 
-Many-to-many relationship between views and repositories.
+Many-to-many between repositories and repository files (the "latest" state).
 
 ```python
-view_repositories = Table(
-    'view_repositories',
-    Column('view_name', ForeignKey('views.name')),
-    Column('repository_id', ForeignKey('repositories.id')),
-    Column('order', Integer),  # Repository order in view
-    PrimaryKey('view_name', 'repository_id')
+repository_repository_files = Table(
+    "repository_repository_files",
+    Column("repository_id", ForeignKey("repositories.id"), primary_key=True),
+    Column("repository_file_id", ForeignKey("repository_files.id"), primary_key=True),
+    Column("added_at", DateTime),
 )
 ```
 
-### view_snapshot_snapshots
+### snapshot_repository_files
 
-Many-to-many relationship between view snapshots and repository snapshots.
+Many-to-many between snapshots and repository files.
 
 ```python
-view_snapshot_snapshots = Table(
-    'view_snapshot_snapshots',
-    Column('view_snapshot_id', ForeignKey('view_snapshots.id')),
-    Column('snapshot_id', ForeignKey('snapshots.id')),
-    PrimaryKey('view_snapshot_id', 'snapshot_id')
+snapshot_repository_files = Table(
+    "snapshot_repository_files",
+    Column("snapshot_id", ForeignKey("snapshots.id"), primary_key=True),
+    Column("repository_file_id", ForeignKey("repository_files.id"), primary_key=True),
 )
 ```
+
+> **Note:** View-to-repository membership is the ORM model `ViewRepository`
+> (see above), and view snapshots reference repository snapshots through the
+> `ViewSnapshot.snapshot_ids` JSON array — there is no `view_repositories` plain
+> table and no `view_snapshot_snapshots` junction table.
 
 ## Indexes
 
-Critical indexes for performance:
+Indexes declared on the models:
 
-```sql
--- Package lookups
-CREATE INDEX idx_packages_name_arch ON packages(name, architecture);
-CREATE INDEX idx_packages_name ON packages(name);
+```text
+content_items:
+  - content_type            (column index)
+  - name                    (column index)
+  - version                 (column index)
+  - sha256                  (unique index)
+  - idx_content_type_name           (content_type, name)
+  - idx_content_type_name_version   (content_type, name, version)
 
--- Repository queries
-CREATE INDEX idx_repositories_enabled ON repositories(enabled);
+repository_files:
+  - file_category, file_type, sha256  (column indexes)
+  - idx_repo_file_category (file_category)
+  - idx_repo_file_type (file_type)
 
--- Snapshot queries
-CREATE INDEX idx_snapshots_repo_name ON snapshots(repository_id, name);
+repositories:
+  - repo_id (unique)
 
--- Sync history
-CREATE INDEX idx_sync_history_repo_started ON sync_history(repository_id, started_at);
+snapshots:
+  - name (column index)
+
+views / view_snapshots:
+  - name (column index)
 ```
 
 ## Database Migrations
 
-Chantal uses Alembic for schema migrations.
+Chantal uses Alembic for schema migrations. Migration scripts live in
+`alembic/versions/`.
 
 ### Migration Files
 
-```
-migrations/
+```text
+alembic/
 ├── versions/
-│   ├── 001_initial_schema.py
-│   ├── 002_add_views.py
-│   └── 003_add_sync_history.py
+│   ├── 20260110_2202_a4a922fdfc63_initial_schema_with_generic_content_.py
+│   ├── 20260111_1138_4ae7cc6b7243_add_repository_files_table_and_.py
+│   └── 20260111_1242_e190d159daac_add_repository_mode_field.py
 └── env.py
+```
+
+Revision chain (head is `e190d159daac`):
+
+```text
+a4a922fdfc63 (initial schema, generic ContentItem)
+    → 4ae7cc6b7243 (add repository_files table + junctions)
+        → e190d159daac (add Repository.mode field)   ← head
 ```
 
 ### Run Migrations
@@ -254,41 +415,42 @@ alembic current
 
 ## Example Queries
 
-### Find all packages in repository
+### Find all content items in a repository
 
 ```python
-repo = session.query(Repository).filter_by(id="epel9-vim").first()
-packages = repo.packages
+repo = session.query(Repository).filter_by(repo_id="epel9-vim").first()
+items = repo.content_items
 ```
 
-### Find all repositories containing a package
+### Find all repositories containing a content item
 
 ```python
-package = session.query(Package).filter_by(sha256="f256abc...").first()
-repos = package.repositories
+item = session.query(ContentItem).filter_by(sha256="f256abc...").first()
+repos = item.repositories
 ```
 
 ### Create snapshot
 
 ```python
 snapshot = Snapshot(
-    repository_id="epel9-vim",
+    repository_id=repo.id,
     name="2025-01",
-    description="January 2025"
+    description="January 2025",
 )
-snapshot.packages = repo.packages  # Copy current packages
+snapshot.content_items = list(repo.content_items)  # Copy current items
+snapshot.repository_files = list(repo.repository_files)
 session.add(snapshot)
 session.commit()
 ```
 
-### Find packages added between snapshots
+### Find content items added between snapshots
 
 ```python
 snapshot1 = session.query(Snapshot).filter_by(name="2025-01").first()
 snapshot2 = session.query(Snapshot).filter_by(name="2025-02").first()
 
-added = set(snapshot2.packages) - set(snapshot1.packages)
-removed = set(snapshot1.packages) - set(snapshot2.packages)
+added = set(snapshot2.content_items) - set(snapshot1.content_items)
+removed = set(snapshot1.content_items) - set(snapshot2.content_items)
 ```
 
 ## Database Backends
@@ -327,17 +489,6 @@ database:
 - Requires PostgreSQL installation
 - More complex setup
 
-## Database Size Estimates
-
-**Typical sizes:**
-- 1,000 packages: ~1 MB (SQLite) / ~500 KB (PostgreSQL)
-- 10,000 packages: ~10 MB / ~5 MB
-- 100,000 packages: ~100 MB / ~50 MB
-- 1,000,000 packages: ~1 GB / ~500 MB
-
-**With snapshots:**
-- 10 snapshots × 10,000 packages: ~15 MB (snapshots are metadata only)
-
 ## Maintenance
 
 ### Vacuum (SQLite)
@@ -352,51 +503,51 @@ sqlite3 /var/lib/chantal/chantal.db "VACUUM;"
 ANALYZE;
 ```
 
-### Cleanup Orphaned Packages
+### Cleanup Orphaned Content Items
 
 ```python
-# Find packages not in any repository
-orphaned = session.query(Package).filter(
-    ~Package.repositories.any()
+# Find content items not in any repository
+orphaned = session.query(ContentItem).filter(
+    ~ContentItem.repositories.any()
 ).all()
 ```
 
 ## Schema Diagram
 
-```
-┌─────────────┐       ┌──────────────────┐       ┌─────────────┐
-│  Repository │◄─────►│ repository_      │◄─────►│   Package   │
-│             │       │   packages       │       │             │
-│ - id (PK)   │       │                  │       │ - sha256(PK)│
-│ - name      │       │ - repository_id  │       │ - name      │
-│ - type      │       │ - package_sha256 │       │ - version   │
-│ - feed_url  │       │ - added_at       │       │ - arch      │
-└─────┬───────┘       └──────────────────┘       └─────┬───────┘
-      │                                                  │
-      │                                                  │
-      ▼                                                  ▼
-┌─────────────┐       ┌──────────────────┐       ┌─────────────┐
-│  Snapshot   │◄─────►│ snapshot_        │◄──────┤             │
-│             │       │   packages       │       │             │
-│ - id (PK)   │       │                  │       │             │
-│ - repo_id   │       │ - snapshot_id    │       │             │
-│ - name      │       │ - package_sha256 │       │             │
-└─────────────┘       └──────────────────┘       └─────────────┘
-
-┌─────────────┐       ┌──────────────────┐
-│    View     │◄─────►│ view_            │
-│             │       │   repositories   │
-│ - name (PK) │       │                  │
-│ - desc      │       │ - view_name      │
-└─────┬───────┘       │ - repository_id  │
-      │               │ - order          │
-      │               └──────────────────┘
-      ▼
-┌─────────────┐       ┌──────────────────┐
-│ ViewSnapshot│◄─────►│ view_snapshot_   │
-│             │       │   snapshots      │
-│ - id (PK)   │       │                  │
-│ - view_name │       │ - view_snap_id   │
-│ - name      │       │ - snapshot_id    │
-└─────────────┘       └──────────────────┘
+```text
+┌──────────────┐     ┌───────────────────────────┐     ┌──────────────┐
+│  Repository  │◄───►│ repository_content_items  │◄───►│ ContentItem  │
+│              │     │                           │     │              │
+│ - id (PK)    │     │ - repository_id           │     │ - id (PK)    │
+│ - repo_id (U)│     │ - content_item_id         │     │ - sha256 (U) │
+│ - type       │     │ - added_at                │     │ - content_type│
+│ - feed       │     └───────────────────────────┘     │ - name        │
+│ - mode       │                                        │ - version     │
+└──┬───────┬───┘     ┌───────────────────────────┐     │ - content_    │
+   │       │◄───────►│ repository_repository_files│◄──►│   metadata    │
+   │       │         └───────────────────────────┘  │  └──────────────┘
+   │       │                                          │
+   │       ▼                                          ▼
+   │  ┌──────────────┐  ┌──────────────────────┐  ┌──────────────┐
+   │  │   Snapshot   │◄►│ snapshot_content_items│◄►│ RepositoryFile│
+   │  │ - id (PK)    │  └──────────────────────┘  │ - id (PK)     │
+   │  │ - repo_id FK │  ┌──────────────────────┐  │ - sha256      │
+   │  │ - name       │◄►│snapshot_repository_files│◄│ - file_category│
+   │  └──────────────┘  └──────────────────────┘  │ - original_path│
+   │                                               └──────────────┘
+   ▼
+┌──────────────┐     ┌──────────────────┐
+│ SyncHistory  │     │     View         │
+│ - id (PK)    │     │ - id (PK)        │
+│ - repo_id FK │     │ - name (U)       │
+│ - status     │     │ - repo_type      │
+└──────────────┘     └───┬──────────┬───┘
+                         │          │
+            ┌────────────▼───┐  ┌───▼──────────────┐
+            │ ViewRepository │  │  ViewSnapshot    │
+            │ - id (PK)      │  │ - id (PK)        │
+            │ - view_id FK   │  │ - view_id FK     │
+            │ - repo_id FK   │  │ - snapshot_ids   │  (JSON array of Snapshot.id)
+            │ - order        │  └──────────────────┘
+            └────────────────┘
 ```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -92,15 +92,23 @@ Chantal follows a clean, modular architecture designed for simplicity and extens
 - `src/chantal/core/storage.py` - StorageManager class
 
 **Storage Layout:**
+
+The pool is split into two subdirectories by pool type: `content/` for packages
+(`ContentItem`) and `files/` for metadata/installer files (`RepositoryFile`).
+
 ```
 pool/
-├── f2/
-│   └── 56/
-│       └── f256abc...def789_nginx-1.20.2-1.el9.x86_64.rpm
-├── 95/
-│   └── 05/
-│       └── 9505484...c1264fde_nginx-module-njs-1.24.0.rpm
-└── ...
+├── content/                       # ContentItem (packages)
+│   ├── f2/
+│   │   └── 56/
+│   │       └── f256abc...def789_nginx-1.20.2-1.el9.x86_64.rpm
+│   └── 95/
+│       └── 05/
+│           └── 9505484...c1264fde_nginx-module-njs-1.24.0.rpm
+└── files/                         # RepositoryFile (metadata/installer)
+    └── 56/
+        └── 78/
+            └── 5678abc..._updateinfo.xml.gz
 ```
 
 #### Database Manager
@@ -108,7 +116,8 @@ pool/
 **Technologies:** SQLAlchemy (ORM), Alembic (migrations)
 
 **Responsibilities:**
-- Package metadata storage
+- Content (package) metadata storage
+- Repository metadata/installer file tracking
 - Repository state tracking
 - Snapshot management
 - Sync history
@@ -116,19 +125,31 @@ pool/
 
 **Key Files:**
 - `src/chantal/db/models.py` - SQLAlchemy models
-- `src/chantal/db/session.py` - Database session management
+- `src/chantal/db/connection.py` - Database connection/session management
 
 **Database Models:**
-- `Repository` - Configured repositories
-- `Package` - Content-addressed packages
+- `Repository` - Configured repositories (with `mode`: mirror/filtered/hosted)
+- `ContentItem` - Content-addressed packages (generic, all types)
+- `RepositoryFile` - Content-addressed metadata/installer files
 - `Snapshot` - Immutable snapshots
+- `View` / `ViewRepository` / `ViewSnapshot` - Virtual repositories spanning repos
 - `SyncHistory` - Sync tracking
+
+**Repository Modes:**
+
+Each `Repository` has a `mode` (`RepositoryMode` enum):
+
+- `mirror` - Full mirror of the upstream; no filtering, metadata unchanged.
+- `filtered` - Filtered package set with customized/regenerated metadata
+  (include/exclude rules, retention, etc.). This is the default.
+- `hosted` - Self-hosted packages with no upstream sync. Content items are
+  uploaded into the repository directly rather than fetched from a feed.
 
 ### Plugin Layer
 
 #### Sync Plugins
 
-**Technologies:** ABC (Abstract Base Classes), Requests (HTTP)
+**Technologies:** Plain Python classes (no shared base class), Requests (HTTP)
 
 **Responsibilities:**
 - Fetch repository metadata
@@ -140,13 +161,14 @@ pool/
 **Plugins:**
 - `RpmSyncPlugin` - RPM/DNF/YUM repositories
 - `AptSyncPlugin` - Debian/Ubuntu APT repositories
-- `HelmSyncPlugin` - Helm chart repositories (HTTP and OCI)
-- `ApkSyncPlugin` - Alpine APK repositories
+- `HelmSyncer` - Helm chart repositories (HTTP and OCI)
+- `ApkSyncer` - Alpine APK repositories
 
 **Key Files:**
-- `src/chantal/plugins/base.py` - Base plugin interface
-- `src/chantal/plugins/rpm_sync.py` - RPM sync implementation
-- `src/chantal/plugins/rpm.py` - RPM publisher implementation
+- `src/chantal/plugins/base.py` - `PublisherPlugin` base class (publishers only;
+  sync plugins are a convention, not a base class)
+- `src/chantal/plugins/rpm/sync.py` - RPM sync implementation
+- `src/chantal/plugins/rpm/publisher.py` - RPM publisher implementation
 
 #### Publisher Plugins
 
@@ -159,8 +181,8 @@ pool/
 - Sign repositories (future)
 
 **Key Files:**
-- `src/chantal/plugins/base.py` - Publisher plugin interface
-- `src/chantal/plugins/rpm.py` - RPM publisher (repomd.xml, primary.xml.gz)
+- `src/chantal/plugins/base.py` - `PublisherPlugin` interface
+- `src/chantal/plugins/rpm/publisher.py` - RPM publisher (repomd.xml, primary.xml.gz)
 
 ## Data Flow
 
@@ -218,7 +240,8 @@ pool/
 ## Technology Stack
 
 ### Runtime
-- **Python 3.12+** - Required for Path.hardlink_to()
+- **Python 3.12+** - Project runtime requirement (`requires-python = ">=3.12"`);
+  hardlinks are created with `os.link()`, not `Path.hardlink_to()`
 - **SQLAlchemy** - Database ORM
 - **Alembic** - Database migrations
 - **Click** - CLI framework
@@ -298,12 +321,14 @@ pool/
 
 ### Adding Repository Types
 
-1. Implement `SyncPlugin` interface
-2. Implement `PublisherPlugin` interface
-3. Register plugin in plugin registry
-4. Add configuration validation
+1. Write a sync plugin class following the sync convention
+   (`sync_repository(session, repository) -> SyncResult`; no base class)
+2. Implement the `PublisherPlugin` interface
+3. Add an `elif` dispatch branch in `cli/repo_commands.py` and
+   `cli/publish_commands.py` (there is no plugin registry)
+4. Add the new type to `RepositoryConfig.type` validation
 
-Example: APT plugin (future)
+See [Plugin System](plugin-system.md) for details.
 
 ### Adding Filter Types
 

--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -12,31 +12,47 @@ Each repository type requires two plugins:
 
 ### Sync Plugin
 
-Responsible for syncing packages from upstream repository.
+Responsible for syncing packages from an upstream repository.
 
-**Base interface:**
+There is **no** abstract `SyncPlugin` base class. "Sync plugin" is a convention,
+not an enforced interface: each sync plugin (`RpmSyncPlugin`, `AptSyncPlugin`,
+`HelmSyncer`, `ApkSyncer`) is a plain class that follows the same shape.
+
+**Convention:**
 
 ```python
-from abc import ABC, abstractmethod
+class RpmSyncPlugin:  # inherits nothing
+    def __init__(
+        self,
+        storage: StorageManager,
+        config: RepositoryConfig,
+        proxy_config: ProxyConfig | None = None,
+        ssl_config: SSLConfig | None = None,
+        cache: MetadataCache | None = None,
+        output_level: OutputLevel = OutputLevel.NORMAL,
+    ):
+        ...
 
-class SyncPlugin(ABC):
-    @abstractmethod
-    def sync(
+    def sync_repository(
         self,
         session: Session,
         repository: Repository,
-        config: RepositoryConfig
     ) -> SyncResult:
         """Sync repository from upstream."""
-        pass
+        ...
 ```
+
+Note that configuration is passed to `__init__`, **not** to `sync_repository()`.
+`SyncResult` is a `@dataclass` defined in `chantal.plugins.rpm.sync` (the APT
+plugin defines its own equivalently named `SyncResult` in
+`chantal.plugins.apt.sync`).
 
 **Responsibilities:**
 - Fetch repository metadata (e.g., repomd.xml for RPM)
-- Parse package list
+- Parse the package list
 - Apply filters
-- Download packages to pool
-- Update database
+- Download packages to the pool (and metadata files as `RepositoryFile`)
+- Update the database
 
 ### Publisher Plugin
 
@@ -117,82 +133,109 @@ class PublisherPlugin(ABC):
 
 **Status:** ✅ Available
 
-- **Helm:** `HelmSyncPlugin` / `HelmPublisher` - HTTP and OCI registries, `index.yaml`
-- **APK:** `ApkSyncPlugin` / `ApkPublisher` - `APKINDEX.tar.gz`, RSA index signing
+- **Helm:** `HelmSyncer` / `HelmPublisher` - HTTP and OCI registries, `index.yaml`
+- **APK:** `ApkSyncer` / `ApkPublisher` - `APKINDEX.tar.gz`, RSA index signing
 
-## Plugin Registration
+## Plugin Dispatch
 
-Plugins are registered in the plugin registry:
+There is **no** plugin registry. `src/chantal/plugins/__init__.py` only re-exports
+a few classes:
 
 ```python
 # src/chantal/plugins/__init__.py
+from chantal.plugins.base import PublisherPlugin
+from chantal.plugins.rpm.publisher import RpmPublisher
+from chantal.plugins.rpm.sync import RpmSyncPlugin
 
-SYNC_PLUGINS = {
-    'rpm': RpmSyncPlugin,
-    'apt': AptSyncPlugin,
-    'helm': HelmSyncPlugin,
-    'apk': ApkSyncPlugin,
-}
+__all__ = ["PublisherPlugin", "RpmPublisher", "RpmSyncPlugin"]
+```
 
-PUBLISHER_PLUGINS = {
-    'rpm': RpmPublisher,
-    'apt': AptPublisher,
-    'helm': HelmPublisher,
-    'apk': ApkPublisher,
-}
+Plugin selection is done with hardcoded `if/elif` branches on the repository type
+inside the CLI command modules:
+
+- **Sync dispatch:** `src/chantal/cli/repo_commands.py`
+- **Publish dispatch:** `src/chantal/cli/publish_commands.py`
+
+```python
+# Sync dispatch (cli/repo_commands.py, simplified)
+if repo_config.type == "rpm":
+    sync_plugin = RpmSyncPlugin(storage=storage, config=repo_config, ...)
+    result = sync_plugin.sync_repository(session, repository)
+elif repo_config.type == "helm":
+    helm_syncer = HelmSyncer(storage=storage, config=repo_config, ...)
+    ...
+elif repo_config.type == "apk":
+    apk_syncer = ApkSyncer(storage=storage, config=repo_config, ...)
+    ...
+elif repo_config.type == "apt":
+    apt_syncer = AptSyncPlugin(storage=storage, config=repo_config, ...)
+    ...
+else:
+    raise click.ClickException(f"Unsupported repository type: {repo_config.type}")
+```
+
+```python
+# Publish dispatch (cli/publish_commands.py, simplified)
+if repo_config.type == "rpm":
+    publisher = RpmPublisher(storage=storage)
+elif repo_config.type == "helm":
+    publisher = HelmPublisher(storage=storage)
+elif repo_config.type == "apk":
+    publisher = ApkPublisher(storage=storage)
+elif repo_config.type == "apt":
+    publisher = AptPublisher(storage=storage, config=repo_config)
+else:
+    raise click.ClickException(f"Unsupported repository type: {repo_config.type}")
 ```
 
 ## Creating a Custom Plugin
 
-### 1. Implement Sync Plugin
+### 1. Implement a Sync Plugin
+
+Follow the sync-plugin convention (a plain class — no base class to inherit):
 
 ```python
-from chantal.plugins.base import SyncPlugin
+class MySyncPlugin:
+    def __init__(self, storage, config, **kwargs):
+        self.storage = storage
+        self.config = config
 
-class MySyncPlugin(SyncPlugin):
-    def sync(self, session, repository, config):
-        # 1. Fetch metadata
-        metadata = self.fetch_metadata(config.feed)
-
-        # 2. Parse package list
-        packages = self.parse_packages(metadata)
-
+    def sync_repository(self, session, repository) -> SyncResult:
+        # 1. Fetch metadata from self.config.feed
+        # 2. Parse the package list
         # 3. Apply filters
-        filtered = self.apply_filters(packages, config.filters)
-
-        # 4. Download packages
-        for pkg in filtered:
-            self.download_package(pkg)
-
-        # 5. Update database
-        self.update_database(session, repository, filtered)
+        # 4. For each package: storage.add_package(local_path, filename)
+        # 5. Update the database (ContentItem rows + associations)
+        ...
 ```
 
-### 2. Implement Publisher Plugin
+### 2. Implement a Publisher Plugin
 
 ```python
 from chantal.plugins.base import PublisherPlugin
 
 class MyPublisher(PublisherPlugin):
     def publish_repository(self, session, repository, config, target_path):
-        # 1. Get packages
-        packages = repository.packages
+        # 1. Get content items (NOT .packages)
+        packages = repository.content_items
 
-        # 2. Create hardlinks
-        for pkg in packages:
-            self.create_hardlink(pkg, target_path)
+        # 2. Create hardlinks from the pool (base-class helper)
+        self._create_hardlinks(packages, target_path)
 
         # 3. Generate metadata
         self.generate_metadata(packages, target_path)
+
+    def publish_snapshot(self, session, snapshot, repository, config, target_path):
+        ...
+
+    def unpublish(self, target_path):
+        ...
 ```
 
-### 3. Register Plugin
+### 3. Wire Up Dispatch
 
-```python
-# In src/chantal/plugins/__init__.py
-SYNC_PLUGINS['my_type'] = MySyncPlugin
-PUBLISHER_PLUGINS['my_type'] = MyPublisher
-```
+Add an `elif` branch for the new type in the sync/publish dispatch in
+`src/chantal/cli/repo_commands.py` and `src/chantal/cli/publish_commands.py`.
 
 ### 4. Add Configuration Support
 
@@ -215,7 +258,7 @@ class RepositoryConfig(BaseModel):
        ↓
 4. Load sync plugin (RpmSyncPlugin)
        ↓
-5. Execute plugin.sync()
+5. Execute plugin.sync_repository(session, repository)
        ↓
 6. Plugin fetches metadata
        ↓
@@ -256,42 +299,39 @@ Common functionality shared across plugins:
 
 ### StorageManager
 
+`StorageManager` is constructed from a `StorageConfig` (not a bare pool path).
+`add_package()` operates on a **local** file that has already been downloaded — it
+does not fetch from a URL — and returns `(sha256, pool_path, size_bytes)`.
+
 ```python
 from chantal.core.storage import StorageManager
 
-storage = StorageManager(pool_path)
+storage = StorageManager(config)  # config: StorageConfig
 
-# Add package to pool
-pool_path = storage.add_package(url, sha256, filename)
+# Add a local package file to the pool (pool/content/...)
+sha256, pool_path, size_bytes = storage.add_package(
+    source_path, filename, verify_checksum=True
+)
 
-# Create hardlink
+# Add a metadata/installer file to the pool (pool/files/...)
+sha256, pool_path, size_bytes = storage.add_repository_file(source_path, filename)
+
+# Create a hardlink from the pool to a publish target
 storage.create_hardlink(sha256, filename, target_path)
 ```
 
-### HTTP Client
+### Downloading
 
-```python
-from chantal.plugins.http_client import HttpClient
+Sync plugins download upstream files themselves via `DownloadManager`
+(`chantal.core.downloader`), which is configured from the repository config plus
+optional `ProxyConfig` / `SSLConfig`. There is no `chantal.plugins.http_client`
+module.
 
-client = HttpClient(proxy_config, ssl_config)
+### Filters
 
-# Fetch URL
-response = client.get(url)
-
-# Download file
-client.download_file(url, target_path)
-```
-
-### Filter Engine
-
-```python
-from chantal.plugins.filters import FilterEngine
-
-engine = FilterEngine(filter_config)
-
-# Apply filters
-filtered_packages = engine.apply(packages)
-```
+RPM filtering lives in `chantal.plugins.rpm.filters` and is applied by the sync
+plugin against the parsed package metadata. There is no generic
+`chantal.plugins.filters.FilterEngine`.
 
 ## Testing Plugins
 
@@ -299,12 +339,12 @@ filtered_packages = engine.apply(packages)
 
 ```python
 def test_rpm_sync_plugin():
-    plugin = RpmSyncPlugin(storage_manager)
+    plugin = RpmSyncPlugin(storage=storage, config=config)
 
-    result = plugin.sync(session, repository, config)
+    result = plugin.sync_repository(session, repository)
 
     assert result.packages_downloaded > 0
-    assert result.status == "success"
+    assert result.success is True
 ```
 
 ### Integration Tests
@@ -312,8 +352,8 @@ def test_rpm_sync_plugin():
 ```python
 def test_rpm_sync_and_publish():
     # Sync
-    sync_plugin = RpmSyncPlugin(storage)
-    sync_plugin.sync(session, repo, config)
+    sync_plugin = RpmSyncPlugin(storage=storage, config=config)
+    sync_plugin.sync_repository(session, repo)
 
     # Publish
     pub_plugin = RpmPublisher(storage)

--- a/docs/configuration/filters.md
+++ b/docs/configuration/filters.md
@@ -92,13 +92,13 @@ filters:
       include: ["x86_64", "noarch"]
       # exclude: ["i686"]  # Alternative: exclude specific arches
 
-    size:
-      min_bytes: 1024         # Minimum 1 KB
-      max_bytes: 1073741824   # Maximum 1 GB
+    size_bytes:
+      min: 1024         # Minimum 1 KB
+      max: 1073741824   # Maximum 1 GB
 
     build_time:
-      after: "2024-01-01T00:00:00Z"
-      before: "2025-01-01T00:00:00Z"
+      newer_than: "2024-01-01"
+      older_than: "2025-01-01"
 ```
 
 ### Architecture Filtering
@@ -127,9 +127,9 @@ Filter by package size:
 ```yaml
 filters:
   metadata:
-    size:
-      min_bytes: 1024         # At least 1 KB
-      max_bytes: 104857600    # At most 100 MB
+    size_bytes:
+      min: 1024         # At least 1 KB
+      max: 104857600    # At most 100 MB
 ```
 
 **Use cases:**
@@ -145,9 +145,13 @@ Filter by package build time:
 filters:
   metadata:
     build_time:
-      after: "2024-01-01T00:00:00Z"    # Only packages built after this
-      before: "2025-01-01T00:00:00Z"   # Only packages built before this
+      newer_than: "2024-01-01"   # Only packages built after this date
+      older_than: "2025-01-01"   # Only packages built before this date
+      # last_n_days: 30          # Alternative: only packages from the last N days
 ```
+
+ISO date strings (`YYYY-MM-DD`) are used for `newer_than`/`older_than`;
+`last_n_days` counts back from the current time.
 
 **Use cases:**
 - Only sync recent packages
@@ -170,6 +174,14 @@ filters:
     licenses:
       include: ["GPL", "MIT", "Apache"]
       # exclude: ["Proprietary"]
+
+    vendors:
+      include: ["nginx, Inc."]
+      # exclude: ["Third Party"]
+
+    epochs:
+      include: ["0", "1"]
+      # exclude: ["10"]
 ```
 
 ### Exclude Source RPMs
@@ -223,6 +235,53 @@ filters:
 - Exclude proprietary software
 - Compliance requirements
 
+### Vendor Filtering
+
+Filter by the package vendor (the `Vendor` RPM header):
+
+```yaml
+filters:
+  rpm:
+    vendors:
+      include: ["nginx, Inc."]
+      # exclude: ["Third Party"]
+```
+
+### Epoch Filtering
+
+Filter by RPM epoch (advanced versioning):
+
+```yaml
+filters:
+  rpm:
+    epochs:
+      include: ["0", "1"]
+      # exclude: ["10"]
+```
+
+## APT/DEB-Specific Filters
+
+Filters specific to APT/DEB repositories (use the `deb` block):
+
+```yaml
+filters:
+  deb:
+    components:
+      include: ["main", "contrib"]
+      exclude: ["non-free"]
+
+    priorities:
+      include: ["required", "important", "standard"]
+      # exclude: ["optional", "extra"]
+
+    sections:
+      include: ["admin", "devel", "libs"]
+      # exclude: ["games"]
+```
+
+**Note:** `rpm` filters can only be used with RPM repositories and `deb`
+filters only with APT/DEB repositories; mixing them raises a validation error.
+
 ## Post-Processing
 
 Applied **after** all other filters:
@@ -231,7 +290,7 @@ Applied **after** all other filters:
 filters:
   post_processing:
     only_latest_version: true
-    # only_latest_n_versions: 3  # Future feature
+    # only_latest_n_versions: 3  # Alternative: keep the last N versions
 ```
 
 ### Only Latest Version
@@ -262,7 +321,7 @@ After:
 
 ### Only Latest N Versions
 
-Keep the last N versions (future feature):
+Keep the last N versions per (name, architecture):
 
 ```yaml
 filters:
@@ -335,7 +394,7 @@ repositories:
     filters:
       metadata:
         build_time:
-          after: "2025-01-01T00:00:00Z"  # Only recent packages
+          newer_than: "2025-01-01"  # Only recent packages
         architectures:
           include: ["x86_64", "noarch"]
       rpm:

--- a/docs/configuration/repositories.md
+++ b/docs/configuration/repositories.md
@@ -17,12 +17,12 @@ repositories:
 
 **Required Fields:**
 - `id`: Unique identifier (alphanumeric, hyphens, underscores)
-- `name`: Human-readable name
 - `type`: Repository type (`rpm`, `apt`, `helm`, `apk`)
-- `feed`: Upstream repository URL
-- `enabled`: Whether to include in `--all` operations
 
 **Optional Fields:**
+- `name`: Human-readable name (falls back to `id` if unset)
+- `feed`: Upstream repository URL. Defaults to `""` and is **required for `mode: mirror` and `mode: filtered`**, but optional (and unused) for `mode: hosted`.
+- `enabled`: Whether to include in `--all` operations (defaults to `true`)
 - `mode`: Repository operation mode (`mirror`, `filtered`, `hosted`) - RPM and APT, defaults to `filtered`
 
 ## Repository Types
@@ -60,11 +60,11 @@ repositories:
 - Supports HTTP and HTTPS
 - Supports file:// URLs for local mirrors
 
-**Repository Modes (RPM only):**
+**Repository Modes (RPM and APT):**
 
 - **`filtered`** (default): Filters packages based on patterns/rules, regenerates metadata to match. Updateinfo filtered to include only relevant errata.
-- **`mirror`**: Full mirror of upstream repository. All metadata types downloaded and published unchanged. No filtering applied.
-- **`hosted`**: Upload-only repository with no upstream feed. Packages are added with `chantal package upload` and published like any other repo. `sync` is a no-op for hosted repos.
+- **`mirror`**: Full mirror of upstream repository. All metadata types downloaded and published unchanged. No filtering applied (using `filters` with `mode: mirror` is a validation error).
+- **`hosted`**: Upload-only repository with no upstream feed. Packages are added with `chantal package upload` and published like any other repo. `sync` is a no-op for hosted repos, and `feed` is not required.
 
 See [RPM Plugin Documentation - Repository Modes](../plugins/rpm-plugin.md) for detailed mode explanations.
 
@@ -165,7 +165,7 @@ repositories:
     feed: https://...
     retention:
       policy: mirror  # mirror, newest-only, keep-all, keep-last-n
-      # keep_last_n: 3  # Only when policy is keep-last-n
+      # keep_count: 3  # Only when policy is keep-last-n
 ```
 
 **Retention Policies:**
@@ -212,7 +212,8 @@ repositories:
 
 ### Metadata Cache Override
 
-Override global cache settings (RPM repositories only):
+Override the global cache setting per repository (`cache_enabled` is a generic
+repository field; leaving it unset uses the global `cache.enabled` default):
 
 ```yaml
 # Global config - cache disabled by default
@@ -281,19 +282,89 @@ repositories:
       verify: true
 ```
 
-### HTTP Headers
+### Custom HTTP Headers
 
-Add custom HTTP headers:
+Custom request headers are configured through the authentication block using
+`auth.type: custom` and an `auth.headers` mapping (there is no top-level
+`http_headers` field):
 
 ```yaml
 repositories:
   - id: custom-repo
     type: rpm
     feed: https://custom.example.com/repo
-    http_headers:
-      User-Agent: "Chantal/1.0"
-      X-Custom-Header: "value"
+    auth:
+      type: custom
+      headers:
+        User-Agent: "Chantal/1.0"
+        X-Custom-Header: "value"
 ```
+
+See [SSL & Authentication](ssl-authentication.md) for the full list of
+authentication types.
+
+### GPG Signing (`gpg`)
+
+When a repository regenerates metadata (APT `filtered` mode), the published
+`Release` file can be re-signed so clients can verify it without
+`[trusted=yes]`. The signing key can come from an imported private key file, an
+existing key in the keyring, or a freshly generated keypair. A per-repository
+`gpg` block overrides the global `gpg` fallback.
+
+```yaml
+repositories:
+  - id: my-apt-repo
+    type: apt
+    feed: https://example.com/debian
+    mode: filtered
+    gpg:
+      enabled: true            # default true; set false to disable signing
+      generate_key: true       # generate a keypair if no key is provided
+      # key_id: ABCD1234       # or use an existing key in the keyring
+      # key_file: /etc/chantal/keys/signing-private.asc  # or import a private key
+      key_name: "Chantal Repo"   # real name for a generated key
+      key_email: "repo@example.com"  # email for a generated key
+      public_key_name: key.gpg   # published public-key filename (default: key.gpg)
+      # passphrase_file: /etc/chantal/keys/passphrase.txt  # preferred over inline
+      # passphrase: "secret"     # inline passphrase (use passphrase_file instead)
+```
+
+At least one of `key_file`, `key_id`, or `generate_key: true` must be set when
+`enabled` is true. Other available keys: `public_key_file` (use an existing
+public key instead of exporting one) and `gnupg_home` (keyring directory; a
+temporary one is used if unset).
+
+### Upstream Signature Verification (`verify`)
+
+Integrity (SHA256) is always checked during sync. `verify` adds *authenticity*
+checking - confirming the upstream metadata/packages were signed by a trusted
+key (analogous to dnf's `repo_gpgcheck`/`gpgcheck` and apt's Release signature
+check). A per-repository `verify` block overrides the global `verify` fallback.
+
+```yaml
+repositories:
+  - id: rhel9-baseos
+    type: rpm
+    feed: https://cdn.redhat.com/...
+    verify:
+      enabled: true            # default false
+      repo_gpgcheck: true      # verify repository metadata signature (default true)
+      gpgcheck: true           # verify individual package signatures (default true)
+      key_files:               # trust anchors: public key file paths
+        - /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      # keys:                  # alternative: inline ASCII-armored public keys
+      #   - |
+      #     -----BEGIN PGP PUBLIC KEY BLOCK-----
+      #     ...
+      trusted_fingerprints:    # optional pinning allow-list of full fingerprints
+        - "199E2F91FD431D51"
+      client_key_name: "RPM-GPG-KEY-{repo_id}"  # published trusted key (empty disables)
+      on_missing_signature: fail   # fail | warn | skip
+      on_invalid_signature: fail   # fail | warn | skip
+```
+
+When `enabled` is true at least one of `key_files` or `keys` must be provided.
+`gpgcheck` requires `repo_gpgcheck` (the default has both enabled).
 
 ## Repository Organization
 
@@ -546,7 +617,7 @@ $ chantal repo list
 Error: Configuration validation failed:
   - repositories[0].id: must match pattern ^[a-zA-Z0-9_-]+$
   - repositories[1].feed: invalid URL format
-  - repositories[2].type: must be one of: rpm, helm, apk
+  - repositories[2].type: must be one of: rpm, apt, helm, apk
 ```
 
 ## Best Practices

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@ Chantal Documentation
 
 *Because every other name was already taken.*
 
-.. image:: https://img.shields.io/badge/version-1.0-blue
-   :alt: Version 1.0
+.. image:: https://img.shields.io/badge/version-1.4-blue
+   :alt: Version 1.4
 
 .. image:: https://img.shields.io/badge/python-3.12+-blue
    :alt: Python 3.12+

--- a/docs/plugins/apk-plugin.md
+++ b/docs/plugins/apk-plugin.md
@@ -51,7 +51,7 @@ When signing is enabled, publishing produces:
 repositories:
   - id: alpine-edge-filtered
     type: apk
-    feed: https://dl-cdn.alpinelinux.org/alpine/edge/main
+    feed: https://dl-cdn.alpinelinux.org/alpine/
     mode: filtered
     apk:
       branch: edge
@@ -92,9 +92,10 @@ apk update
 
 ## Repository Modes
 
-The APK plugin supports **mirror mode** for byte-for-byte identical repository copies.
+The default mode is `filtered`. Set `mode: mirror` explicitly for a byte-for-byte
+identical repository copy.
 
-### Mirror Mode (Default)
+### Mirror Mode
 
 **Status:** ✅ Available
 
@@ -133,7 +134,7 @@ repositories:
       branch: v3.19
       repository: main
       architecture: x86_64
-    # Mirror mode is automatic - no additional config needed
+    mode: mirror   # explicit; the default is 'filtered'
 ```
 
 **Use Cases:**
@@ -414,7 +415,7 @@ Published structure:
 
 ```bash
 chantal snapshot create --repo-id alpine-v3.19-main --name 2025-01-11
-chantal publish snapshot --snapshot alpine-v3.19-main-2025-01-11
+chantal publish snapshot --snapshot 2025-01-11 --repo-id alpine-v3.19-main
 ```
 
 Published structure:

--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -124,9 +124,9 @@ repositories:
         - amd64
 
     auth:
-      basic:
-        username: myuser
-        password: mypassword
+      type: basic
+      username: myuser
+      password: mypassword
 ```
 
 ## APT-Specific Options
@@ -279,7 +279,7 @@ deb [arch=amd64] http://mirror.example.com/repos/ubuntu-jammy-main jammy main
 
 ```bash
 # Create snapshot first
-chantal snapshot create ubuntu-jammy-main --name 2026-01-12
+chantal snapshot create --repo-id ubuntu-jammy-main --name 2026-01-12
 
 # Publish the snapshot
 chantal publish snapshot --snapshot 2026-01-12 --repo-id ubuntu-jammy-main
@@ -811,7 +811,7 @@ Sync and publish:
 chantal repo sync --repo-id ubuntu-jammy
 
 # Create monthly snapshot
-chantal snapshot create ubuntu-jammy --name $(date +%Y-%m)
+chantal snapshot create --repo-id ubuntu-jammy --name $(date +%Y-%m)
 
 # Publish latest state
 chantal publish repo --repo-id ubuntu-jammy
@@ -840,8 +840,8 @@ repositories:
       include_source_packages: false
 
     retention:
-      policy: keep_snapshots
-      max_snapshots: 10
+      policy: keep-last-n
+      keep_count: 10
 ```
 
 Automated workflow:
@@ -850,10 +850,10 @@ Automated workflow:
 chantal repo sync --repo-id docker-ce-ubuntu-jammy
 
 # Create snapshot with current date
-chantal snapshot create docker-ce-ubuntu-jammy --name $(date +%Y-%m-%d)
+chantal snapshot create --repo-id docker-ce-ubuntu-jammy --name $(date +%Y-%m-%d)
 
-# Check what changed
-chantal snapshot diff docker-ce-ubuntu-jammy --from-snapshot 2026-01-01 --to-snapshot $(date +%Y-%m-%d)
+# Check what changed (positional SNAPSHOT1 SNAPSHOT2)
+chantal snapshot diff --repo-id docker-ce-ubuntu-jammy 2026-01-01 $(date +%Y-%m-%d)
 
 # Publish latest
 chantal publish repo --repo-id docker-ce-ubuntu-jammy
@@ -977,7 +977,7 @@ Chantal can replace apt-mirror with additional features:
 | Package filtering | ✅ | ✅ |
 | Snapshots | ✅ | ✅ |
 | GPG signing | ✅ | ✅ |
-| Package uploads | ✅ | ⏳ (planned) |
+| Package uploads | ✅ | ✅ |
 | Multi-format | ❌ | ✅ |
 | Views (virtual repos) | ❌ | ✅ |
 

--- a/docs/plugins/custom-plugins.md
+++ b/docs/plugins/custom-plugins.md
@@ -2,6 +2,25 @@
 
 Guide to creating custom plugins for Chantal.
 
+> **⚠️ Conceptual sketch.** This page illustrates the *shape* of a plugin; the
+> code snippets below are pseudo-code and do **not** map 1:1 onto the current API.
+> The accurate anchors are:
+> - **Base class:** only `PublisherPlugin` exists (`chantal.plugins.base`). There
+>   is no `SyncPlugin` base class — syncers are plain classes (e.g.
+>   `RpmSyncPlugin`, `HelmSyncer`).
+> - **Models:** packages/charts are stored as **`ContentItem`** (not `Package`),
+>   and the relationship is **`repository.content_items`** (not
+>   `repository.packages`). See `chantal/db/models.py`.
+> - **Storage:** `StorageManager.add_package(source_path, filename,
+>   verify_checksum=True)` takes a **local file path** (not a URL) and returns
+>   `(sha256, pool_path, size_bytes)`. See `chantal/core/storage.py`.
+> - **Dispatch:** there is no `SYNC_PLUGINS`/`PUBLISHER_PLUGINS` registry. The
+>   repository `type` is dispatched with a hardcoded `if/elif` chain in
+>   `chantal/cli/repo_commands.py` and `chantal/cli/publish_commands.py`.
+>
+> Read `base.py`, `db/models.py`, `storage.py`, and an existing plugin under
+> `chantal/plugins/` before implementing your own.
+
 ## Overview
 
 Custom plugins allow you to extend Chantal to support new repository types. Each repository type requires:
@@ -34,13 +53,13 @@ src/chantal/plugins/
 ```python
 # src/chantal/plugins/my_plugin_sync.py
 
-from chantal.plugins.base import SyncPlugin
 from chantal.core.storage import StorageManager
 from sqlalchemy.orm import Session
-from chantal.db.models import Package, Repository
+from chantal.db.models import ContentItem, Repository
 from chantal.core.config import RepositoryConfig
 
-class MyPluginSync(SyncPlugin):
+# Syncers are plain classes (no SyncPlugin base class)
+class MyPluginSync:
     def __init__(self, storage: StorageManager):
         self.storage = storage
 
@@ -66,30 +85,29 @@ class MyPluginSync(SyncPlugin):
         skipped = 0
 
         for pkg_info in filtered:
-            sha256 = pkg_info['sha256']
             url = pkg_info['url']
             filename = pkg_info['filename']
 
-            # Check if package exists in pool
-            if self.storage.exists(sha256, filename):
-                skipped += 1
-                continue
-
-            # Download to pool
-            pool_path = self.storage.add_package(url, sha256, filename)
+            # Download the file locally first (add_package takes a local path,
+            # computes the SHA256 itself, and deduplicates by content).
+            local_path = self.download_package(url, filename)
+            sha256, pool_path, size_bytes = self.storage.add_package(
+                local_path, filename, verify_checksum=True
+            )
             downloaded += 1
 
-            # Add to database
-            package = Package(
+            # Add to database as a ContentItem
+            item = ContentItem(
                 sha256=sha256,
                 filename=filename,
-                size=pkg_info['size'],
+                size_bytes=size_bytes,
+                pool_path=pool_path,
                 name=pkg_info['name'],
                 version=pkg_info['version'],
-                architecture=pkg_info['arch']
+                content_type='my_type',
             )
-            session.add(package)
-            repository.packages.append(package)
+            session.add(item)
+            repository.content_items.append(item)
 
         session.commit()
 
@@ -147,7 +165,7 @@ from chantal.plugins.base import PublisherPlugin
 from chantal.core.storage import StorageManager
 from pathlib import Path
 from sqlalchemy.orm import Session
-from chantal.db.models import Package, Repository, Snapshot
+from chantal.db.models import ContentItem, Repository, Snapshot
 
 class MyPluginPublisher(PublisherPlugin):
     def __init__(self, storage: StorageManager):
@@ -235,24 +253,24 @@ def generate_metadata(self, packages: list, target_path: Path):
         json.dump(index_data, f, indent=2)
 ```
 
-## Step 4: Register Plugin
+## Step 4: Wire Up Dispatch
 
-Update `src/chantal/plugins/__init__.py`:
+There is no plugin registry to register with. Instead, extend the hardcoded
+`if/elif` dispatch on `repo_config.type` in the two CLI modules:
+
+- `src/chantal/cli/repo_commands.py` — sync path
+- `src/chantal/cli/publish_commands.py` — publish path
 
 ```python
-from .my_plugin_sync import MyPluginSync
-from .my_plugin import MyPluginPublisher
-
-SYNC_PLUGINS = {
-    'rpm': RpmSyncPlugin,
-    'my_type': MyPluginSync,  # Add your plugin
-}
-
-PUBLISHER_PLUGINS = {
-    'rpm': RpmPublisher,
-    'my_type': MyPluginPublisher,  # Add your plugin
-}
+# src/chantal/cli/repo_commands.py (sync dispatch)
+if repo_config.type == "rpm":
+    ...
+elif repo_config.type == "my_type":          # add your branch
+    syncer = MyPluginSync(storage)
+    syncer.sync(session, repository, repo_config)
 ```
+
+Do the same in `publish_commands.py` for the publish dispatch.
 
 ## Step 5: Add Configuration Support
 
@@ -317,8 +335,8 @@ def test_publish(tmp_path, db_session):
 Complete example for a simple HTTP directory listing repository:
 
 ```python
-# sync plugin
-class HttpArchiveSync(SyncPlugin):
+# sync plugin (plain class)
+class HttpArchiveSync:
     def fetch_metadata(self, feed_url):
         # Parse HTML directory listing
         response = self.http_client.get(feed_url)

--- a/docs/plugins/helm-plugin.md
+++ b/docs/plugins/helm-plugin.md
@@ -22,14 +22,24 @@ The Helm plugin consists of:
 - ✅ Snapshot support
 - ✅ **Mirror Mode** - Byte-for-byte identical repositories with snapshot versioning
 - ✅ **Hosted Mode** - Upload-only repositories for self-hosted charts (`chantal package upload`)
-- ✅ OCI registry support (`oci://` chart repositories)
-- ℹ️ Charts are served unmodified; Chantal does not sign or re-sign charts (upstream Helm provenance `.prov` files are preserved if present)
+- ℹ️ OCI ingest only — `oci://` chart URLs *referenced inside an upstream HTTP `index.yaml`* are pulled via the `helm` binary (which must be installed). You cannot configure an `oci://` feed, and Chantal never publishes charts over OCI (published repos are always plain HTTP with an `index.yaml`).
+- ℹ️ Charts are served unmodified; Chantal does not sign or re-sign charts
+- ⛔ Not supported: Helm provenance — upstream `.prov` files are **not** downloaded or republished, and `helm pull --verify` against a mirror will fail
 
 ## Repository Modes
 
-The Helm plugin supports **mirror mode** for byte-for-byte identical repository copies.
+The default mode is `filtered`. Set `mode: mirror` explicitly for a byte-for-byte
+identical repository copy.
 
-### Mirror Mode (Default)
+> **Note on the Helm index:** regardless of mode, the sync step always stores the
+> upstream `index.yaml` in the content-addressed pool as a `RepositoryFile`. At
+> publish time the publisher hardlinks that stored `index.yaml` if one is present,
+> and only falls back to generating an index from the database when none is found.
+> The choice is therefore driven by whether a stored `index.yaml` exists, not by
+> the configured mode — so a `filtered` Helm repo may still republish the upstream
+> index it captured during sync.
+
+### Mirror Mode
 
 **Status:** ✅ Available
 
@@ -64,7 +74,7 @@ repositories:
     type: helm
     feed: https://kubernetes.github.io/ingress-nginx
     enabled: true
-    # Mirror mode is automatic - no additional config needed
+    mode: mirror   # explicit; the default is 'filtered'
 ```
 
 **Use Cases:**
@@ -73,16 +83,22 @@ repositories:
 - Snapshot versioning for reproducible deployments
 - Bandwidth optimization (metadata reused across snapshots)
 
-### Dynamic Generation Mode (Fallback)
+### Dynamic Index Generation (Fallback)
 
-If no `RepositoryFile` is found (e.g., for older repositories or filtered repositories), Chantal falls back to dynamic index.yaml generation from database metadata.
+If no stored `index.yaml` `RepositoryFile` is found (e.g., hosted repositories, or
+older repositories synced before index capture), Chantal falls back to generating
+`index.yaml` from the chart metadata in the database.
 
-This mode:
+This path:
 - Generates index.yaml from HelmMetadata in database
-- Allows filtered repositories (subset of charts)
+- Produces an index covering exactly the charts in the repository (e.g. a filtered subset)
 - Supports post-processing (e.g., only latest versions)
 
-**Note:** For filtered repositories (pattern-based chart selection), dynamic generation is used automatically.
+**Note:** Generation is *not* keyed off the mode. A `filtered` repo whose sync
+captured the upstream `index.yaml` will republish that captured index; the
+generated index is used only when no stored `index.yaml` is available. If you need
+a regenerated index that matches a filtered chart set exactly, use a hosted repo
+(no upstream index to capture).
 
 ### Hosted Mode
 
@@ -334,7 +350,7 @@ Published structure:
 
 ```bash
 chantal snapshot create --repo-id ingress-nginx --name 2025-01-10
-chantal publish snapshot --snapshot ingress-nginx-2025-01-10
+chantal publish snapshot --snapshot 2025-01-10 --repo-id ingress-nginx
 ```
 
 Published structure:
@@ -419,7 +435,7 @@ chantal repo sync --repo-id my-helm-repo
 
 Verify charts were synced:
 ```bash
-chantal package list --repo-id my-helm-repo
+chantal content list --repo-id my-helm-repo
 ```
 
 Check published directory permissions:
@@ -491,7 +507,7 @@ pipeline {
         }
         stage('Publish Snapshot') {
             steps {
-                sh 'chantal publish snapshot --snapshot ingress-nginx-${BUILD_ID}'
+                sh 'chantal publish snapshot --snapshot ${BUILD_ID} --repo-id ingress-nginx'
             }
         }
     }

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -75,7 +75,7 @@ For DNF/YUM-based distributions (RHEL, CentOS, Fedora, Rocky, Alma).
 - Repomd.xml/primary.xml.gz parsing
 - RPM-specific filtering
 - RHEL CDN support (client certificates)
-- Modular repository support (future)
+- Modular repository support (modules.yaml)
 
 **See:** [RPM Plugin Documentation](rpm-plugin.md)
 
@@ -95,7 +95,8 @@ For Debian/Ubuntu-based distributions.
 
 ### Helm Plugin
 
-For Kubernetes Helm chart repositories (HTTP and OCI registries).
+For Kubernetes Helm chart repositories (HTTP `index.yaml` feeds; `oci://` charts
+referenced by an upstream index can be ingested via the `helm` binary).
 
 **See:** [Helm Plugin Documentation](helm-plugin.md)
 
@@ -112,13 +113,17 @@ See [Custom Plugins](custom-plugins.md) for detailed guide on creating your own 
 **Quick example:**
 
 ```python
-from chantal.plugins.base import SyncPlugin
+from chantal.plugins.base import PublisherPlugin
 
-class MyPlugin(SyncPlugin):
-    def sync(self, session, repository, config):
-        # Implement sync logic
-        pass
+class MyPublisher(PublisherPlugin):
+    def publish_repository(self, session, repository, config, target_path):
+        # Implement publish logic
+        ...
 ```
+
+`PublisherPlugin` (in `chantal.plugins.base`) is the only abstract base class.
+Syncers are plain classes (e.g. `RpmSyncPlugin`, `HelmSyncer`); there is no
+`SyncPlugin` base class.
 
 ## Plugin Configuration
 
@@ -132,21 +137,26 @@ repositories:
     # Plugin-specific options...
 ```
 
-## Plugin Registry
+## Plugin Dispatch
 
-Plugins are registered in `src/chantal/plugins/__init__.py`:
+There is no plugin registry. The repository `type` is dispatched with a hardcoded
+`if/elif` chain in the CLI command modules — `src/chantal/cli/repo_commands.py`
+(sync) and `src/chantal/cli/publish_commands.py` (publish):
 
 ```python
-SYNC_PLUGINS = {
-    'rpm': RpmSyncPlugin,
-    # Add new plugins here
-}
-
-PUBLISHER_PLUGINS = {
-    'rpm': RpmPublisher,
-    # Add new plugins here
-}
+# src/chantal/cli/publish_commands.py
+if repo_config.type == "rpm":
+    ...
+elif repo_config.type == "helm":
+    ...
+elif repo_config.type == "apk":
+    ...
+elif repo_config.type == "apt":
+    ...
 ```
+
+Adding a new type means extending those branches (and `RepositoryConfig.type` in
+`src/chantal/core/config.py`).
 
 ## Plugin Best Practices
 

--- a/docs/plugins/rpm-plugin.md
+++ b/docs/plugins/rpm-plugin.md
@@ -127,9 +127,11 @@ repositories:
 
 ## Repository Modes
 
-Chantal supports three repository operation modes for RPM repositories:
+Chantal supports three repository operation modes for RPM repositories. The
+default mode is `filtered`; set `mode: mirror` explicitly for a full unmodified
+mirror.
 
-### Mirror Mode (Default)
+### Mirror Mode
 
 **Full metadata mirroring** - Downloads and publishes ALL metadata types from upstream repository unchanged.
 
@@ -140,7 +142,7 @@ repositories:
     type: rpm
     feed: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os
     enabled: true
-    mode: mirror  # Default
+    mode: mirror  # must be set explicitly; default is 'filtered'
 ```
 
 **Behavior:**
@@ -869,9 +871,7 @@ Warning: Filtered out all packages, 0 remaining
 
 ## Future Enhancements
 
-- **Modular repositories** - Support for modules.yaml
-- **Delta RPMs** - Download only package deltas
-- **GPG verification** - Verify package signatures
-- **Comps.xml** - Package group metadata
-- **Updateinfo.xml** - Security/bug fix advisories
-- **Filelists.xml** - File listings for packages
+- **Delta RPMs** - Download only package deltas (drpm)
+
+(Modular repositories, GPG package-signature verification, comps, updateinfo, and
+filelists are already implemented — see the sections above.)

--- a/docs/user-guide/cli-commands.md
+++ b/docs/user-guide/cli-commands.md
@@ -12,8 +12,13 @@ chantal [OPTIONS] COMMAND [ARGS]...
 Options:
   --config PATH      Path to configuration file
   --version          Show version and exit
+  -v, --verbose      Verbose output
   -h, --help         Show help message and exit
 ```
+
+**Command groups:** `repo`, `snapshot`, `content`, `publish`, `view`,
+`package`, `pool`, `cache`, `db`, `stats`, `schema`. Each group is documented
+in the sections below.
 
 ## Configuration File Priority
 
@@ -176,7 +181,10 @@ chantal repo sync --pattern "epel9-*"
 - `--repo-id`: Repository ID
 - `--all`: Sync all enabled repositories
 - `--pattern`: Repository ID pattern (glob)
-- `--type`: Filter by repository type
+- `--type`: Filter by repository type (rpm, apt) when using `--all` or `--pattern`
+- `--workers`: Number of parallel workers (with `--all` or `--pattern`)
+- `-v`, `--verbose`: Show detailed package-by-package progress
+- `-q`, `--quiet`: Show only errors, no progress output
 
 **Examples:**
 ```bash
@@ -191,6 +199,9 @@ chantal repo sync --all
 
 # Sync only RPM repositories
 chantal repo sync --all --type rpm
+
+# Sync all with 4 parallel workers, quiet output
+chantal repo sync --all --workers 4 --quiet
 ```
 
 ### `chantal repo check-updates`
@@ -227,12 +238,22 @@ Feed URL: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os
 Show sync history for a repository.
 
 ```bash
+# History for one repository
 chantal repo history --repo-id REPO_ID [--limit 10]
+
+# History across all repositories
+chantal repo history --all
+
+# Only the last sync of each repository
+chantal repo history --all --last
 ```
 
 **Options:**
-- `--repo-id`: Repository ID (required)
+- `--repo-id`: Repository ID
+- `--all`: Show sync history for all repositories
+- `--last`: Show only the last sync (use with `--all`)
 - `--limit`: Maximum number of entries to show
+- `--format`: Output format (table, json)
 
 ## Snapshot Management
 
@@ -365,6 +386,36 @@ chantal snapshot delete \
 **Options:**
 - `--repo-id`: Repository ID (required)
 - `SNAPSHOT_NAME`: Snapshot name to delete (required)
+- `--force`: Force deletion even if the snapshot is currently published
+
+### `chantal snapshot copy`
+
+Copy a snapshot to a new name to enable promotion workflows (e.g. staging →
+production). Only database entries are created - no files are copied, since both
+snapshots reference the same content-addressed packages in the pool.
+
+```bash
+chantal snapshot copy \
+  --source SOURCE_NAME \
+  --target TARGET_NAME \
+  --repo-id REPO_ID \
+  [--description "..."]
+```
+
+**Options:**
+- `--source`: Source snapshot name (required)
+- `--target`: Target snapshot name (required)
+- `--repo-id`: Repository ID (required)
+- `--description`: Description for the new snapshot
+
+**Example:**
+```bash
+# Promote a tested snapshot to "stable"
+chantal snapshot copy \
+  --source 2025-01-10 \
+  --target stable \
+  --repo-id rhel9-baseos
+```
 
 ## Content Management
 
@@ -387,7 +438,7 @@ chantal content list --view VIEW_NAME
 # Filter by content type
 chantal content list --repo-id REPO_ID --type rpm
 chantal content list --repo-id REPO_ID --type helm
-chantal content list --repo-id REPO_ID --type apk
+chantal content list --repo-id REPO_ID --type apt
 
 # Limit results
 chantal content list --repo-id REPO_ID --limit 50
@@ -401,8 +452,8 @@ chantal content list --repo-id REPO_ID --format csv
 - `--repo-id`: Filter by repository ID
 - `--snapshot-id`: Filter by snapshot ID
 - `--view`: Filter by view name
-- `--type`: Filter by content type (rpm, helm, apk)
-- `--limit`: Maximum number of items to show (default: 100)
+- `--type`: Filter by content type (rpm, helm, apt)
+- `--limit`: Maximum number of items to show
 - `--format`: Output format (table, json, csv)
 
 **Note:** Only one of `--repo-id`, `--snapshot-id`, or `--view` can be specified.
@@ -427,7 +478,7 @@ chantal content search nginx --view rhel9-webserver
 # Filter by content type
 chantal content search python --type rpm
 chantal content search ingress --type helm
-chantal content search alpine --type apk
+chantal content search nginx --type apt
 
 # Output as JSON
 chantal content search nginx --format json
@@ -438,7 +489,7 @@ chantal content search nginx --format json
 - `--repo-id`: Search in specific repository
 - `--snapshot-id`: Search in specific snapshot
 - `--view`: Search in specific view
-- `--type`: Filter by content type (rpm, helm, apk)
+- `--type`: Filter by content type (rpm, helm, apt)
 - `--format`: Output format (table, json)
 
 **Note:** Only one of `--repo-id`, `--snapshot-id`, or `--view` can be specified.
@@ -499,11 +550,82 @@ Snapshots (1):
 ======================================================================
 ```
 
+## View Management
+
+Views group multiple repositories into a single virtual repository. All
+repositories in a view must have the same type (rpm or apt). See
+[Views (Virtual Repositories)](views.md) for the full guide.
+
+### `chantal view list`
+
+List all configured views.
+
+```bash
+chantal view list [--format table|json]
+```
+
+**Options:**
+- `--format`: Output format (table, json)
+
+### `chantal view show`
+
+Show detailed information about a view, including its repositories and package
+counts.
+
+```bash
+chantal view show --name VIEW_NAME [--format table|json]
+```
+
+**Options:**
+- `--name`: View name (required)
+- `--format`: Output format (table, json)
+
+> **Note:** Views are *published* with `chantal publish view` and *snapshotted*
+> with `chantal snapshot create --view` (see those commands).
+
+## Package Management
+
+The `package` commands inject custom (locally provided) packages into a
+repository's content-addressed pool. This powers *hosted* repositories built
+from your own packages, independent of an upstream feed.
+
+### `chantal package upload`
+
+Upload one or more local package files into a repository's pool.
+
+```bash
+# Upload a single package
+chantal package upload --file ./mypackage-1.0.0.x86_64.rpm --repo-id myrepo
+
+# Upload all packages in a directory
+chantal package upload --directory ./packages/ --repo-id myrepo
+
+# Recurse into subdirectories
+chantal package upload --directory ./packages/ --recursive --repo-id myrepo
+
+# Replace a conflicting same-version package
+chantal package upload --file ./mypackage-1.0.0.x86_64.rpm --repo-id myrepo --force
+
+# Upload .deb packages into a specific APT component
+chantal package upload --file ./mypackage_1.0.0_amd64.deb --repo-id myrepo --component contrib
+```
+
+**Options:**
+- `--file`: A single package file to upload
+- `--directory`: A directory of packages to upload
+- `--recursive`: Recurse into `--directory`
+- `--repo-id`: Target repository ID (required)
+- `--force`: Replace a conflicting same-version package
+- `--component`: APT component for uploaded `.deb` packages (default: `main`; ignored for rpm/helm)
+
+**Supported types:** RPM, DEB/APT, and Helm. (Alpine APK upload is not supported.)
+
 ## Publishing
 
 ### `chantal publish repo`
 
-Publish a repository.
+Publish a repository to its target directory. Creates hardlinks from the package
+pool and (re)generates repository metadata.
 
 ```bash
 # Publish single repository
@@ -511,26 +633,53 @@ chantal publish repo --repo-id REPO_ID
 
 # Publish all repositories
 chantal publish repo --all
+
+# Publish to a custom target directory
+chantal publish repo --repo-id REPO_ID --target /var/www/custom
 ```
 
 **Options:**
 - `--repo-id`: Repository ID
 - `--all`: Publish all repositories
+- `--target`: Custom target directory (default: from config)
 
 ### `chantal publish snapshot`
 
-Publish a snapshot.
+Publish a specific snapshot. Works for both repository snapshots (`--repo-id`)
+and view snapshots (`--view`).
 
 ```bash
-chantal publish snapshot --snapshot REPO_ID-NAME
+# Repository snapshot
+chantal publish snapshot --snapshot NAME --repo-id REPO_ID
+
+# View snapshot
+chantal publish snapshot --snapshot NAME --view VIEW_NAME
 ```
 
 **Options:**
-- `--snapshot`: Snapshot identifier (format: `repo-id-name`)
+- `--snapshot`: Snapshot name (required)
+- `--repo-id`: Repository ID (for repository snapshots)
+- `--view`: View name (for view snapshots)
+- `--target`: Custom target directory
+
+### `chantal publish view`
+
+Publish a view (combines all repositories in the view into one virtual
+repository). Views are published directly from the configuration file - no
+database sync needed.
+
+```bash
+chantal publish view --name VIEW_NAME
+```
+
+**Options:**
+- `--name`: View name to publish (required)
+
+See [Views (Virtual Repositories)](views.md) for details.
 
 ### `chantal publish list`
 
-List published repositories and snapshots.
+List currently published repositories and snapshots.
 
 ```bash
 chantal publish list
@@ -538,15 +687,21 @@ chantal publish list
 
 ### `chantal publish unpublish`
 
-Unpublish a repository or snapshot.
+Unpublish a snapshot. Removes the published directory (hardlinks) but keeps the
+packages in the pool and the snapshot in the database, so it can be re-published
+later.
 
 ```bash
-# Unpublish repository
-chantal publish unpublish --repo-id REPO_ID
+# Unpublish by snapshot name
+chantal publish unpublish --snapshot SNAPSHOT_NAME
 
-# Unpublish snapshot
-chantal publish unpublish --snapshot REPO_ID-NAME
+# Disambiguate when the same snapshot name exists in multiple repositories
+chantal publish unpublish --snapshot SNAPSHOT_NAME --repo-id REPO_ID
 ```
+
+**Options:**
+- `--snapshot`: Snapshot name to unpublish (required)
+- `--repo-id`: Repository ID (optional; only needed if the snapshot name is not unique)
 
 ## Storage Pool Management
 
@@ -570,54 +725,50 @@ Shows files that exist in pool but are not referenced in the database.
 
 ### `chantal pool cleanup`
 
-Remove orphaned files from pool.
+Clean up pool integrity issues. By default cleans both orphaned files (in pool
+but not in database) and missing entries (in database but without a pool file).
+Requires confirmation unless `--force` or `--dry-run` is used.
 
 ```bash
-# Dry-run (show what would be removed)
+# Dry-run (show what would be deleted)
 chantal pool cleanup --dry-run
 
-# Actually remove orphaned files
+# Clean both orphaned files and missing entries (prompts for confirmation)
 chantal pool cleanup
 
-# Clean only content files (packages)
-chantal pool cleanup --content-only
+# Clean only orphaned files (in pool but not in database)
+chantal pool cleanup --orphaned
 
-# Clean only metadata files
-chantal pool cleanup --metadata-only
+# Clean only missing entries (in database but not in pool)
+chantal pool cleanup --missing
 
-# Delete specific pool entries by SHA256
-chantal pool cleanup --sha256 abc123def456...
+# Skip the confirmation prompt
+chantal pool cleanup --force
 ```
 
 **Options:**
-- `--dry-run`: Show what would be removed without actually removing
-- `--content-only`: Only clean orphaned content files (packages)
-- `--metadata-only`: Only clean orphaned metadata files
-- `--sha256`: Delete specific pool entry by SHA256 checksum
+- `--dry-run`: Show what would be deleted without actually deleting
+- `--orphaned`: Only clean orphaned files (in pool but not in database)
+- `--missing`: Only clean missing entries (in database but not in pool)
+- `--force`: Skip confirmation prompt
 
 ### `chantal pool verify`
 
-Verify pool integrity.
+Verify pool integrity. Performs a comprehensive integrity check.
 
 ```bash
-# Verify all pool files
 chantal pool verify
-
-# Verify specific repository
-chantal pool verify --repo-id epel9-latest
-
-# Verify and show detailed output
-chantal pool verify --verbose
 ```
 
 **Checks:**
-- File existence (database entry exists but file missing)
-- Checksum verification (file SHA256 matches database)
-- Database consistency (orphaned entries, duplicate files)
+- Orphaned files (in pool but not in database)
+- Missing files (in database but not in pool)
+- SHA256 checksum verification
+- File size verification
 
-**Options:**
-- `--repo-id`: Verify only files for specific repository
-- `--verbose`: Show detailed verification output
+For detailed file lists, use `chantal pool orphaned` or `chantal pool missing`.
+
+This command takes no options.
 
 ### `chantal pool missing`
 
@@ -663,15 +814,102 @@ chantal db verify
 
 ### `chantal db cleanup`
 
-Clean up unreferenced packages.
+Clean up database issues. By default cleans both orphaned repositories (in the
+database but not in the configuration) and unreferenced packages (without
+repository references). Requires confirmation unless `--force` or `--dry-run`
+is used.
 
 ```bash
 # Dry-run
 chantal db cleanup --dry-run
 
-# Actually cleanup
+# Clean both (prompts for confirmation)
 chantal db cleanup
+
+# Clean only orphaned repositories
+chantal db cleanup --orphaned
+
+# Clean only unreferenced packages
+chantal db cleanup --unreferenced
+
+# Skip the confirmation prompt
+chantal db cleanup --force
 ```
+
+**Options:**
+- `--dry-run`: Show what would be deleted without actually deleting
+- `--orphaned`: Only clean orphaned repositories (in DB but not in config)
+- `--unreferenced`: Only clean unreferenced packages
+- `--force`: Skip confirmation prompt
+
+### `chantal db orphaned`
+
+List orphaned repositories in the database (present in the database but not in
+the configuration file).
+
+```bash
+chantal db orphaned
+```
+
+## Metadata Cache Management
+
+The `cache` commands manage the SHA256-based metadata cache (used to speed up
+RPM syncs).
+
+### `chantal cache stats`
+
+Show cache statistics.
+
+```bash
+chantal cache stats
+```
+
+### `chantal cache list`
+
+List cached metadata files.
+
+```bash
+chantal cache list [--limit N]
+```
+
+**Options:**
+- `--limit`: Limit the number of files shown
+
+### `chantal cache clear`
+
+Clear the metadata cache. By default clears all cached metadata files.
+
+```bash
+# Clear the entire cache (prompts for confirmation)
+chantal cache clear
+
+# Skip the confirmation prompt
+chantal cache clear --force
+```
+
+**Options:**
+- `--all`: Clear the entire cache
+- `--force`: Skip confirmation prompt
+- `--repo-id`: Reserved for per-repository clearing (currently clears all)
+
+## Configuration Schema
+
+### `chantal schema`
+
+Output the JSON Schema for the configuration file. The schema is generated from
+the configuration models and can be used by editors (e.g. the VS Code YAML
+extension) to validate and autocomplete `config.yaml`.
+
+```bash
+# Print schema to stdout
+chantal schema
+
+# Write schema to a file
+chantal schema --output chantal-config.schema.json
+```
+
+**Options:**
+- `-o`, `--output`: Write the schema to this file instead of stdout
 
 ## Output Formats
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -7,35 +7,54 @@
 
 ## Installation Steps
 
-### 1. Clone the Repository
+### Install from PyPI (Recommended)
+
+Chantal is published on [PyPI](https://pypi.org/project/chantal/):
 
 ```bash
-git clone https://github.com/slauger/chantal.git
-cd chantal
+pip install chantal
 ```
 
-### 2. Install in Development Mode
-
-```bash
-pip install -e .
-```
-
-### 3. Verify Installation
+Verify the installation:
 
 ```bash
 chantal --version
 ```
 
+### Install from Source
+
+To work on Chantal or run an unreleased version, install from a checkout in
+editable mode:
+
+```bash
+git clone https://github.com/slauger/chantal.git
+cd chantal
+pip install -e .
+```
+
+For development (linters, tests), install the optional `dev` extras:
+
+```bash
+pip install -e ".[dev]"
+```
+
 ## Dependencies
 
-Chantal will automatically install the following dependencies:
+Chantal automatically installs the following dependencies:
 
-- **SQLAlchemy** - Database ORM
-- **Click** - CLI framework
-- **Requests** - HTTP client
-- **PyYAML** - Configuration file parsing
-- **lxml** - XML parsing for repository metadata
-- **Pydantic** - Configuration validation
+- **click** - CLI framework
+- **pydantic** - Configuration validation
+- **pyyaml** - Configuration file parsing
+- **packaging** - Version parsing/comparison
+- **sqlalchemy** - Database ORM
+- **psycopg2-binary** - PostgreSQL driver
+- **alembic** - Database schema migrations
+- **requests** / **urllib3** - HTTP client and downloads
+- **zstandard** - Zstandard metadata compression
+- **python-gnupg** - GPG signing (APT/RPM filtered mode)
+- **cryptography** - RSA signing of APK indexes (APKINDEX.tar.gz)
+- **tqdm** - Progress bars
+- **rich** - Terminal output formatting
 
 ## Database Setup
 

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -117,6 +117,11 @@ tar czf chantal-export-2025-01.tar.gz \
   /etc/chantal/conf.d/
 ```
 
+> **Note:** The `/var/lib/chantal/chantal.db` path assumes a SQLite database with
+> the default storage layout. If you use PostgreSQL, back up the database with
+> `pg_dump` instead of copying a file; if your SQLite file lives elsewhere,
+> adjust the path to match the `database.url` in your config.
+
 ### Phase 2: Offline System (Air-Gapped)
 
 ```bash
@@ -316,6 +321,11 @@ tar czf chantal-backup-$(date +%Y%m%d).tar.gz \
 # Store backup offsite
 rsync -avz chantal-backup-*.tar.gz backup-server:/backups/
 ```
+
+> **Note:** The `/var/lib/chantal/chantal.db` path is specific to a SQLite
+> database with the default storage layout. For PostgreSQL, dump the database
+> separately with `pg_dump`; for a non-default SQLite location, use the path
+> from your config's `database.url`.
 
 ### Restore
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,23 +4,40 @@ This directory contains production-ready example configurations for popular Linu
 
 ## Directory Structure
 
+The examples are organized in a flat directory per package type:
+
 ```
 examples/
 ├── README.md                          # This file
+├── config/                            # Full config.yaml + conf.d/ include example
+│   ├── config.yaml
+│   └── conf.d/rhel9.yaml
+├── auth-examples.yaml                 # Authentication configuration examples
+├── filter-examples.yaml               # Package filter examples
 ├── rpm/                               # RPM-based repository examples
-│   ├── distributions/                 # Official distribution repositories
-│   │   ├── rhel8.yaml                # Red Hat Enterprise Linux 8
-│   │   └── rhel9.yaml                # Red Hat Enterprise Linux 9
-│   └── third-party/                   # Third-party software repositories
-│       ├── docker-ce.yaml            # Docker CE (Community Edition)
-│       ├── epel.yaml                 # Extra Packages for Enterprise Linux
-│       ├── gitlab.yaml               # GitLab CE/EE
-│       ├── gitlab-runner.yaml        # GitLab CI/CD Runner
-│       ├── grafana.yaml              # Grafana Observability Platform
-│       ├── hashicorp.yaml            # HashiCorp Tools (Terraform, Vault, Consul)
-│       ├── icinga.yaml               # Icinga Monitoring Platform
-│       ├── postgresql.yaml           # PostgreSQL Database
-│       └── zabbix.yaml               # Zabbix Monitoring Platform
+│   ├── rhel8.yaml                    # Red Hat Enterprise Linux 8
+│   ├── rhel9.yaml                    # Red Hat Enterprise Linux 9
+│   ├── docker-ce.yaml               # Docker CE (Community Edition)
+│   ├── epel.yaml                    # Extra Packages for Enterprise Linux
+│   ├── gitlab.yaml                  # GitLab CE/EE
+│   ├── gitlab-runner.yaml           # GitLab CI/CD Runner
+│   ├── grafana.yaml                 # Grafana Observability Platform
+│   ├── hashicorp.yaml               # HashiCorp Tools (Terraform, Vault, Consul)
+│   ├── icinga.yaml                  # Icinga Monitoring Platform
+│   ├── lynis.yaml                   # Lynis security auditing
+│   ├── postgresql.yaml              # PostgreSQL Database
+│   ├── zabbix.yaml                  # Zabbix Monitoring Platform
+│   ├── filtered-signed.yaml         # Filtered mode with GPG re-signing
+│   └── verified.yaml                # Upstream signature verification
+├── apt/                               # APT/Debian repository examples
+│   ├── docker-ce.yaml               # Docker CE for Ubuntu/Debian
+│   ├── gitlab.yaml                  # GitLab CE + Runner
+│   ├── grafana.yaml                 # Grafana
+│   ├── hashicorp.yaml               # HashiCorp Tools
+│   ├── icinga.yaml                  # Icinga
+│   ├── lynis.yaml                   # Lynis security auditing
+│   ├── filtered-signed.yaml         # Filtered mode with GPG re-signing
+│   └── verified.yaml                # Upstream Release signature verification
 ├── helm/                              # Helm chart repository examples
 │   ├── kubernetes-charts.yaml        # Official Kubernetes charts
 │   ├── bitnami.yaml                  # Bitnami application charts
@@ -28,14 +45,13 @@ examples/
 │   ├── ci-cd.yaml                    # GitLab, ArgoCD, Jenkins, Harbor
 │   └── aws.yaml                      # AWS EKS charts (Load Balancer, CSI drivers, Karpenter)
 └── apk/                               # Alpine APK repository examples
-    ├── distributions/                 # Alpine Linux releases
-    │   ├── alpine-3.19.yaml          # Alpine 3.19 LTS (current)
-    │   ├── alpine-3.18.yaml          # Alpine 3.18 LTS
-    │   └── alpine-edge.yaml          # Alpine Edge (rolling)
-    └── use-cases/                     # Common use cases
-        ├── container-base.yaml       # Minimal/extended container images
-        ├── development.yaml          # Build tools, Python, Node.js, Go
-        └── webserver.yaml            # NGINX, Apache, PHP-FPM
+    ├── alpine-3.19.yaml              # Alpine 3.19 LTS (current)
+    ├── alpine-3.18.yaml              # Alpine 3.18 LTS
+    ├── alpine-edge.yaml              # Alpine Edge (rolling)
+    ├── container-base.yaml           # Minimal/extended container images
+    ├── development.yaml              # Build tools, Python, Node.js, Go
+    ├── webserver.yaml                # NGINX, Apache, PHP-FPM
+    └── filtered-signed.yaml          # Filtered mode with signing
 ```
 
 ## How to Use These Examples
@@ -49,13 +65,16 @@ Copy the example file(s) you need to your Chantal configuration directory:
 mkdir -p ~/.config/chantal/conf.d/
 
 # Copy RHEL 9 example
-cp examples/rpm/distributions/rhel9.yaml ~/.config/chantal/conf.d/
+cp examples/rpm/rhel9.yaml ~/.config/chantal/conf.d/
 
-# Copy Docker CE example
-cp examples/rpm/third-party/docker-ce.yaml ~/.config/chantal/conf.d/
+# Copy Docker CE example (RPM)
+cp examples/rpm/docker-ce.yaml ~/.config/chantal/conf.d/
 
 # Copy EPEL example
-cp examples/rpm/third-party/epel.yaml ~/.config/chantal/conf.d/
+cp examples/rpm/epel.yaml ~/.config/chantal/conf.d/
+
+# Copy an APT example (Docker CE for Ubuntu/Debian)
+cp examples/apt/docker-ce.yaml ~/.config/chantal/conf.d/
 ```
 
 ### 2. Customize Configuration
@@ -179,6 +198,20 @@ Enterprise monitoring platform
 - LTS versions (6.0, 7.0) supported for 5 years
 - Agent 2 with plugin support
 - Database backend: MySQL/PostgreSQL/TimescaleDB
+
+### APT/Debian Repositories
+
+APT examples live in `examples/apt/` and target Debian/Ubuntu-based systems.
+Each repository uses an `apt:` block (distribution, components, architectures).
+
+- **docker-ce.yaml**: Docker CE for Ubuntu (jammy, focal) and Debian (bookworm)
+- **gitlab.yaml**: GitLab CE and GitLab Runner for Ubuntu
+- **grafana.yaml**: Grafana observability platform
+- **hashicorp.yaml**: HashiCorp tools (Terraform, Vault, Consul)
+- **icinga.yaml**: Icinga monitoring for Ubuntu and Debian
+- **lynis.yaml**: Lynis security auditing
+- **filtered-signed.yaml**: `filtered` mode with regenerated, GPG re-signed `Release`
+- **verified.yaml**: Upstream `Release` signature verification (`verify` block)
 
 ### Helm Chart Repositories
 
@@ -338,11 +371,11 @@ Create views to combine multiple repositories into one published repository:
 # Example: Complete RHEL 9 system
 views:
   - name: rhel9-complete
-    repositories:
-      - repo_id: rhel9-baseos
-      - repo_id: rhel9-appstream
-      - repo_id: rhel9-crb
-      - repo_id: epel9
+    repos:
+      - rhel9-baseos
+      - rhel9-appstream
+      - rhel9-crb
+      - epel9
 ```
 
 ### 4. Test in Staging Before Production
@@ -488,11 +521,13 @@ Planned additions (see Issue #3):
 - Database clients and tools
 - Security tools (fail2ban, iptables)
 
-**APT/Debian** (future):
-- Ubuntu LTS releases (22.04, 24.04)
-- Debian stable releases (11, 12)
-- APT-based third-party repositories
-- Docker, Kubernetes, GitLab, etc. (APT versions)
+**APT/Debian**:
+- ✅ Docker CE (Ubuntu/Debian) (DONE)
+- ✅ GitLab CE + Runner (DONE)
+- ✅ Grafana, HashiCorp, Icinga, Lynis (DONE)
+- ✅ Filtered mode with GPG re-signing and upstream verification (DONE)
+- Ubuntu/Debian official base repositories
+- Kubernetes (APT version)
 
 ## License
 

--- a/examples/apt/docker-ce.yaml
+++ b/examples/apt/docker-ce.yaml
@@ -25,10 +25,7 @@ repositories:
     retention:
       policy: mirror
 
----
-
-# Docker CE for Ubuntu 20.04 Focal
-repositories:
+  # Docker CE for Ubuntu 20.04 Focal
   - id: docker-ce-ubuntu-focal
     name: "Docker CE - Ubuntu 20.04 Focal (amd64)"
     type: apt
@@ -47,10 +44,7 @@ repositories:
     retention:
       policy: mirror
 
----
-
-# Docker CE for Debian 12 Bookworm
-repositories:
+  # Docker CE for Debian 12 Bookworm
   - id: docker-ce-debian-bookworm
     name: "Docker CE - Debian 12 Bookworm (amd64)"
     type: apt

--- a/examples/apt/gitlab.yaml
+++ b/examples/apt/gitlab.yaml
@@ -32,10 +32,7 @@ repositories:
       cron: "0 4 * * *"  # Daily at 4 AM
       create_snapshot: true
 
----
-
-# GitLab Runner Repository
-repositories:
+  # GitLab Runner Repository
   - id: gitlab-runner-ubuntu-jammy
     name: "GitLab Runner - Ubuntu 22.04 Jammy"
     type: apt

--- a/examples/apt/icinga.yaml
+++ b/examples/apt/icinga.yaml
@@ -31,10 +31,7 @@ repositories:
       cron: "0 6 * * *"  # Daily at 6 AM
       create_snapshot: true
 
----
-
-# Icinga for Debian 12 Bookworm
-repositories:
+  # Icinga for Debian 12 Bookworm
   - id: icinga-debian-bookworm
     name: "Icinga - Debian 12 Bookworm"
     type: apt


### PR DESCRIPTION
The documentation had drifted well behind the code. A full accuracy review (every doc cross-checked against the real code, CLI `--help`, and config schema) surfaced stale status, a pre-refactor schema, a fictional plugin framework, wrong CLI flags, and config examples that either silently no-op or fail to load. This brings all 25 doc/example files back in line with the actual **1.4.0** codebase.

## Highlights

**Status & install**
- `ROADMAP`/`CONTRIBUTING`/`index`: 1.4.0 (released, on PyPI); dropped the *"research phase / not accepting contributions"* framing; moved shipped work (hosted upload #16, release engineering, 1.0) to completed; fixed the GitHub owner (`yourusername` → `slauger`).
- `README`/`installation`: added `pip install chantal`; corrected the dependency list (removed `lxml`); advertised hosted mode + `chantal package upload`.

**CLI reference** (every command verified against `--help`)
- Documented the previously-missing `package`, `view`, `cache`, `schema` groups; removed fabricated flags on `pool verify`/`pool cleanup`/`db cleanup`; fixed `publish unpublish`, `snapshot create`/`diff`, `publish snapshot` usage; dropped the unsupported `apk` content type from examples.

**Plugins**
- Corrected the **default mode** (it's `filtered`, not `mirror`) across all plugin docs; fixed the helm `.prov` *"preserved"* claim and the OCI overclaim; flipped APT *"uploads planned"* → shipped; trimmed RPM *"future enhancements"* to just delta RPMs; fixed invalid auth/retention config examples.

**Configuration & examples**
- Fixed silently-ignored filter field names (`size_bytes.min/max`, `newer_than`/`older_than`/`last_n_days`) and the invented `http_headers` field; documented the `gpg`/`verify`/`hosted` sections; merged three multi-document APT example files so they load with the real single-document loader.

**Architecture** (rewritten against the code)
- Replaced the non-existent `Package` model with `ContentItem`; documented `RepositoryFile`, `Repository.mode`, the `View*` models and the real junction tables; corrected the migration chain. Replaced the fictional `SyncPlugin` base class / plugin registry with the real convention + hardcoded dispatch; fixed the storage pool layout (`content/` + `files/`) and hardlink/cleanup details.

## Verification
- **No code changes** — the JSON config schema is byte-identical; `tests/test_schema.py` passes and all bundled example configs still validate.
- The three previously-broken multi-document APT examples now load via the real loader.
- A fresh-context fact-check confirmed the rewritten architecture docs match `models.py`/`storage.py`/`base.py` exactly (no fictional columns, methods, or imports remain).

Closes nothing; pure documentation accuracy.