### PR TITLE
fix(helm): regenerate index.yaml in filtered mode

### DIFF
--- a/src/chantal/plugins/helm/publisher.py
+++ b/src/chantal/plugins/helm/publisher.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Session
 
 from chantal.core.config import RepositoryConfig
 from chantal.core.storage import StorageManager
-from chantal.db.models import ContentItem, Repository, Snapshot
+from chantal.db.models import ContentItem, Repository, RepositoryMode, Snapshot
 from chantal.plugins.base import PublisherPlugin
 from chantal.plugins.helm.models import HelmMetadata
 
@@ -141,10 +141,11 @@ class HelmPublisher(PublisherPlugin):
         charts: list[ContentItem],
         snapshot: Snapshot | None = None,
     ) -> None:
-        """Publish index.yaml from RepositoryFile or generate it.
+        """Publish index.yaml: regenerate it (filtered/hosted) or hardlink it.
 
-        For mirror mode, this hardlinks the index.yaml from pool.
-        If not found, falls back to generating index.yaml.
+        Filtered mode always regenerates index.yaml from the published charts.
+        Mirror mode hardlinks the verbatim upstream index.yaml from the pool,
+        falling back to generation when none was stored.
 
         Args:
             session: Database session
@@ -154,6 +155,15 @@ class HelmPublisher(PublisherPlugin):
             charts: List of charts (for fallback generation)
             snapshot: Optional snapshot model instance
         """
+        # In filtered mode the published chart set differs from upstream, so
+        # always regenerate index.yaml from the published charts. Republishing
+        # the verbatim upstream index (stored unconditionally during sync) would
+        # still list charts that were filtered out. Mirror mode keeps the
+        # upstream index as-is.
+        if repository.mode == RepositoryMode.FILTERED:
+            self._generate_index_yaml(charts, target_path, config)
+            return
+
         # Find index.yaml RepositoryFile
         index_file = None
 

--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -95,7 +95,9 @@ class HelmSyncer:
         self.output.phase("Downloading index.yaml", number=1)
         index_data = self._fetch_index(index_url, config)
 
-        # Store index.yaml as RepositoryFile for mirror mode
+        # Store the upstream index.yaml as a RepositoryFile so mirror mode can
+        # republish it verbatim. Filtered mode ignores it and regenerates the
+        # index from the published charts at publish time.
         self._store_index_file(index_url, config, session, repository)
 
         # Parse charts from index

--- a/tests/e2e/test_helm_features_real_client_e2e.py
+++ b/tests/e2e/test_helm_features_real_client_e2e.py
@@ -201,8 +201,19 @@ def test_helm_filtering_excludes_chart_from_real_client(tmp_path, serve, chantal
     )
     target = chantal_env.sync_and_publish("demo-filt")
 
+    # The published index.yaml itself must be regenerated from the filtered set:
+    # the excluded chart must NOT be listed (not just absent as a .tgz).
+    index = yaml.safe_load((target / "index.yaml").read_text())
+    assert "demo" in index["entries"], "kept chart missing from published index.yaml"
+    assert "other" not in index["entries"], (
+        "excluded chart 'other' still listed in the published index.yaml "
+        "(filtered mode must regenerate the index, not republish upstream)"
+    )
+
     ok = _helm(
         target,
+        "helm search repo local/ | tee /tmp/s; "
+        "grep -q demo /tmp/s && ! grep -q other /tmp/s; "
         "helm pull local/demo --version 0.1.0 && test -f demo-0.1.0.tgz && echo KEPT_OK; "
         "if helm pull local/other --version 0.1.0 2>/dev/null; then echo OTHER_PRESENT; "
         "else echo OTHER_ABSENT; fi",


### PR DESCRIPTION
Closes #88.

## Problem

A Helm repository with `mode: filtered` republished the **verbatim upstream `index.yaml`**, which still listed charts that were filtered out. Their `.tgz` files were absent (so `helm pull` 404'd), but the index — and therefore `helm search repo` — was inconsistent with what was actually published.

## Root cause

`_publish_metadata_files` chose hardlink-vs-generate purely by the **presence** of the stored upstream index `RepositoryFile` (stored on every sync for mirror mode), regardless of repository mode. A filtered repo had that file, so the `if index_file` (hardlink-verbatim) branch always won.

## Fix

Gate on the mode instead, mirroring the established APK publisher pattern:

```python
if repository.mode == RepositoryMode.FILTERED:
    self._generate_index_yaml(charts, target_path, config)
    return
```

- **filtered**: always regenerate `index.yaml` from the published charts (the filtered set).
- **mirror**: unchanged — still republishes the upstream index verbatim.
- **hosted**: unchanged — no stored upstream index, generates from uploaded charts.

This also fixes the index listing stale versions when `only_latest_version` filtering is on. The fix covers both repository and snapshot publishing (snapshots use the parent repo's mode).

## Tests

The filtered real-client e2e (`test_helm_filtering_excludes_chart_from_real_client`) now asserts the published `index.yaml` **content** excludes the filtered-out chart (a true regression test — confirmed to fail without the gate), plus a `helm search repo` check. All 21 helm tests pass (mirror verbatim, hosted upload, multi-version, filtered).

No schema/config change.