### PR TITLE
docs: describe HOSTED mode as operational in RepositoryMode

### DIFF
--- a/src/chantal/db/models.py
+++ b/src/chantal/db/models.py
@@ -32,7 +32,8 @@ class RepositoryMode(enum.StrEnum):
 
     - MIRROR: Full mirror, no filtering, metadata unchanged
     - FILTERED: Filtered packages with customized metadata (include/exclude, retention, etc.)
-    - HOSTED: Self-hosted packages (for future use)
+    - HOSTED: Upload-only repository with no upstream feed; packages are added
+      with ``chantal package upload`` and sync is a no-op
     """
 
     MIRROR = "mirror"


### PR DESCRIPTION
Closes #89.

The `RepositoryMode` enum still labelled `HOSTED` *"(for future use)"*, but hosted (upload-only) repositories have been operational since the custom package upload work (#16): `chantal package upload` adds packages, `feed` is optional for `mode: hosted`, and `sync` is a no-op for hosted repos (covered by real-client e2e tests).

Comment-only docstring update to match reality — **no behavior change, no schema change** (the JSON config schema is unaffected; `tests/test_schema.py` passes).