### PR TITLE
fix(rpm): preserve dependency metadata in published primary.xml

### DIFF
--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -12,7 +12,7 @@ import hashlib
 import shutil
 import xml.etree.ElementTree as ET
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from sqlalchemy.orm import Session
 
@@ -176,11 +176,20 @@ class RpmPublisher(PublisherPlugin):
                 packages, repodata_path, published_metadata
             )
 
-        # Generate primary.xml (always generated)
-        primary_xml_path = self._generate_primary_xml(packages, repodata_path, compression)
-
-        # Add primary to published metadata list
-        published_metadata.append(("primary", primary_xml_path))
+        # Produce exactly one primary.xml. Prefer regenerating it from the
+        # upstream primary: that preserves the <format> block (provides /
+        # requires / conflicts / obsoletes and the primary file list) that dnf
+        # needs for dependency resolution, with each package <location> rewritten
+        # to the republished Packages/ layout. Fall back to a minimal,
+        # database-built primary only when there is no upstream primary
+        # (e.g. hosted/upload-only repositories).
+        published_metadata, regenerated = self._regenerate_primary(
+            packages, repodata_path, mode, compression, published_metadata
+        )
+        if not regenerated:
+            published_metadata = [m for m in published_metadata if m[0] != "primary"]
+            primary_xml_path = self._generate_primary_xml(packages, repodata_path, compression)
+            published_metadata.append(("primary", primary_xml_path))
 
         # Generate repomd.xml with all metadata entries
         repomd_path = self._generate_repomd_xml(repodata_path, published_metadata)
@@ -411,6 +420,107 @@ class RpmPublisher(PublisherPlugin):
         primary_xml_path.unlink()
 
         return primary_xml_compressed_path
+
+    def _regenerate_primary(
+        self,
+        packages: list[ContentItem],
+        repodata_path: Path,
+        mode: str,
+        compression: CompressionFormat,
+        published_metadata: list[tuple[str, Path]],
+    ) -> tuple[list[tuple[str, Path]], bool]:
+        """Regenerate primary.xml from the upstream primary, preserving <format>.
+
+        Filters the upstream primary to the published package set (filtered mode)
+        and rewrites every package ``<location>`` to the republished ``Packages/``
+        layout, keeping the ``<format>`` dependency metadata and file lists
+        verbatim. The single regenerated primary replaces the upstream one in
+        ``published_metadata`` so repomd.xml references exactly one primary.
+
+        Returns ``(updated_metadata, True)`` on success, or
+        ``(published_metadata, False)`` when there is no upstream primary to work
+        from (the caller then builds a minimal primary from the database).
+        """
+        primary_index = next(
+            (i for i, (ft, _) in enumerate(published_metadata) if ft == "primary"), None
+        )
+        if primary_index is None:
+            return published_metadata, False
+
+        primary_path = published_metadata[primary_index][1]
+        common_ns = "http://linux.duke.edu/metadata/common"
+        rpm_ns = "http://linux.duke.edu/metadata/rpm"
+        ET.register_namespace("", common_ns)
+        ET.register_namespace("rpm", rpm_ns)
+
+        try:
+            data = decompress_bytes(primary_path.read_bytes(), primary_path.suffix)
+            root = ET.fromstring(data)
+
+            # Match published packages by NEVR+arch (checksum-independent, so it
+            # works regardless of whether the upstream primary uses sha1/sha256/
+            # sha512 pkgids).
+            def _nevra_of_content(pkg: ContentItem) -> tuple[str, str, str, str]:
+                meta = pkg.content_metadata or {}
+                return (pkg.name, pkg.version, meta.get("release", ""), meta.get("arch", ""))
+
+            kept = {_nevra_of_content(pkg) for pkg in packages}
+            filename_by_nevra = {_nevra_of_content(pkg): pkg.filename for pkg in packages}
+
+            original_count = len(root.findall(f"{{{common_ns}}}package"))
+            removed = 0
+            for pkg_elem in root.findall(f"{{{common_ns}}}package"):
+                name_elem = pkg_elem.find(f"{{{common_ns}}}name")
+                version_elem = pkg_elem.find(f"{{{common_ns}}}version")
+                arch_elem = pkg_elem.find(f"{{{common_ns}}}arch")
+                nevra = (
+                    (name_elem.text or "") if name_elem is not None else "",
+                    version_elem.get("ver", "") if version_elem is not None else "",
+                    version_elem.get("rel", "") if version_elem is not None else "",
+                    (arch_elem.text or "") if arch_elem is not None else "",
+                )
+
+                if mode == RepositoryMode.FILTERED and nevra not in kept:
+                    root.remove(pkg_elem)
+                    removed += 1
+                    continue
+
+                # Rewrite <location> to the republished Packages/<filename> path.
+                location = pkg_elem.find(f"{{{common_ns}}}location")
+                if location is not None:
+                    href = location.get("href", "")
+                    filename = filename_by_nevra.get(nevra) or PurePosixPath(href).name
+                    location.set("href", f"Packages/{filename}")
+
+            kept_count = original_count - removed
+            # Safety net: if matching dropped everything (e.g. unexpected NEVRA
+            # shape) but we do have packages, fall back to the database-built
+            # primary rather than publishing an empty index.
+            if kept_count == 0 and packages:
+                return published_metadata, False
+
+            root.set("packages", str(kept_count))
+            if removed:
+                print(
+                    f"Filtered primary: {original_count} → {original_count - removed} packages "
+                    f"(removed {removed} unavailable)"
+                )
+
+            # Write the regenerated primary using the repository's configured
+            # metadata compression (not necessarily the upstream's).
+            xml_bytes = ET.tostring(root, encoding="UTF-8", xml_declaration=True)
+            target = repodata_path / add_compression_extension("primary.xml", compression)
+            old_target = repodata_path / primary_path.name
+            old_target.unlink(missing_ok=True)  # drop the hardlinked upstream primary
+            target.unlink(missing_ok=True)
+            target.write_bytes(compress_file(xml_bytes, compression))
+
+            updated = published_metadata.copy()
+            updated[primary_index] = ("primary", target)
+            return updated, True
+        except Exception as e:  # noqa: BLE001 - fall back to DB-built primary
+            print(f"Warning: failed to regenerate primary from upstream: {e}")
+            return published_metadata, False
 
     def _publish_metadata_files(
         self, repository_files: list[RepositoryFile], repodata_path: Path

--- a/src/chantal/plugins/rpm/sync.py
+++ b/src/chantal/plugins/rpm/sync.py
@@ -325,10 +325,10 @@ class RpmSyncPlugin:
             metadata_downloaded = 0
 
             for metadata_info in metadata_files:
-                # Skip primary (already used for package sync)
-                if metadata_info["file_type"] == "primary":
-                    continue
-
+                # Store every metadata file, including primary.xml. The publisher
+                # filters/relocates the upstream primary at publish time to keep
+                # the <format> dependency metadata; without the stored primary it
+                # would fall back to a dependency-less regenerated index.
                 try:
                     # Convert dict to MetadataFileInfo for compatibility
                     mfi = MetadataFileInfo(

--- a/tests/e2e/test_rpm_features_real_client_e2e.py
+++ b/tests/e2e/test_rpm_features_real_client_e2e.py
@@ -50,11 +50,15 @@ export GNUPGHOME=/gpg; mkdir -p /gpg; chmod 700 /gpg
 printf '%%no-protection\nKey-Type: RSA\nKey-Length: 3072\nName-Real: Chantal Test\nName-Email: %s\nExpire-Date: 0\n%%commit\n' EMAIL > /key
 gpg --batch --gen-key /key >/dev/null 2>&1
 mkdir -p /rb/SPECS /up
-for name in demo-keep demo-drop; do
+# Standalone packages (no dependencies) used by the filtering/signing tests.
+for name in demo-keep demo-drop demo-lib; do
   printf 'Name: %s\nVersion: 1.0\nRelease: 1\nSummary: %s\nLicense: MIT\nBuildArch: noarch\n%%description\n%s\n%%install\nmkdir -p %%{buildroot}/usr/share/%s\necho hello-from-%s > %%{buildroot}/usr/share/%s/README\n%%files\n/usr/share/%s/README\n' \
     "$name" "$name" "$name" "$name" "$name" "$name" "$name" > /rb/SPECS/$name.spec
   rpmbuild --define "_topdir /rb" -bb /rb/SPECS/$name.spec >/dev/null 2>&1
 done
+# demo-app Requires: demo-lib -> exercises dependency metadata (primary <format>).
+printf 'Name: demo-app\nVersion: 1.0\nRelease: 1\nSummary: demo-app\nLicense: MIT\nBuildArch: noarch\nRequires: demo-lib\n%%description\ndemo-app\n%%install\nmkdir -p %%{buildroot}/usr/share/demo-app\necho hello-from-demo-app > %%{buildroot}/usr/share/demo-app/README\n%%files\n/usr/share/demo-app/README\n' > /rb/SPECS/demo-app.spec
+rpmbuild --define "_topdir /rb" -bb /rb/SPECS/demo-app.spec >/dev/null 2>&1
 cp /rb/RPMS/noarch/*.rpm /up/
 rpm --define "_gpg_name EMAIL" --addsign /up/*.rpm >/dev/null 2>&1
 createrepo_c /up >/dev/null 2>&1
@@ -291,3 +295,44 @@ def test_rpm_zstd_metadata_installs(tmp_path, serve, chantal_env):
     )
     assert ok.returncode == 0, f"zstd repo install failed: {ok.stderr.decode()[-800:]}"
     assert b"hello-from-demo-keep" in ok.stdout
+
+
+@requires_docker
+@pytest.mark.parametrize("mode", ["mirror", "filtered"])
+def test_rpm_dependency_metadata_preserved(mode, tmp_path, serve, chantal_env):
+    """The published primary.xml keeps <format> deps, so dnf resolves a
+    Requires: from the repo (demo-app pulls in demo-lib). Covers both the
+    verbatim-mirror and the regenerated-filtered publish paths."""
+    upstream = tmp_path / "upstream"
+    _build_signed_upstream(upstream)
+
+    repo: dict = {
+        "id": "deps",
+        "name": "Deps",
+        "type": "rpm",
+        "feed": serve(upstream),
+        "enabled": True,
+        "mode": mode,
+    }
+    if mode == "filtered":
+        # Keep both the app and its dependency in the filtered set.
+        repo["filters"] = {"patterns": {"include": ["^demo-app$", "^demo-lib$"]}}
+    chantal_env.write_config(repo)
+    target = chantal_env.sync_and_publish("deps")
+
+    # Exactly one primary index (no duplicate <data type="primary">).
+    assert len(list(target.glob("repodata/*primary.xml*"))) == 1, "expected a single primary.xml"
+
+    # dnf must see demo-app's Requires and pull demo-lib automatically.
+    res = _dnf(
+        target,
+        _repo_file(gpgcheck=0, repo_gpgcheck=0, gpgkey=None)
+        + "dnf install -y demo-app >/dev/null; "
+        + "rpm -q demo-app demo-lib; "
+        + "cat /usr/share/demo-lib/README",
+    )
+    assert res.returncode == 0, (
+        f"dependency resolution failed in {mode} mode:\n"
+        f"stdout={res.stdout.decode()[-800:]}\nstderr={res.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-demo-lib" in res.stdout, "demo-lib (dependency) was not installed"


### PR DESCRIPTION
## The bug (CRITICAL)

chantal-published RPM repositories advertised **no dependencies**. `_generate_primary_xml` built `primary.xml` with **no `<format>` block** — no `rpm:provides`/`requires`/`conflicts`/`obsoletes` and no primary file list — so `dnf` saw every package as dependency-free. `dnf install <pkg-with-deps>` could not resolve requirements from the repo, making mirrored real-world repos (EPEL, Docker-CE, …) largely unusable for dependency resolution.

Root cause was twofold:
- `rpm/sync.py` downloaded the upstream `primary.xml` only to parse the package list and **never stored it**.
- `rpm/publisher.py` always rebuilt a minimal, dependency-less `primary.xml` from the database, in **both** mirror and filtered mode.

It went unnoticed because every test RPM was dependency-free (a real coverage gap).

## The fix

- **sync**: store the upstream `primary.xml` as a `RepositoryFile`.
- **publish**: new `_regenerate_primary` takes the stored upstream primary, drops packages not in the published set (filtered mode only, matched by **NEVR+arch** so it's independent of the upstream pkgid checksum type — also avoids the sha1/sha512 trap), rewrites each `<location>` to the republished `Packages/` layout, and recompresses with the repo's configured metadata compression. Every kept package's `<format>` is preserved **verbatim**, so dnf resolves dependencies again. Hosted/upload repos (no upstream primary) fall back to the database-built primary.

## Tests

A parametrized real-client e2e (**mirror + filtered**) builds `demo-app` `Requires: demo-lib`, publishes, and asserts a real `dnf install demo-app` actually pulls in `demo-lib`, and that exactly one primary index is published. Verified it fails against the old depless primary.

Full RPM e2e suite + unit suite green; ruff/black/mypy/yamllint clean.

## Follow-ups (pre-existing, out of scope)
- Re-sync can accumulate stale metadata associations (already affects filelists/other/updateinfo/modules; now also primary) — worth a separate prune-on-resync fix.
- filelists/other still match by sha256 pkgid (would empty for sha1/sha512 upstreams) — separate from primary, which this PR moves to NEVRA matching.