### PR TITLE
fix(helm): verify chart digest on sync; emit bare-hex index digest

### DIFF
--- a/src/chantal/plugins/helm/publisher.py
+++ b/src/chantal/plugins/helm/publisher.py
@@ -233,8 +233,10 @@ class HelmPublisher(PublisherPlugin):
             else:
                 entry["urls"] = [chart.filename]
 
-            # Update digest with actual SHA256
-            entry["digest"] = f"sha256:{chart.sha256}"
+            # Set the digest to the actual chart SHA256. Helm index.yaml digests
+            # are bare hex (no "sha256:" prefix); emitting the prefix breaks
+            # digest-consuming tooling and self-mirror dedup.
+            entry["digest"] = chart.sha256
 
             entries[name].append(entry)
 

--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -26,6 +26,17 @@ from chantal.plugins.helm.models import HelmMetadata
 logger = logging.getLogger(__name__)
 
 
+def normalize_digest(digest: str | None) -> str | None:
+    """Return the bare hex of a chart digest, stripping an optional algo prefix.
+
+    Helm ``index.yaml`` digests are bare hex, but some producers (including
+    chantal's own generated index, historically) prefix them with ``sha256:``.
+    """
+    if not digest:
+        return None
+    return digest.split(":", 1)[1] if ":" in digest else digest
+
+
 class HelmSyncer:
     """Syncer for Helm chart repositories.
 
@@ -123,14 +134,17 @@ class HelmSyncer:
 
         for i, chart_entry in enumerate(filtered_charts, 1):
             try:
-                # Check if chart already exists
+                # The index.yaml digest is the expected SHA256 of the chart
+                # tarball (bare hex, possibly with a 'sha256:' prefix).
+                expected_digest = normalize_digest(chart_entry.get("digest"))
+
+                # Check if chart already exists (content-addressed by digest).
                 existing = (
                     session.query(ContentItem)
-                    .filter_by(
-                        content_type="helm",
-                        sha256=chart_entry["digest"] if chart_entry.get("digest") else None,
-                    )
+                    .filter_by(content_type="helm", sha256=expected_digest)
                     .first()
+                    if expected_digest
+                    else None
                 )
 
                 if existing:
@@ -157,6 +171,22 @@ class HelmSyncer:
                 self.output.downloading(chart_name, 0, i, len(filtered_charts))
 
                 pool_path, sha256, size = self._download_chart(chart_url, config)
+
+                # Verify the downloaded bytes against the digest advertised in
+                # index.yaml. A mismatch means the tarball was tampered with or
+                # corrupted in transit; reject it (the chart is skipped, never
+                # stored or published).
+                if expected_digest and sha256 != expected_digest:
+                    # The download already content-addressed the bytes into the
+                    # pool; remove the orphan if nothing else references it.
+                    if not session.query(ContentItem).filter_by(sha256=sha256).first():
+                        self.storage.get_absolute_pool_path(sha256, Path(chart_url).name).unlink(
+                            missing_ok=True
+                        )
+                    raise ValueError(
+                        f"digest mismatch for {chart_name}: index.yaml advertises "
+                        f"{expected_digest}, downloaded content is {sha256} (possible tampering)"
+                    )
 
                 # Create metadata
                 metadata = HelmMetadata(**chart_entry)

--- a/tests/test_helm_sync_verify.py
+++ b/tests/test_helm_sync_verify.py
@@ -1,0 +1,157 @@
+"""Tests for Helm chart digest verification during sync.
+
+A chart whose downloaded bytes do not match the digest advertised in
+index.yaml must be rejected (never stored or linked). The digest comparison is
+tolerant of an optional ``sha256:`` prefix.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from chantal.core.config import RepositoryConfig, StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.models import Base, ContentItem, Repository
+from chantal.plugins.helm.sync import HelmSyncer, normalize_digest
+
+_GOOD = "a" * 64
+_BAD = "b" * 64
+
+
+@pytest.fixture
+def storage():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        sm = StorageManager(
+            StorageConfig(
+                base_path=str(tmp / "base"),
+                pool_path=str(tmp / "pool"),
+                published_path=str(tmp / "published"),
+                temp_path=str(tmp / "tmp"),
+            )
+        )
+        sm.ensure_directories()
+        yield sm
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    sess = Session(engine)
+    yield sess
+    sess.close()
+
+
+@pytest.fixture
+def repository(session):
+    repo = Repository(repo_id="h", name="H", type="helm", feed="https://charts.example.com")
+    session.add(repo)
+    session.commit()
+    return repo
+
+
+def _index(digest: str) -> dict:
+    return {
+        "apiVersion": "v1",
+        "entries": {
+            "demo": [
+                {
+                    "name": "demo",
+                    "version": "0.1.0",
+                    "digest": digest,
+                    "urls": ["https://charts.example.com/demo-0.1.0.tgz"],
+                }
+            ]
+        },
+    }
+
+
+def _syncer(storage, repo_config, *, downloaded_sha: str):
+    syncer = HelmSyncer(storage=storage, config=repo_config)
+    # Avoid real HTTP for the index-store side effect.
+    syncer._store_index_file = lambda *a, **k: None  # type: ignore[method-assign]
+    # _download_chart returns (pool_path, sha256, size).
+    syncer._download_chart = lambda *a, **k: (Path("/pool/demo-0.1.0.tgz"), downloaded_sha, 123)  # type: ignore[method-assign]
+    return syncer
+
+
+def test_normalize_digest():
+    assert normalize_digest("sha256:" + _GOOD) == _GOOD
+    assert normalize_digest(_GOOD) == _GOOD
+    assert normalize_digest(None) is None
+    assert normalize_digest("") is None
+
+
+def test_tampered_chart_is_rejected(storage, session, repository):
+    """index.yaml advertises _GOOD, but the bytes hash to _BAD -> rejected."""
+    cfg = RepositoryConfig(id="h", name="H", type="helm", feed="https://charts.example.com")
+    syncer = _syncer(storage, cfg, downloaded_sha=_BAD)
+
+    with patch.object(syncer, "_fetch_index", return_value=_index(_GOOD)):
+        stats = syncer.sync_repository(session, repository, cfg)
+
+    assert stats["charts_added"] == 0, "tampered chart must not be added"
+    assert session.query(ContentItem).count() == 0, "no ContentItem for a tampered chart"
+
+
+def test_matching_chart_is_accepted(storage, session, repository):
+    cfg = RepositoryConfig(id="h", name="H", type="helm", feed="https://charts.example.com")
+    syncer = _syncer(storage, cfg, downloaded_sha=_GOOD)
+
+    with patch.object(syncer, "_fetch_index", return_value=_index(_GOOD)):
+        stats = syncer.sync_repository(session, repository, cfg)
+
+    assert stats["charts_added"] == 1
+    item = session.query(ContentItem).one()
+    assert item.sha256 == _GOOD
+
+
+def test_prefixed_digest_matches(storage, session, repository):
+    """A 'sha256:'-prefixed index digest still verifies against the bare hash."""
+    cfg = RepositoryConfig(id="h", name="H", type="helm", feed="https://charts.example.com")
+    syncer = _syncer(storage, cfg, downloaded_sha=_GOOD)
+
+    with patch.object(syncer, "_fetch_index", return_value=_index("sha256:" + _GOOD)):
+        stats = syncer.sync_repository(session, repository, cfg)
+
+    assert stats["charts_added"] == 1
+
+
+def test_prefixed_digest_dedup(storage, session, repository):
+    """A 'sha256:'-prefixed index digest dedups against a stored bare sha256."""
+    existing = ContentItem(
+        content_type="helm",
+        name="demo",
+        version="0.1.0",
+        sha256=_GOOD,
+        size_bytes=123,
+        pool_path="ab/cd/demo-0.1.0.tgz",
+        filename="demo-0.1.0.tgz",
+        content_metadata={},
+    )
+    session.add(existing)
+    session.commit()
+
+    cfg = RepositoryConfig(id="h", name="H", type="helm", feed="https://charts.example.com")
+    # If dedup works, _download_chart is never called; make it fail loudly if it is.
+    syncer = HelmSyncer(storage=storage, config=cfg)
+    syncer._store_index_file = lambda *a, **k: None  # type: ignore[method-assign]
+
+    def _boom(*a, **k):
+        raise AssertionError("_download_chart should not be called when the chart is deduped")
+
+    syncer._download_chart = _boom  # type: ignore[method-assign]
+
+    with patch.object(syncer, "_fetch_index", return_value=_index("sha256:" + _GOOD)):
+        stats = syncer.sync_repository(session, repository, cfg)
+
+    assert stats["charts_added"] == 0
+    assert session.query(ContentItem).count() == 1  # linked, not duplicated
+    assert repository in existing.repositories


### PR DESCRIPTION
## The bug

The Helm syncer **never verified** a downloaded chart against the `digest` advertised in `index.yaml` — a tampered or corrupted `.tgz` was silently stored and published (no integrity check beyond TLS). APT and RPM both enforce the upstream checksum; Helm was the gap (a real fail-closed hole).

A related correctness bug: the generated `index.yaml` emitted `digest: sha256:<hex>`, but Helm repo index digests are **bare hex**. The prefix broke digest-consuming tooling and self-mirror dedup (a chantal-mirror of a chantal index re-downloaded every chart forever — and would now have been false-rejected by the new verification).

## The fix

- **Verify on sync**: after download, compare the chart's SHA256 to the index digest; on mismatch the chart is **rejected** — never stored as a `ContentItem`, never linked or published — and the orphaned pool blob is removed. The comparison tolerates an optional `sha256:` prefix (`normalize_digest`), which is also applied to the dedup lookup.
- **Bare-hex digest**: the generated index now emits bare hex, fixing tooling conformance and self-mirror dedup.

## Tests

`tests/test_helm_sync_verify.py` drives the **real** `sync_repository` loop (only the index fetch / chart download are stubbed, the verification is real code):
- tampered chart → rejected (no `ContentItem`, `charts_added == 0`) — the fail-closed test that was missing
- matching chart → accepted
- `sha256:`-prefixed digest → accepted, and deduped against a stored bare hash (no re-download)

Fresh-context review confirmed the fix is correct with no remaining publishing fail-open path. Full gate + all helm e2e green (real `helm` consumes the bare-hex index).