### PR TITLE
fix(apk): verify packages against the real APKINDEX control checksum

### DIFF
--- a/src/chantal/plugins/apk/checksum.py
+++ b/src/chantal/plugins/apk/checksum.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""
+APK package checksum helper.
+
+The ``C:`` field in an ``APKINDEX`` is ``Q1`` + base64(SHA1) where the SHA1 is
+taken over the *compressed bytes of the control segment* of the ``.apk`` — not
+the whole file. An ``.apk`` (APKv2) is a sequence of concatenated gzip streams:
+an optional signature, the control segment, then the data segment. The control
+segment is therefore always the second-to-last stream.
+"""
+
+import base64
+import hashlib
+import zlib
+
+_GZIP_MAGIC = b"\x1f\x8b"
+
+
+_CHUNK = 65536
+
+
+def _split_gzip_streams(data: bytes) -> list[bytes]:
+    """Split concatenated gzip streams into their raw (compressed) byte chunks.
+
+    Only the compressed stream boundaries are needed, so the decompressed output
+    is produced in bounded chunks and discarded — a maliciously high-expansion
+    member cannot exhaust memory.
+    """
+    streams: list[bytes] = []
+    rest = data
+    while rest[:2] == _GZIP_MAGIC:
+        decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+        pending = rest
+        while not decompressor.eof:
+            out = decompressor.decompress(pending, _CHUNK)
+            pending = decompressor.unconsumed_tail
+            if not out and not pending:
+                break  # truncated / no progress
+        consumed = len(rest) - len(decompressor.unused_data)
+        if consumed <= 0:
+            break
+        streams.append(rest[:consumed])
+        rest = decompressor.unused_data
+    return streams
+
+
+def compute_apk_control_checksum(data: bytes) -> str | None:
+    """Compute an ``.apk``'s ``C:`` checksum (``Q1`` + base64(SHA1) of control).
+
+    Returns ``None`` when ``data`` is not a parseable APKv2 archive (fewer than
+    two gzip streams, or a corrupt stream), so callers can treat that as a
+    verification failure.
+    """
+    try:
+        streams = _split_gzip_streams(data)
+    except (zlib.error, OverflowError):
+        return None
+    if len(streams) < 2:
+        return None
+    control_segment = streams[-2]  # data is last; control precedes it
+    digest = hashlib.sha1(control_segment).digest()  # noqa: S324 - APK index format
+    return "Q1" + base64.b64encode(digest).decode("ascii")

--- a/src/chantal/plugins/apk/sync.py
+++ b/src/chantal/plugins/apk/sync.py
@@ -6,7 +6,6 @@ Alpine APK repository syncer.
 This module implements syncing for Alpine APK repositories.
 """
 
-import hashlib
 import logging
 import tarfile
 import tempfile
@@ -20,6 +19,7 @@ from chantal.core.downloader import DownloadManager
 from chantal.core.output import OutputLevel, SyncOutputter
 from chantal.core.storage import StorageManager
 from chantal.db.models import ContentItem, Repository, RepositoryFile
+from chantal.plugins.apk.checksum import compute_apk_control_checksum
 from chantal.plugins.apk.models import ApkMetadata
 
 logger = logging.getLogger(__name__)
@@ -187,8 +187,13 @@ class ApkSyncer:
                     pkg_url, config, metadata.checksum
                 )
                 if not sha1_ok:
+                    # The downloaded bytes do not match the signed APKINDEX
+                    # checksum: reject the package (it is not pooled or linked).
                     stats["sha1_mismatches"] += 1
-                    self.output.warning(f"SHA1 mismatch for {pkg_name}")
+                    raise ValueError(
+                        f"checksum mismatch for {pkg_name} (expected {metadata.checksum}); "
+                        "possible tampering or a stale upstream APKINDEX"
+                    )
 
                 # Create ContentItem
                 content_item = ContentItem(
@@ -498,25 +503,24 @@ class ApkSyncer:
         response = self.session.get(url, timeout=300, stream=True)
         response.raise_for_status()
 
-        # Download to temp file and verify SHA1
-        import base64
-
         with tempfile.NamedTemporaryFile(delete=False, suffix=".apk") as tmp:
-            sha1_hash = hashlib.sha1()
             for chunk in response.iter_content(chunk_size=8192):
                 tmp.write(chunk)
-                sha1_hash.update(chunk)
             tmp_path = Path(tmp.name)
 
-        # Verify SHA1 (APK uses base64-encoded SHA1 with Q1 prefix)
-        # Note: Alpine CDN sometimes has stale APKINDEX, so we track mismatches but don't fail
-        calculated_sha1 = "Q1" + base64.b64encode(sha1_hash.digest()).decode("ascii")
-        sha1_ok = calculated_sha1 == expected_sha1
+        # Verify the package against the APKINDEX C: checksum (Q1 + base64(SHA1)
+        # of the control segment). Verify BEFORE pooling so a tampered/corrupt
+        # package never enters the content pool.
+        calculated_sha1 = compute_apk_control_checksum(tmp_path.read_bytes())
+        sha1_ok = calculated_sha1 is not None and calculated_sha1 == expected_sha1
 
         if not sha1_ok:
-            logger.debug(
-                f"SHA1 mismatch for {Path(url).name}: expected {expected_sha1}, got {calculated_sha1}"
+            logger.warning(
+                f"APK checksum mismatch for {Path(url).name}: "
+                f"expected {expected_sha1}, got {calculated_sha1}"
             )
+            tmp_path.unlink(missing_ok=True)
+            return None, None, None, False
 
         filename = Path(url).name
 

--- a/tests/e2e/test_apk_e2e.py
+++ b/tests/e2e/test_apk_e2e.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
+import gzip
 import io
 import tarfile
 from pathlib import Path
 
 import pytest
+
+from chantal.plugins.apk.checksum import compute_apk_control_checksum
 
 pytestmark = pytest.mark.e2e
 
@@ -17,15 +18,35 @@ REPO = "main"
 ARCH = "x86_64"
 
 
+def _gz_tar(name: str, content: bytes) -> bytes:
+    """Return a single gzip stream wrapping a one-entry tar (an .apk segment)."""
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tar:
+        info = tarfile.TarInfo(name)
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    out = io.BytesIO()
+    with gzip.GzipFile(fileobj=out, mode="wb") as gz:
+        gz.write(raw.getvalue())
+    return out.getvalue()
+
+
+def _build_minimal_apk() -> bytes:
+    """A valid APKv2 archive: concatenated control + data gzip streams."""
+    control = _gz_tar(".PKGINFO", b"pkgname = demo\npkgver = 1.0-r0\n")
+    data = _gz_tar("usr/share/demo/README", b"hello-from-demo\n")
+    return control + data
+
+
 def _build_apk_upstream(root: Path) -> None:
     """Create a minimal Alpine repo (APKINDEX.tar.gz + one .apk)."""
     arch_dir = root / BRANCH / REPO / ARCH
     arch_dir.mkdir(parents=True, exist_ok=True)
 
-    apk = b"dummy apk payload" * 16
+    apk = _build_minimal_apk()
     (arch_dir / "demo-1.0-r0.apk").write_bytes(apk)
-    # APK checksum field: "Q1" + base64(sha1(file))
-    q1 = "Q1" + base64.b64encode(hashlib.sha1(apk).digest()).decode("ascii")
+    # APK checksum field: Q1 + base64(SHA1 of the control segment).
+    q1 = compute_apk_control_checksum(apk)
 
     apkindex = (
         f"C:{q1}\n"

--- a/tests/test_apk_checksum.py
+++ b/tests/test_apk_checksum.py
@@ -1,0 +1,115 @@
+"""Tests for APK control-segment checksum + sync-time integrity rejection."""
+
+from __future__ import annotations
+
+import gzip
+import io
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from chantal.core.config import RepositoryConfig, StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.plugins.apk.checksum import compute_apk_control_checksum
+from chantal.plugins.apk.sync import ApkSyncer
+
+
+def _gz_tar(name: str, content: bytes) -> bytes:
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tar:
+        info = tarfile.TarInfo(name)
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    out = io.BytesIO()
+    with gzip.GzipFile(fileobj=out, mode="wb") as gz:
+        gz.write(raw.getvalue())
+    return out.getvalue()
+
+
+def _apk(control_payload: bytes = b"pkgname = demo\n", data_payload: bytes = b"hello\n") -> bytes:
+    return _gz_tar(".PKGINFO", control_payload) + _gz_tar("usr/x", data_payload)
+
+
+def test_checksum_is_control_segment_not_whole_file():
+    apk = _apk()
+    csum = compute_apk_control_checksum(apk)
+    assert csum is not None and csum.startswith("Q1")
+    # It is the control segment's checksum: changing only the DATA segment must
+    # not change it, but changing the control segment must.
+    apk_other_data = _gz_tar(".PKGINFO", b"pkgname = demo\n") + _gz_tar("usr/x", b"different\n")
+    assert compute_apk_control_checksum(apk_other_data) == csum
+    apk_other_control = _gz_tar(".PKGINFO", b"pkgname = evil\n") + _gz_tar("usr/x", b"hello\n")
+    assert compute_apk_control_checksum(apk_other_control) != csum
+
+
+def test_checksum_handles_signed_three_stream_apk():
+    """For a signed apk [sign, control, data], control is still streams[-2]."""
+    unsigned = _apk()  # [control, data]
+    control_only = compute_apk_control_checksum(unsigned)
+    signed = _gz_tar(".SIGN.RSA.key.pub", b"signature-bytes") + unsigned
+    assert compute_apk_control_checksum(signed) == control_only
+
+
+def test_checksum_rejects_non_apk():
+    assert compute_apk_control_checksum(b"not an apk at all") is None
+    assert compute_apk_control_checksum(b"") is None
+    assert compute_apk_control_checksum(_gz_tar("only-one", b"x")) is None  # single stream
+
+
+@pytest.fixture
+def storage():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        sm = StorageManager(
+            StorageConfig(
+                base_path=str(tmp / "base"),
+                pool_path=str(tmp / "pool"),
+                published_path=str(tmp / "published"),
+                temp_path=str(tmp / "tmp"),
+            )
+        )
+        sm.ensure_directories()
+        yield sm
+
+
+def _syncer(storage, content: bytes):
+    cfg = RepositoryConfig(
+        id="a",
+        name="A",
+        type="apk",
+        feed="https://example.com/alpine/",
+        apk={"branch": "v3.19", "repository": "main", "architecture": "x86_64"},
+    )
+    syncer = ApkSyncer(storage=storage, config=cfg)
+    resp = Mock()
+    resp.raise_for_status = Mock()
+    resp.iter_content = lambda chunk_size=8192: iter([content])
+    syncer.session.get = Mock(return_value=resp)
+    return syncer
+
+
+def test_download_accepts_matching_checksum(storage):
+    apk = _apk()
+    expected = compute_apk_control_checksum(apk)
+    syncer = _syncer(storage, apk)
+    pool_path, sha256, size, ok = syncer._download_package(
+        "https://example.com/demo-1.0-r0.apk", syncer.config, expected
+    )
+    assert ok is True
+    assert pool_path and sha256 and size
+
+
+def test_download_rejects_mismatched_checksum(storage):
+    apk = _apk(control_payload=b"pkgname = tampered\n")
+    syncer = _syncer(storage, apk)
+    # Expected checksum is for a DIFFERENT control segment -> reject, no pooling.
+    pool_path, sha256, size, ok = syncer._download_package(
+        "https://example.com/demo-1.0-r0.apk", syncer.config, "Q1deadbeefdeadbeefdeadbeefdeadbeef="
+    )
+    assert ok is False
+    assert pool_path is None and sha256 is None and size is None
+    # Nothing was written to the pool.
+    assert not list((storage.pool_path).rglob("*.apk"))


### PR DESCRIPTION
## The bug

The APK syncer's integrity check was **dead**. It computed SHA1 over the **whole** `.apk` file and compared it to the APKINDEX `C:` field — but `C:` is `Q1` + base64(SHA1) of only the **control segment** (the second-to-last of the concatenated gzip streams in an APKv2 archive). The whole-file hash never matched real packages, so mismatches were tracked-but-tolerated and a tampered/corrupt `.apk` was stored and published regardless. (APT/RPM/Helm all enforce the upstream checksum; APK was the gap.)

## The fix

- New `compute_apk_control_checksum()` splits the concatenated gzip streams (decompressing in **bounded chunks**, so a high-expansion data segment can't exhaust memory) and hashes the control segment — reproducing apk's `C:` value. Empirically validated against Alpine's real `tzdata` package.
- The syncer verifies this **before** adding the package to the pool, and **rejects** a mismatch: the package is skipped (never pooled, linked, or published) and the sync continues for the rest. No orphan, no partial `ContentItem`.

## Tests

- `tests/test_apk_checksum.py`: control-segment scope (data-segment change doesn't affect it, control change does), signed (3-stream) and unsigned (2-stream) layouts, non-apk rejection, and accept-matching / reject-mismatching at the real `_download_package` boundary (asserts nothing reaches the pool).
- The apk sync→publish e2e now uses a valid minimal apk; the **real-client** e2e (real `tzdata`/`tini`) now genuinely exercises the verification and still installs with real `apk`.

## Notes
- `C:` covers the control segment only; data-segment integrity is verified by the apk client via the control segment's `datahash`, as before.
- Behavior change: a genuinely stale upstream APKINDEX now skips the affected package (per-package, sync continues) instead of silently mirroring mismatched bytes — the correct fail-closed choice.

Fresh-context review confirmed the fix is correct with no remaining integrity fail-open. Full gate + all apk e2e green.