### PR TITLE
fix(apt): mirror repositories whose indices are not gzip

### DIFF
--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -26,8 +26,33 @@ from chantal.plugins.apt.parsers import (
     parse_release_file,
     parse_sources_from_bytes,
 )
+from chantal.plugins.rpm.modules import decompress_bytes
 
 logger = logging.getLogger(__name__)
+
+# Compression variants for an APT index (Packages/Sources), in preference order.
+# Debian/Ubuntu repos vary: some ship only .gz, some only .xz, some uncompressed.
+_INDEX_VARIANTS = (".gz", ".xz", ".bz2", ".zst", "")
+_COMPRESSED_SUFFIXES = (".gz", ".xz", ".bz2", ".zst")
+
+
+def _pick_index_variant(base: str, checksums: dict) -> str | None:
+    """Return the first present compression variant of ``base`` in ``checksums``.
+
+    ``base`` is the index path without a compression suffix
+    (e.g. ``main/binary-amd64/Packages``).
+    """
+    for ext in _INDEX_VARIANTS:
+        path = f"{base}{ext}"
+        if path in checksums:
+            return path
+    return None
+
+
+def _decompress_index(data: bytes, relative_path: str) -> bytes:
+    """Decompress an index file by its path suffix (gz/xz/bz2/zst or raw)."""
+    suffix = PurePosixPath(relative_path).suffix
+    return decompress_bytes(data, suffix if suffix in _COMPRESSED_SUFFIXES else "")
 
 
 @dataclass
@@ -183,11 +208,9 @@ class AptSyncPlugin:
                 with open(packages_gz_path, "rb") as f:
                     packages_data = f.read()
 
-                # Parse (file is already decompressed in storage as .gz)
+                # Decompress according to the actual index suffix.
                 try:
-                    import gzip
-
-                    packages_content = gzip.decompress(packages_data)
+                    packages_content = _decompress_index(packages_data, metadata_info.relative_path)
                     packages = parse_packages_from_bytes(packages_content, compressed=False)
                 except Exception as e:
                     logger.error(f"Failed to parse Packages file: {e}")
@@ -559,9 +582,12 @@ class AptSyncPlugin:
 
         for component in components:
             for arch in architectures:
-                # Binary packages (Packages.gz)
-                packages_path = f"{component}/binary-{arch}/Packages.gz"
-                if packages_path in sha256_checksums:
+                # Binary packages: pick whichever compression variant the Release
+                # actually advertises (Packages.gz / .xz / .bz2 / .zst / raw).
+                packages_path = _pick_index_variant(
+                    f"{component}/binary-{arch}/Packages", sha256_checksums
+                )
+                if packages_path is not None:
                     checksum, size = sha256_checksums[packages_path]
                     metadata_files.append(
                         MetadataFileInfo(
@@ -574,10 +600,10 @@ class AptSyncPlugin:
                         )
                     )
 
-            # Source packages (Sources.gz) - if configured
+            # Source packages - if configured (same variant handling).
             if self.apt_config.include_source_packages:
-                sources_path = f"{component}/source/Sources.gz"
-                if sources_path in sha256_checksums:
+                sources_path = _pick_index_variant(f"{component}/source/Sources", sha256_checksums)
+                if sources_path is not None:
                     checksum, size = sha256_checksums[sources_path]
                     metadata_files.append(
                         MetadataFileInfo(
@@ -672,7 +698,8 @@ class AptSyncPlugin:
         metadata_url = urljoin(dists_url, metadata_info.relative_path)
 
         with tempfile.NamedTemporaryFile(
-            delete=False, suffix=f".{metadata_info.file_type}.gz"
+            delete=False,
+            suffix=f".{metadata_info.file_type}{PurePosixPath(metadata_info.relative_path).suffix}",
         ) as tmp_file:
             tmp_path = Path(tmp_file.name)
 
@@ -1035,8 +1062,6 @@ class AptSyncPlugin:
         Returns:
             Tuple of (artifacts_downloaded, bytes_downloaded).
         """
-        import gzip
-
         # Collect source stanzas from every Sources index.
         all_sources: list[SourcesMetadata] = []
         for metadata_info in metadata_files:
@@ -1047,7 +1072,7 @@ class AptSyncPlugin:
                 logger.warning(f"Sources file not found in storage: {metadata_info.relative_path}")
                 continue
             try:
-                content = gzip.decompress(sources_path.read_bytes())
+                content = _decompress_index(sources_path.read_bytes(), metadata_info.relative_path)
                 stanzas = parse_sources_from_bytes(content, compressed=False)
             except Exception as e:
                 logger.error(f"Failed to parse Sources file: {e}")

--- a/src/chantal/plugins/rpm/modules.py
+++ b/src/chantal/plugins/rpm/modules.py
@@ -130,9 +130,13 @@ def decompress_bytes(data: bytes, suffix: str) -> bytes:
     if suffix == ".bz2":
         return bz2.decompress(data)
     if suffix == ".zst":
+        import io
+
         import zstandard as zstd
 
-        return zstd.ZstdDecompressor().decompress(data)
+        # Use the streaming reader: the one-shot decompress() requires the frame
+        # to embed its content size, which streaming producers often omit.
+        return zstd.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
     return data
 
 

--- a/tests/e2e/test_apt_features_real_client_e2e.py
+++ b/tests/e2e/test_apt_features_real_client_e2e.py
@@ -64,10 +64,18 @@ def _build_real_deb(name: str = "hello-chantal") -> bytes:
     return base64.b64decode(out.stdout)
 
 
-def _build_binary_upstream(root: Path, deb: bytes, name: str = "hello-chantal") -> None:
-    """Write a minimal binary apt upstream (pool + Packages + Release)."""
+def _build_binary_upstream(
+    root: Path, deb: bytes, name: str = "hello-chantal", *, compression: str = "gz"
+) -> None:
+    """Write a minimal binary apt upstream (pool + Packages + Release).
+
+    ``compression`` selects which Packages index variant the upstream ships:
+    ``"gz"`` writes Packages + Packages.gz; ``"xz"`` writes ONLY Packages.xz
+    (to exercise non-gzip index handling).
+    """
     import gzip
     import hashlib
+    import lzma
 
     deb_rel = f"pool/{COMP}/h/{name}/{name}_1.0_{ARCH}.deb"
     (root / deb_rel).parent.mkdir(parents=True, exist_ok=True)
@@ -86,16 +94,30 @@ def _build_binary_upstream(root: Path, deb: bytes, name: str = "hello-chantal") 
     ).encode()
     comp_dir = root / "dists" / DIST / COMP / f"binary-{ARCH}"
     comp_dir.mkdir(parents=True, exist_ok=True)
-    (comp_dir / "Packages").write_bytes(packages)
-    packages_gz = gzip.compress(packages)
-    (comp_dir / "Packages.gz").write_bytes(packages_gz)
-
     sha = hashlib.sha256
+    lines = []
+    if compression == "xz":
+        packages_xz = lzma.compress(packages)
+        (comp_dir / "Packages.xz").write_bytes(packages_xz)
+        lines.append(
+            f" {sha(packages_xz).hexdigest()} {len(packages_xz)} "
+            f"{COMP}/binary-{ARCH}/Packages.xz\n"
+        )
+    else:
+        (comp_dir / "Packages").write_bytes(packages)
+        packages_gz = gzip.compress(packages)
+        (comp_dir / "Packages.gz").write_bytes(packages_gz)
+        lines.append(
+            f" {sha(packages).hexdigest()} {len(packages)} " f"{COMP}/binary-{ARCH}/Packages\n"
+        )
+        lines.append(
+            f" {sha(packages_gz).hexdigest()} {len(packages_gz)} "
+            f"{COMP}/binary-{ARCH}/Packages.gz\n"
+        )
+
     release = (
         f"Origin: Upstream\nSuite: {DIST}\nCodename: {DIST}\nComponents: {COMP}\n"
-        f"Architectures: {ARCH}\nDate: Thu, 01 Jan 2026 00:00:00 UTC\nSHA256:\n"
-        f" {sha(packages).hexdigest()} {len(packages)} {COMP}/binary-{ARCH}/Packages\n"
-        f" {sha(packages_gz).hexdigest()} {len(packages_gz)} {COMP}/binary-{ARCH}/Packages.gz\n"
+        f"Architectures: {ARCH}\nDate: Thu, 01 Jan 2026 00:00:00 UTC\nSHA256:\n" + "".join(lines)
     )
     (root / "dists" / DIST / "Release").write_text(release, encoding="utf-8")
 
@@ -299,3 +321,37 @@ def test_apt_arch_all_visible_to_real_client(tmp_path, serve, chantal_env):
         f"stderr={ok.stderr.decode()[-800:]}"
     )
     assert b"archall-readme-marker" in ok.stdout
+
+
+@requires_docker
+def test_apt_xz_only_repo_installs(tmp_path, serve, chantal_env):
+    """A repo whose Release advertises only Packages.xz still mirrors and
+    installs (previously such repos synced zero packages)."""
+    deb = _build_real_deb()
+    upstream = tmp_path / "upstream"
+    _build_binary_upstream(upstream, deb, compression="xz")
+
+    chantal_env.write_config(
+        {
+            "id": "xz-apt",
+            "name": "Xz apt",
+            "type": "apt",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {"distribution": DIST, "components": [COMP], "architectures": [ARCH]},
+        }
+    )
+    target = chantal_env.sync_and_publish("xz-apt")
+    assert list(target.rglob("hello-chantal_1.0_amd64.deb")), "xz-only repo synced 0 packages"
+
+    ok = _client(
+        target,
+        f'echo "deb [trusted=yes] file:/repo {DIST} {COMP}" > /etc/apt/sources.list.d/c.list; '
+        "apt-get update; apt-get install -y hello-chantal; hello-chantal",
+    )
+    assert ok.returncode == 0, (
+        f"xz-only repo install failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-hello-chantal" in ok.stdout

--- a/tests/test_apt_compression_variants.py
+++ b/tests/test_apt_compression_variants.py
@@ -1,0 +1,108 @@
+"""Tests for APT index compression-variant selection and decompression.
+
+A repository whose Release advertises a non-gzip Packages index (xz, bz2, zst
+or uncompressed) must still be mirrored. Previously only ``Packages.gz`` was
+recognised, so such repos synced zero packages.
+"""
+
+from __future__ import annotations
+
+import bz2
+import gzip
+import lzma
+
+import pytest
+
+from chantal.core.config import RepositoryConfig
+from chantal.plugins.apt.sync import (
+    AptSyncPlugin,
+    _decompress_index,
+    _pick_index_variant,
+)
+
+
+def test_pick_index_variant_prefers_gz_then_falls_back():
+    assert _pick_index_variant("c/binary-amd64/Packages", {"c/binary-amd64/Packages.gz": 1}) == (
+        "c/binary-amd64/Packages.gz"
+    )
+    # Only xz present -> xz is selected (the bug: previously skipped).
+    assert _pick_index_variant("c/binary-amd64/Packages", {"c/binary-amd64/Packages.xz": 1}) == (
+        "c/binary-amd64/Packages.xz"
+    )
+    # Uncompressed only.
+    assert _pick_index_variant("c/binary-amd64/Packages", {"c/binary-amd64/Packages": 1}) == (
+        "c/binary-amd64/Packages"
+    )
+    # gz preferred over xz when both present.
+    both = {"c/binary-amd64/Packages.gz": 1, "c/binary-amd64/Packages.xz": 1}
+    assert _pick_index_variant("c/binary-amd64/Packages", both) == "c/binary-amd64/Packages.gz"
+    # Nothing present.
+    assert _pick_index_variant("c/binary-amd64/Packages", {}) is None
+
+
+def test_decompress_index_by_suffix():
+    payload = b"Package: demo\nVersion: 1.0\n\n"
+    assert _decompress_index(gzip.compress(payload), "main/binary-amd64/Packages.gz") == payload
+    assert _decompress_index(lzma.compress(payload), "main/binary-amd64/Packages.xz") == payload
+    assert _decompress_index(bz2.compress(payload), "main/binary-amd64/Packages.bz2") == payload
+    # Uncompressed (no suffix) is returned as-is.
+    assert _decompress_index(payload, "main/binary-amd64/Packages") == payload
+
+
+def test_decompress_index_zst_streaming_frame():
+    """zstd frames without an embedded content size (streaming producers) must
+    still decompress (the one-shot API would raise on these)."""
+    zstd = pytest.importorskip("zstandard")
+    payload = b"Package: demo\nVersion: 1.0\n\n"
+    # stream_writer produces a frame without a content-size header.
+    import io
+
+    buf = io.BytesIO()
+    with zstd.ZstdCompressor().stream_writer(buf, closefd=False) as w:
+        w.write(payload)
+    assert _decompress_index(buf.getvalue(), "main/binary-amd64/Packages.zst") == payload
+
+
+def _plugin(tmp_path):
+    from chantal.core.config import StorageConfig
+    from chantal.core.storage import StorageManager
+
+    (tmp_path / "pool").mkdir()
+    storage = StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(tmp_path / "pool"),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+    config = RepositoryConfig(
+        id="u",
+        name="U",
+        type="apt",
+        feed="http://example.com/ubuntu",
+        apt={"distribution": "jammy", "components": ["main"], "architectures": ["amd64"]},
+    )
+    return AptSyncPlugin(storage=storage, config=config)
+
+
+@pytest.mark.parametrize("ext", [".gz", ".xz", ".bz2", ".zst", ""])
+def test_build_metadata_file_list_finds_any_variant(ext, tmp_path):
+    """An xz-only (or any-variant) Release still yields a Packages entry."""
+    plugin = _plugin(tmp_path)
+    path = f"main/binary-amd64/Packages{ext}"
+    release_metadata = {
+        "components": ["main"],
+        "architectures": ["amd64"],
+        "sha256": {path: ("deadbeef", 123)},
+    }
+    files = plugin._build_metadata_file_list(release_metadata, mode="filtered")
+    packages = [m for m in files if m.file_type == "Packages"]
+    assert len(packages) == 1, f"variant {ext!r} not selected"
+    assert packages[0].relative_path == path
+
+
+def test_build_metadata_file_list_empty_when_no_packages(tmp_path):
+    plugin = _plugin(tmp_path)
+    release_metadata = {"components": ["main"], "architectures": ["amd64"], "sha256": {}}
+    files = plugin._build_metadata_file_list(release_metadata, mode="filtered")
+    assert not [m for m in files if m.file_type == "Packages"]


### PR DESCRIPTION
## The bug

`_build_metadata_file_list` hardcoded `Packages.gz` / `Sources.gz`. A repository whose `Release` advertises only `Packages.xz` (or `.bz2`/`.zst`/uncompressed) was **silently skipped — it mirrored zero packages**, with no error. Two index parse sites also hardcoded `gzip.decompress`.

## The fix

- Probe the compression variants the `Release` actually lists (`.gz` → `.xz` → `.bz2` → `.zst` → uncompressed) and pick the first present, threading the real suffix through download → storage → parse. The parse now decompresses by suffix (`_decompress_index`).
- Harden the shared zstd decompressor (`rpm.modules.decompress_bytes`, also used by apt) to use the **streaming reader**, so zstd frames without an embedded content size decompress correctly — the one-shot API raised on those, which would have made `.zst` indices (and RPM `.zst` metadata) silently fail the same way.

## Tests

- `tests/test_apt_compression_variants.py`: variant-selection priority, per-suffix decompression (incl. a **content-size-less zstd frame**), and `_build_metadata_file_list` selecting any variant (the `.xz`-only case produced **zero** entries before).
- `tests/e2e/...`: `_build_binary_upstream` gained an `xz` mode; new `test_apt_xz_only_repo_installs` mirrors an **xz-only** upstream and `apt-get install`s it with real apt.

Fresh-context review confirmed the fix is correct and complete (and flagged the zstd streaming caveat, now fixed). gz repos behave identically; full gate + rpm zstd e2e + apt e2e green.