### PR TITLE
fix(rpm): correct repomd open-checksum for xz metadata

### DIFF
--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -633,30 +633,16 @@ class RpmPublisher(PublisherPlugin):
                 file_sha256 = hashlib.sha256(file_data).hexdigest()
                 file_size = len(file_data)
 
-            # Calculate checksum of uncompressed file (if compressed)
+            # Checksum/size of the uncompressed payload. dnf decompresses the
+            # metadata and verifies it against open-checksum/open-size, so this
+            # must describe the decompressed bytes for every supported format
+            # (gz/xz/bz2/zst); uncompressed files use the file values as-is.
             try:
-                if file_path.suffix == ".gz":
-                    with gzip.open(file_path, "rb") as f:
-                        open_data = f.read()
-                        open_sha256 = hashlib.sha256(open_data).hexdigest()
-                        open_size = len(open_data)
-                elif file_path.suffix == ".zst":
-                    import zstandard as zstd
-
-                    dctx = zstd.ZstdDecompressor()
-                    open_data = dctx.decompress(file_data)
-                    open_sha256 = hashlib.sha256(open_data).hexdigest()
-                    open_size = len(open_data)
-                elif file_path.suffix == ".bz2":
-                    open_data = bz2.decompress(file_data)
-                    open_sha256 = hashlib.sha256(open_data).hexdigest()
-                    open_size = len(open_data)
-                else:
-                    # Not compressed
-                    open_sha256 = file_sha256
-                    open_size = file_size
+                open_data = decompress_bytes(file_data, file_path.suffix)
+                open_sha256 = hashlib.sha256(open_data).hexdigest()
+                open_size = len(open_data)
             except Exception:
-                # If decompression fails, use compressed values
+                # If decompression fails, fall back to the compressed values.
                 open_sha256 = file_sha256
                 open_size = file_size
 

--- a/tests/e2e/test_rpm_features_real_client_e2e.py
+++ b/tests/e2e/test_rpm_features_real_client_e2e.py
@@ -61,7 +61,7 @@ printf 'Name: demo-app\nVersion: 1.0\nRelease: 1\nSummary: demo-app\nLicense: MI
 rpmbuild --define "_topdir /rb" -bb /rb/SPECS/demo-app.spec >/dev/null 2>&1
 cp /rb/RPMS/noarch/*.rpm /up/
 rpm --define "_gpg_name EMAIL" --addsign /up/*.rpm >/dev/null 2>&1
-createrepo_c /up >/dev/null 2>&1
+createrepo_c CREATEREPO_FLAGS /up >/dev/null 2>&1
 gpg --batch --yes --detach-sign --armor -o /up/repodata/repomd.xml.asc /up/repodata/repomd.xml
 tar -cf - -C /up . | base64 | tr -d '\n'
 echo ===KEY===
@@ -69,10 +69,15 @@ gpg --armor --export EMAIL | base64 | tr -d '\n'
 """.replace("EMAIL", _EMAIL)
 
 
-def _build_signed_upstream(root: Path) -> str:
-    """Build a signed upstream repo into ``root``; return the armored public key."""
+def _build_signed_upstream(root: Path, *, createrepo_flags: str = "") -> str:
+    """Build a signed upstream repo into ``root``; return the armored public key.
+
+    ``createrepo_flags`` is injected into the createrepo_c invocation, e.g.
+    ``--general-compress-type=xz`` to produce xz-compressed metadata.
+    """
+    script = _BUILD_SCRIPT.replace("CREATEREPO_FLAGS", createrepo_flags)
     out = subprocess.run(
-        ["docker", "run", "--rm", _IMAGE, "bash", "-c", _BUILD_SCRIPT],
+        ["docker", "run", "--rm", _IMAGE, "bash", "-c", script],
         capture_output=True,
         timeout=600,
     )
@@ -336,3 +341,41 @@ def test_rpm_dependency_metadata_preserved(mode, tmp_path, serve, chantal_env):
         f"stdout={res.stdout.decode()[-800:]}\nstderr={res.stderr.decode()[-800:]}"
     )
     assert b"hello-from-demo-lib" in res.stdout, "demo-lib (dependency) was not installed"
+
+
+@requires_docker
+def test_rpm_xz_metadata_makecache_and_install(tmp_path, serve, chantal_env):
+    """An upstream with xz-compressed metadata, filtered + republished, must
+    yield a valid repomd (correct open-checksum for the xz filelists/other) so
+    real dnf accepts it and installs."""
+    upstream = tmp_path / "upstream"
+    _build_signed_upstream(upstream, createrepo_flags="--general-compress-type=xz")
+    assert list(upstream.glob("repodata/*filelists.xml.xz")), "upstream is not xz-compressed"
+
+    chantal_env.write_config(
+        {
+            "id": "xzmeta",
+            "name": "Xz metadata",
+            "type": "rpm",
+            "feed": serve(upstream),
+            "enabled": True,
+            "mode": "filtered",
+            "filters": {"patterns": {"include": ["^demo-keep$"]}},
+        }
+    )
+    target = chantal_env.sync_and_publish("xzmeta")
+    assert list(target.glob("repodata/*filelists.xml.xz")), "published filelists is not xz"
+
+    ok = _dnf(
+        target,
+        _repo_file(gpgcheck=0, repo_gpgcheck=0, gpgkey=None)
+        # makecache validates every data entry's open-checksum (incl. the xz
+        # filelists/other) before install.
+        + "dnf -y makecache >/dev/null && dnf install -y demo-keep >/dev/null; "
+        + "cat /usr/share/demo-keep/README",
+    )
+    assert ok.returncode == 0, (
+        f"xz-metadata repo failed in real dnf:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+    assert b"hello-from-demo-keep" in ok.stdout

--- a/tests/test_rpm_repomd_open_checksum.py
+++ b/tests/test_rpm_repomd_open_checksum.py
@@ -1,0 +1,76 @@
+"""Regression test: repomd.xml open-checksum/open-size must describe the
+*decompressed* metadata for every supported compression — notably ``.xz``,
+which was previously unhandled and got the compressed checksum (so dnf rejected
+the repository's filtered ``.xz`` filelists/other).
+"""
+
+from __future__ import annotations
+
+import bz2
+import gzip
+import hashlib
+import lzma
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from chantal.core.config import StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.plugins.rpm.publisher import RpmPublisher
+
+_NS = "http://linux.duke.edu/metadata/repo"
+
+
+@pytest.fixture
+def publisher():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "pool").mkdir()
+        storage = StorageManager(
+            StorageConfig(
+                base_path=str(tmp),
+                pool_path=str(tmp / "pool"),
+                published_path=str(tmp / "published"),
+            )
+        )
+        yield RpmPublisher(storage=storage)
+
+
+def _compress(payload: bytes, ext: str) -> bytes:
+    if ext == ".gz":
+        return gzip.compress(payload)
+    if ext == ".xz":
+        return lzma.compress(payload)
+    if ext == ".bz2":
+        return bz2.compress(payload)
+    if ext == ".zst":
+        import zstandard as zstd
+
+        return zstd.ZstdCompressor().compress(payload)
+    return payload
+
+
+@pytest.mark.parametrize("ext", [".gz", ".xz", ".bz2", ".zst", ""])
+def test_repomd_open_checksum_describes_decompressed(ext, tmp_path, publisher):
+    repodata = tmp_path / "repodata"
+    repodata.mkdir()
+    payload = b"<filelists packages='1'><package/></filelists>\n"
+    compressed = _compress(payload, ext)
+    fl = repodata / f"filelists.xml{ext}"
+    fl.write_bytes(compressed)
+
+    publisher._generate_repomd_xml(repodata, [("filelists", fl)])
+
+    root = ET.fromstring((repodata / "repomd.xml").read_text())
+    data = next(d for d in root.findall(f"{{{_NS}}}data") if d.get("type") == "filelists")
+    checksum = data.find(f"{{{_NS}}}checksum").text
+    open_checksum = data.find(f"{{{_NS}}}open-checksum").text
+    open_size = int(data.find(f"{{{_NS}}}open-size").text)
+
+    # <checksum> is over the compressed file; <open-checksum>/<open-size> over
+    # the decompressed payload (== file for the uncompressed case).
+    assert checksum == hashlib.sha256(compressed).hexdigest()
+    assert open_checksum == hashlib.sha256(payload).hexdigest()
+    assert open_size == len(payload)


### PR DESCRIPTION
## The bug

`_generate_repomd_xml` computed the repomd `open-checksum`/`open-size` for `.gz`, `.zst` and `.bz2` metadata but had **no `.xz` branch**, so xz-compressed `filelists`/`other` (common on EL7/EL8) fell through to the 'uncompressed' case and were described by their **compressed** checksum and size. dnf decompresses the metadata and verifies it against `open-checksum`, so it **rejected the repository as corrupt**.

## The fix

Compute the open values via the shared `decompress_bytes` helper (gz/xz/bz2/zst + uncompressed, unified), fixing the missing `.xz` case in one block.

## Tests

- `tests/test_rpm_repomd_open_checksum.py`: parametrized over `.gz/.xz/.bz2/.zst`/uncompressed — asserts `<checksum>` is over the compressed file and `<open-checksum>`/`<open-size>` over the **decompressed** payload. Confirmed to **fail on the old code for `.xz`**.
- A real-dnf e2e filters and republishes an **xz-metadata** upstream (`createrepo_c --general-compress-type=xz`) and asserts `dnf makecache` (which validates `open-checksum`) plus install succeed.

Full RPM e2e + gate green.