### PR TITLE
fix(downloader): send proxy credentials to the proxy, not upstream

### DIFF
--- a/src/chantal/core/downloader.py
+++ b/src/chantal/core/downloader.py
@@ -12,6 +12,7 @@ import hashlib
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import requests
 
@@ -22,6 +23,26 @@ from chantal.core.config import (
     RepositoryConfig,
     SSLConfig,
 )
+
+
+def _proxy_url_with_auth(url: str, username: str | None, password: str | None) -> str:
+    """Embed proxy credentials into the proxy URL.
+
+    Credentials belong in the proxy URL so ``requests`` sends them as
+    ``Proxy-Authorization`` to the proxy. Setting ``session.auth`` instead would
+    send them as ``Authorization`` to the *destination* host (leaking the proxy
+    credentials upstream) and would be overwritten by repository basic auth.
+    """
+    if not (username and password):
+        return url
+    parts = urlsplit(url)
+    if parts.username:  # already carries credentials
+        return url
+    host = parts.hostname or ""
+    netloc = f"{quote(username, safe='')}:{quote(password, safe='')}@{host}"
+    if parts.port:
+        netloc += f":{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
 @dataclass
@@ -104,18 +125,22 @@ class RequestsBackend(DownloadBackend):
         """
         session = requests.Session()
 
-        # Setup proxy
+        # Setup proxy. Proxy credentials go into the proxy URL (sent to the
+        # proxy as Proxy-Authorization), never on session.auth (which would be
+        # sent to the destination host, leaking the proxy credentials upstream).
         if self.proxy_config:
+            username = self.proxy_config.username
+            password = self.proxy_config.password
             proxies = {}
             if self.proxy_config.http_proxy:
-                proxies["http"] = self.proxy_config.http_proxy
+                proxies["http"] = _proxy_url_with_auth(
+                    self.proxy_config.http_proxy, username, password
+                )
             if self.proxy_config.https_proxy:
-                proxies["https"] = self.proxy_config.https_proxy
+                proxies["https"] = _proxy_url_with_auth(
+                    self.proxy_config.https_proxy, username, password
+                )
             session.proxies.update(proxies)
-
-            # Basic auth for proxy if needed
-            if self.proxy_config.username and self.proxy_config.password:
-                session.auth = (self.proxy_config.username, self.proxy_config.password)
 
         # Setup SSL/TLS verification
         if self.ssl_config:

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -1,0 +1,70 @@
+"""Tests for proxy credential handling in the download manager.
+
+Proxy credentials must go into the proxy URL (sent to the proxy as
+Proxy-Authorization), never onto ``session.auth`` (which would be sent to the
+destination host, leaking the proxy credentials upstream, and would be
+overwritten by repository basic auth).
+"""
+
+from __future__ import annotations
+
+from chantal.core.config import AuthConfig, ProxyConfig, RepositoryConfig
+from chantal.core.downloader import DownloadManager, _proxy_url_with_auth
+
+
+def test_proxy_url_with_auth_embeds_credentials():
+    assert (
+        _proxy_url_with_auth("http://proxy.example.com:8080", "user", "pass")
+        == "http://user:pass@proxy.example.com:8080"
+    )
+    # No credentials -> unchanged.
+    assert _proxy_url_with_auth("http://proxy:8080", None, None) == "http://proxy:8080"
+    # Already-credentialed URL -> unchanged.
+    assert _proxy_url_with_auth("http://a:b@proxy:8080", "user", "pass") == "http://a:b@proxy:8080"
+    # Special characters are percent-encoded.
+    assert (
+        _proxy_url_with_auth("http://proxy:8080", "u@ser", "p:ss/word")
+        == "http://u%40ser:p%3Ass%2Fword@proxy:8080"
+    )
+
+
+def _manager(proxy: ProxyConfig, auth: AuthConfig | None = None) -> DownloadManager:
+    config = RepositoryConfig(
+        id="r", name="R", type="rpm", feed="http://upstream.example.com/repo", auth=auth
+    )
+    return DownloadManager(config=config, proxy_config=proxy)
+
+
+def test_proxy_credentials_go_into_proxy_url_not_session_auth():
+    proxy = ProxyConfig(
+        http_proxy="http://proxy:8080",
+        https_proxy="http://proxy:8080",
+        username="puser",
+        password="ppass",
+    )
+    mgr = _manager(proxy)
+    session = mgr.session
+
+    # Credentials are carried by the proxy URLs (-> Proxy-Authorization).
+    assert session.proxies["http"] == "http://puser:ppass@proxy:8080"
+    assert session.proxies["https"] == "http://puser:ppass@proxy:8080"
+    # NOT on session.auth (which would leak to the destination host).
+    assert session.auth is None
+
+
+def test_repo_basic_auth_coexists_with_proxy_auth():
+    proxy = ProxyConfig(http_proxy="http://proxy:8080", username="puser", password="ppass")
+    auth = AuthConfig(type="basic", username="repouser", password="repopass")
+    mgr = _manager(proxy, auth)
+    session = mgr.session
+
+    # Proxy creds in the proxy URL; repository creds on session.auth — no clash.
+    assert session.proxies["http"] == "http://puser:ppass@proxy:8080"
+    assert session.auth == ("repouser", "repopass")
+
+
+def test_proxy_without_credentials_is_unchanged():
+    proxy = ProxyConfig(http_proxy="http://proxy:8080")
+    mgr = _manager(proxy)
+    assert mgr.session.proxies["http"] == "http://proxy:8080"
+    assert mgr.session.auth is None


### PR DESCRIPTION
## The bug

Proxy basic-auth credentials were assigned to `session.auth`, which `requests` sends as an `Authorization` header to the **destination** host. That:
- broke proxy authentication (proxies expect `Proxy-Authorization`),
- **leaked the proxy credentials to the upstream repository**, and
- was silently overwritten when the repository itself used `type: basic` auth (its `session.auth` clobbered the proxy creds).

## The fix

Embed the proxy credentials in the **proxy URL** (`http://user:pass@proxy:8080`), so `requests` sends them as `Proxy-Authorization` to the proxy. `session.auth` is left free for repository authentication, so the two no longer conflict. Credentials are percent-encoded for safe URL inclusion.

## Tests

`tests/test_proxy_auth.py`: credentials land in the proxy URL (not `session.auth`), repository basic auth coexists with proxy auth, special characters are percent-encoded, and a credential-less proxy is unchanged.

Full gate green.