### PR TITLE
fix(config): validate views, normalize filters, reject unknown keys

### DIFF
--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -248,23 +248,6 @@
           ],
           "default": null,
           "title": "Headers"
-        },
-        "verify_ssl": {
-          "default": true,
-          "title": "Verify Ssl",
-          "type": "boolean"
-        },
-        "ca_bundle": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Ca Bundle"
         }
       },
       "required": [
@@ -872,6 +855,7 @@
       "type": "object"
     },
     "RepositoryConfig": {
+      "additionalProperties": false,
       "description": "Repository configuration.",
       "properties": {
         "id": {
@@ -1516,6 +1500,7 @@
       "type": "object"
     }
   },
+  "additionalProperties": false,
   "description": "Global Chantal configuration.",
   "properties": {
     "database": {

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -11,7 +11,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ProxyConfig(BaseModel):
@@ -61,9 +61,8 @@ class AuthConfig(BaseModel):
     # Custom HTTP headers
     headers: dict[str, str] | None = None  # e.g., {"X-API-Key": "secret"}
 
-    # SSL/TLS verification
-    verify_ssl: bool = True  # Verify SSL certificates (set False to disable)
-    ca_bundle: str | None = None  # Path to CA bundle for custom CAs
+    # NOTE: SSL/TLS verification is configured under the repository's `ssl:`
+    # section (SSLConfig), not here.
 
 
 class RetentionConfig(BaseModel):
@@ -484,19 +483,23 @@ class FilterConfig(BaseModel):
         """Validate that only appropriate plugin-specific filters are used.
 
         Args:
-            repo_type: Repository type (rpm, deb, etc.)
+            repo_type: Repository type (rpm, apt, etc.)
 
         Raises:
             ValueError: If incompatible filters are specified
         """
         if repo_type == "rpm" and self.deb is not None:
             raise ValueError("Cannot use 'deb' filters with RPM repository")
-        if repo_type == "deb" and self.rpm is not None:
-            raise ValueError("Cannot use 'rpm' filters with DEB repository")
+        if repo_type == "apt" and self.rpm is not None:
+            raise ValueError("Cannot use 'rpm' filters with APT repository")
 
 
 class RepositoryConfig(BaseModel):
     """Repository configuration."""
+
+    # Reject unknown keys so a typo (e.g. `enabledd: true`) fails loudly at load
+    # time instead of being silently ignored.
+    model_config = ConfigDict(extra="forbid")
 
     id: str
     name: str | None = None
@@ -722,6 +725,9 @@ class DownloadConfig(BaseModel):
 class GlobalConfig(BaseModel):
     """Global Chantal configuration."""
 
+    # Reject unknown top-level keys so config typos fail loudly at load time.
+    model_config = ConfigDict(extra="forbid")
+
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     storage: StorageConfig = Field(default_factory=StorageConfig)
     cache: CacheConfig | None = Field(default_factory=CacheConfig)
@@ -737,6 +743,24 @@ class GlobalConfig(BaseModel):
 
     # Include pattern for additional config files
     include: str | None = None
+
+    @model_validator(mode="after")
+    def validate_repositories_and_views(self) -> GlobalConfig:
+        """Normalize/validate repository filters and validate views at load time.
+
+        - Migrate legacy flat filters to the structured form for every repo
+          (previously only the RPM plugin did this, so APT silently ignored
+          legacy ``include_packages``/``exclude_packages``).
+        - Reject plugin-specific filters used with the wrong repository type.
+        - Reject views that reference unknown repositories or mix repo types.
+        """
+        for repo in self.repositories:
+            if repo.filters is not None:
+                repo.filters = repo.filters.normalize()
+                repo.filters.validate_for_repo_type(repo.type)
+        for view in self.views:
+            view.validate_repos(self.repositories)
+        return self
 
     def get_repository(self, repo_id: str) -> RepositoryConfig | None:
         """Get repository configuration by ID."""

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,100 @@
+"""Tests for global config validation: extra-key rejection, view validation,
+filter type checks, and legacy filter normalization."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from chantal.core.config import GlobalConfig, RepositoryConfig
+
+
+def _repo(**kw):
+    base = {"id": "r", "type": "rpm", "feed": "http://x", "mode": "mirror"}
+    base.update(kw)
+    return base
+
+
+def test_unknown_key_on_repository_is_rejected():
+    with pytest.raises(ValidationError, match="enabledd|Extra inputs"):
+        RepositoryConfig(**_repo(enabledd=True))
+
+
+def test_unknown_top_level_key_is_rejected():
+    with pytest.raises(ValidationError, match="databse|Extra inputs"):
+        GlobalConfig(databse={"url": "sqlite://"})
+
+
+def test_view_referencing_unknown_repo_is_rejected():
+    with pytest.raises(ValidationError, match="unknown repository"):
+        GlobalConfig(
+            repositories=[_repo(id="a")],
+            views=[{"name": "v", "repos": ["a", "missing"]}],
+        )
+
+
+def test_view_mixing_repo_types_is_rejected():
+    with pytest.raises(ValidationError, match="different types"):
+        GlobalConfig(
+            repositories=[
+                _repo(id="a", type="rpm"),
+                _repo(id="b", type="apt", apt={"distribution": "jammy"}),
+            ],
+            views=[{"name": "v", "repos": ["a", "b"]}],
+        )
+
+
+def test_valid_view_loads():
+    cfg = GlobalConfig(
+        repositories=[_repo(id="a", type="rpm"), _repo(id="b", type="rpm")],
+        views=[{"name": "v", "repos": ["a", "b"]}],
+    )
+    assert cfg.views[0].repos == ["a", "b"]
+
+
+def test_rpm_filter_on_apt_repo_is_rejected():
+    with pytest.raises(ValidationError, match="Cannot use 'rpm' filters with APT"):
+        GlobalConfig(
+            repositories=[
+                _repo(
+                    id="a",
+                    type="apt",
+                    mode="filtered",
+                    apt={"distribution": "jammy"},
+                    filters={"rpm": {"vendors": {"include": ["X"]}}},
+                )
+            ]
+        )
+
+
+def test_deb_filter_on_rpm_repo_is_rejected():
+    with pytest.raises(ValidationError, match="Cannot use 'deb' filters with RPM"):
+        GlobalConfig(
+            repositories=[
+                _repo(
+                    id="a",
+                    type="rpm",
+                    mode="filtered",
+                    filters={"deb": {"components": {"include": ["main"]}}},
+                )
+            ]
+        )
+
+
+def test_legacy_flat_filters_are_normalized_for_apt():
+    """Legacy include_packages must be migrated into patterns so APT honors it."""
+    cfg = GlobalConfig(
+        repositories=[
+            _repo(
+                id="a",
+                type="apt",
+                mode="filtered",
+                apt={"distribution": "jammy"},
+                filters={"include_packages": ["^nginx.*"], "exclude_packages": ["-dbg$"]},
+            )
+        ]
+    )
+    patterns = cfg.repositories[0].filters.patterns
+    assert patterns is not None
+    assert patterns.include == ["^nginx.*"]
+    assert patterns.exclude == ["-dbg$"]


### PR DESCRIPTION
Addresses a cluster of silent config footguns from the final review.

## What was silently broken

- **Views were never validated.** `ViewConfig.validate_repos` existed but had **no caller**, so a view referencing an unknown repository (or mixing repo types) was accepted and only blew up later at publish time.
- **Legacy flat filters ignored for APT.** `include_packages`/`exclude_packages` were normalized only by the RPM plugin, so APT silently applied **no** filtering.
- **Dead filter type-check.** `FilterConfig.validate_for_repo_type` checked `repo_type == 'deb'` (types are rpm/apt/helm/apk), so `rpm` filters on an APT repo were never rejected.
- **Typo'd keys silently dropped.**
- **`AuthConfig.verify_ssl`/`ca_bundle` never consumed** (SSL lives under `ssl:`), misleading users.

## The fix

- New `GlobalConfig` model_validator: normalizes each repo's filters, validates them against the repo type, and validates every view **at load time**.
- Fixed the dead `'deb'` branch → `'apt'`.
- `extra='forbid'` on `GlobalConfig` + `RepositoryConfig` so typos fail loudly (forward-compat metadata models keep `extra='allow'`).
- Removed the dead `AuthConfig` SSL fields; regenerated the JSON schema.

## Tests / safety

New `tests/test_config_validation.py` covers each behavior (typo rejected, unknown-repo & mixed-type views rejected, rpm-filter-on-apt & deb-filter-on-rpm rejected, legacy filters normalized for APT). All 38 bundled example configs still load; schema in sync; full gate green. Fresh-context review: ships safely.

One of the four remaining clean-up items; the other three (honest stats, `db cleanup --unreferenced`, atomic publish) follow as separate PRs.