### PR TITLE
feat(stats): report real numbers in 'stats' and 'db stats'

### DIFF
--- a/src/chantal/cli/db_commands.py
+++ b/src/chantal/cli/db_commands.py
@@ -407,16 +407,40 @@ def create_db_group(cli: click.Group) -> click.Group:
     @click.pass_context
     def db_stats(ctx: click.Context) -> None:
         """Show database statistics."""
-        click.echo("Database Statistics:")
-        click.echo("TODO: Query database statistics")
-        click.echo()
-        click.echo("Expected output:")
-        click.echo("  Total Packages: 8,320")
-        click.echo("  Referenced Packages: 8,273 (99%)")
-        click.echo("  Unreferenced Packages: 47 (1%, 450 MB)")
-        click.echo("  Total Repositories: 5")
-        click.echo("  Total Snapshots: 23")
-        click.echo("  Database Size: 245 MB")
+        from sqlalchemy.exc import OperationalError
+
+        from chantal.core.stats import (
+            format_bytes,
+            gather_global_stats,
+            unreferenced_content_items,
+        )
+
+        config: GlobalConfig = ctx.obj["config"]
+        db_manager = DatabaseManager(config.database.url)
+        session = db_manager.get_session()
+        try:
+            s = gather_global_stats(session)
+            unref = unreferenced_content_items(session)
+            unref_count = unref.count()
+            unref_bytes = sum(item.size_bytes for item in unref) if unref_count else 0
+            total = s["content_items"]
+            referenced = total - unref_count
+
+            click.echo("Database Statistics:")
+            click.echo(f"  Total Packages: {total:,}")
+            for ctype, count in sorted(s["by_type"].items()):
+                click.echo(f"    {ctype}: {count:,}")
+            ref_pct = (referenced / total * 100) if total else 0
+            click.echo(f"  Referenced Packages: {referenced:,} ({ref_pct:.0f}%)")
+            click.echo(f"  Unreferenced Packages: {unref_count:,} ({format_bytes(unref_bytes)})")
+            click.echo(f"  Total Repositories: {s['repositories']:,}")
+            click.echo(f"  Total Snapshots: {s['snapshots']:,}")
+            click.echo(f"  Pool Size on Disk: {format_bytes(s['pool_bytes'])}")
+        except OperationalError:
+            click.echo("Database not initialized. Run 'chantal db init' first.", err=True)
+            ctx.exit(1)
+        finally:
+            session.close()
 
     @db.command("verify")
     @click.pass_context

--- a/src/chantal/cli/main.py
+++ b/src/chantal/cli/main.py
@@ -76,19 +76,46 @@ def cli(ctx: click.Context, config: Path | None, verbose: bool) -> None:
 @click.pass_context
 def stats(ctx: click.Context, repo_id: str) -> None:
     """Show repository and package statistics."""
-    if repo_id:
-        click.echo(f"Statistics for repository: {repo_id}")
-        click.echo("TODO: Query repository-specific statistics")
-    else:
-        click.echo("Global Statistics:")
-        click.echo("TODO: Query global statistics")
-    click.echo()
-    click.echo("Expected output:")
-    click.echo("  Total Repositories: 5")
-    click.echo("  Total Packages: 12,450")
-    click.echo("  Deduplicated: 8,320 (33% savings)")
-    click.echo("  Total Size on Disk: 18.5 GB")
-    click.echo("  Total Snapshots: 23")
+    from sqlalchemy.exc import OperationalError
+
+    from chantal.core.stats import (
+        format_bytes,
+        gather_global_stats,
+        gather_repository_stats,
+    )
+    from chantal.db.connection import DatabaseManager
+
+    config: GlobalConfig = ctx.obj["config"]
+    db_manager = DatabaseManager(config.database.url)
+    try:
+        with db_manager.session() as session:
+            if repo_id:
+                s = gather_repository_stats(session, repo_id)
+                if s is None:
+                    click.echo(f"Repository '{repo_id}' not found in the database.", err=True)
+                    ctx.exit(1)
+                click.echo(f"Statistics for repository: {s['repo_id']} ({s['type']}, {s['mode']})")
+                click.echo(f"  Packages: {s['content_items']:,}")
+                for ctype, count in sorted(s["by_type"].items()):
+                    click.echo(f"    {ctype}: {count:,}")
+                click.echo(f"  Snapshots: {s['snapshots']:,}")
+                click.echo(f"  Size: {format_bytes(s['pool_bytes'])}")
+            else:
+                s = gather_global_stats(session)
+                click.echo("Global Statistics:")
+                click.echo(f"  Total Repositories: {s['repositories']:,}")
+                click.echo(f"  Total Packages: {s['content_items']:,}")
+                for ctype, count in sorted(s["by_type"].items()):
+                    click.echo(f"    {ctype}: {count:,}")
+                click.echo(f"  Total Snapshots: {s['snapshots']:,}")
+                click.echo(f"  Pool Size on Disk: {format_bytes(s['pool_bytes'])}")
+                click.echo(
+                    f"  Deduplication: {format_bytes(s['saved_bytes'])} saved "
+                    f"({s['dedup_pct']:.0f}%)"
+                )
+    except OperationalError:
+        click.echo("Database not initialized. Run 'chantal db init' first.", err=True)
+        ctx.exit(1)
 
 
 # ============================================================================

--- a/src/chantal/core/stats.py
+++ b/src/chantal/core/stats.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+"""
+Repository / database statistics computed from the live database.
+
+Used by ``chantal stats`` and ``chantal db stats`` so both report real numbers
+instead of placeholders.
+"""
+
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Query, Session
+
+from chantal.db.models import (
+    ContentItem,
+    Repository,
+    RepositoryFile,
+    Snapshot,
+    repository_content_items,
+    snapshot_content_items,
+)
+
+
+def unreferenced_content_items(session: Session) -> Query[ContentItem]:
+    """Query for ContentItems linked to no repository and no snapshot.
+
+    Returned as a query so callers can ``.count()``, iterate, or delete.
+    """
+    linked_to_repo = select(repository_content_items.c.content_item_id)
+    linked_to_snapshot = select(snapshot_content_items.c.content_item_id)
+    return session.query(ContentItem).filter(
+        ContentItem.id.notin_(linked_to_repo),
+        ContentItem.id.notin_(linked_to_snapshot),
+    )
+
+
+def _sum(session: Session, column: Any) -> int:
+    return int(session.query(func.coalesce(func.sum(column), 0)).scalar() or 0)
+
+
+def gather_global_stats(session: Session) -> dict:
+    """Aggregate statistics across all repositories."""
+    by_type: dict[str, int] = {
+        row[0]: row[1]
+        for row in session.query(ContentItem.content_type, func.count())
+        .group_by(ContentItem.content_type)
+        .all()
+    }
+    total_items = sum(by_type.values())
+
+    # Physical pool usage = unique content-addressed blobs (sha256 is unique).
+    content_bytes = _sum(session, ContentItem.size_bytes)
+    file_bytes = _sum(session, RepositoryFile.size_bytes)
+
+    # Logical bytes = what every repository/snapshot reference would cost if the
+    # pool were not content-addressed (each link counted separately).
+    repo_logical = int(
+        session.query(func.coalesce(func.sum(ContentItem.size_bytes), 0))
+        .select_from(repository_content_items)
+        .join(ContentItem, ContentItem.id == repository_content_items.c.content_item_id)
+        .scalar()
+        or 0
+    )
+    snap_logical = int(
+        session.query(func.coalesce(func.sum(ContentItem.size_bytes), 0))
+        .select_from(snapshot_content_items)
+        .join(ContentItem, ContentItem.id == snapshot_content_items.c.content_item_id)
+        .scalar()
+        or 0
+    )
+    logical_bytes = repo_logical + snap_logical
+    # Deduplication baseline is the unique bytes of blobs that are referenced at
+    # least once (unreferenced/GC-able blobs don't count as "saved").
+    referenced_ids = select(repository_content_items.c.content_item_id).union(
+        select(snapshot_content_items.c.content_item_id)
+    )
+    referenced_bytes = int(
+        session.query(func.coalesce(func.sum(ContentItem.size_bytes), 0))
+        .filter(ContentItem.id.in_(referenced_ids))
+        .scalar()
+        or 0
+    )
+    saved_bytes = max(0, logical_bytes - referenced_bytes)
+
+    return {
+        "repositories": session.query(Repository).count(),
+        "snapshots": session.query(Snapshot).count(),
+        "content_items": total_items,
+        "by_type": by_type,
+        "pool_bytes": content_bytes + file_bytes,
+        "logical_bytes": logical_bytes,
+        "saved_bytes": saved_bytes,
+        "dedup_pct": (saved_bytes / logical_bytes * 100) if logical_bytes else 0.0,
+    }
+
+
+def gather_repository_stats(session: Session, repo_id: str) -> dict | None:
+    """Statistics for a single repository, or ``None`` if it does not exist."""
+    repo = session.query(Repository).filter_by(repo_id=repo_id).first()
+    if repo is None:
+        return None
+
+    by_type: dict[str, int] = {}
+    total_bytes = 0
+    for item in repo.content_items:
+        by_type[item.content_type] = by_type.get(item.content_type, 0) + 1
+        total_bytes += item.size_bytes
+
+    return {
+        "repo_id": repo.repo_id,
+        "type": repo.type,
+        "mode": str(repo.mode),
+        "content_items": sum(by_type.values()),
+        "by_type": by_type,
+        "snapshots": session.query(Snapshot).filter_by(repository_id=repo.id).count(),
+        "pool_bytes": total_bytes,
+    }
+
+
+def format_bytes(num: int) -> str:
+    """Human-readable byte size."""
+    value = float(num)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} {unit}"
+        value /= 1024
+    return f"{value:.1f} TB"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,11 +72,12 @@ def test_package_show():
 
 
 def test_stats():
-    """Test stats command."""
+    """stats against an uninitialized database degrades gracefully."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["stats"])
-    assert result.exit_code == 0
-    assert "Statistics" in result.output
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["stats"])
+    assert result.exit_code == 1
+    assert "not initialized" in result.output
 
 
 def test_repo_check_updates():
@@ -92,11 +93,12 @@ def test_repo_check_updates():
 
 
 def test_db_stats():
-    """Test db stats command."""
+    """db stats against an uninitialized database degrades gracefully."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["db", "stats"])
-    assert result.exit_code == 0
-    assert "Database Statistics" in result.output
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["db", "stats"])
+    assert result.exit_code == 1
+    assert "not initialized" in result.output
 
 
 def test_db_help():

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,107 @@
+"""Tests that `chantal stats` and `chantal db stats` report real numbers."""
+
+from __future__ import annotations
+
+import yaml
+from click.testing import CliRunner
+
+from chantal.cli.main import cli
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import Base, ContentItem, Repository, Snapshot
+
+
+def _seed(db_url: str) -> None:
+    dbm = DatabaseManager(db_url)
+    Base.metadata.create_all(dbm.engine)
+    session = dbm.get_session()
+
+    repo = Repository(repo_id="r1", name="R1", type="rpm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+
+    shared = ContentItem(
+        content_type="rpm",
+        name="shared",
+        version="1.0",
+        sha256="a" * 64,
+        size_bytes=1000,
+        pool_path="aa/bb/shared.rpm",
+        filename="shared.rpm",
+        content_metadata={},
+    )
+    orphan = ContentItem(
+        content_type="rpm",
+        name="orphan",
+        version="1.0",
+        sha256="b" * 64,
+        size_bytes=500,
+        pool_path="bb/cc/orphan.rpm",
+        filename="orphan.rpm",
+        content_metadata={},
+    )
+    repo.content_items.append(shared)  # referenced; orphan is unreferenced
+    snap = Snapshot(repository_id=repo.id, name="snap-1")
+    snap.content_items.append(shared)  # shared is linked twice -> dedup savings
+    session.add_all([shared, orphan, snap])
+    session.commit()
+    session.close()
+
+
+def _config(tmp_path, db_url: str) -> str:
+    config = {
+        "database": {"url": db_url},
+        "storage": {
+            "base_path": str(tmp_path / "data"),
+            "pool_path": str(tmp_path / "data" / "pool"),
+            "published_path": str(tmp_path / "pub"),
+        },
+        "repositories": [],
+    }
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return str(p)
+
+
+def test_global_stats_reports_real_numbers(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    _seed(db_url)
+    out = CliRunner().invoke(cli, ["--config", _config(tmp_path, db_url), "stats"])
+    assert out.exit_code == 0, out.output
+    assert "TODO" not in out.output and "Expected output" not in out.output
+    assert "Total Repositories: 1" in out.output
+    assert "Total Packages: 2" in out.output
+    assert "Total Snapshots: 1" in out.output
+    # shared (1000 B) is referenced by a repo + a snapshot -> 1000 B deduplicated.
+    assert "Deduplication: 1000 B saved" in out.output
+
+
+def test_repo_stats(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    _seed(db_url)
+    out = CliRunner().invoke(
+        cli, ["--config", _config(tmp_path, db_url), "stats", "--repo-id", "r1"]
+    )
+    assert out.exit_code == 0, out.output
+    assert "Packages: 1" in out.output  # only 'shared' is linked to r1
+    assert "TODO" not in out.output
+
+
+def test_repo_stats_unknown_repo(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    _seed(db_url)
+    out = CliRunner().invoke(
+        cli, ["--config", _config(tmp_path, db_url), "stats", "--repo-id", "nope"]
+    )
+    assert out.exit_code == 1
+    assert "not found" in out.output
+
+
+def test_db_stats_reports_unreferenced(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    _seed(db_url)
+    out = CliRunner().invoke(cli, ["--config", _config(tmp_path, db_url), "db", "stats"])
+    assert out.exit_code == 0, out.output
+    assert "TODO" not in out.output and "Expected output" not in out.output
+    assert "Total Packages: 2" in out.output
+    assert "Referenced Packages: 1" in out.output
+    assert "Unreferenced Packages: 1" in out.output


### PR DESCRIPTION
## The problem

`chantal stats` and `chantal db stats` printed **fabricated placeholder figures** under a `TODO` / `Expected output` banner (e.g. "Total Packages: 12,450", "245 MB") — easy to mistake for real data.

## The fix

New `core/stats.py` derives statistics from the database:
- `chantal stats`: real repository, package (with per-type breakdown) and snapshot counts, pool size on disk, and a **deduplication** figure (bytes saved by content-addressing referenced blobs).
- `chantal stats --repo-id <id>`: per-repository numbers (or a clear not-found error).
- `chantal db stats`: totals plus **referenced / unreferenced** package counts.
- Both **degrade gracefully** with "Database not initialized. Run 'chantal db init' first." instead of a traceback.

The `unreferenced_content_items` query (items linked to no repo and no snapshot) is shared with the upcoming `db cleanup --unreferenced` work.

## Tests

`tests/test_stats.py` seeds a DB (1 repo, 2 items — one referenced + snapshotted, one orphan) and asserts the real output: Total Packages 2, Referenced 1, Unreferenced 1, "Deduplication: 1000 B saved", and that the placeholder strings are gone. The two old CLI tests now assert the graceful uninitialized-DB path (via `isolated_filesystem`).

Fresh-context review: no CRITICAL/IMPORTANT; dedup math and the NOT-IN/NULL safety verified. Full gate green.

Second of the four remaining clean-up items.