### PR TITLE
feat(db): implement 'db cleanup --unreferenced'

### DIFF
--- a/src/chantal/cli/db_commands.py
+++ b/src/chantal/cli/db_commands.py
@@ -233,19 +233,38 @@ def create_db_group(cli: click.Group) -> click.Group:
                 click.echo("Analyzing database issues...")
             click.echo()
 
+            from chantal.core.stats import format_bytes, unreferenced_content_items
+
             total_repos_deleted = 0
             total_snapshots_deleted = 0
             total_history_deleted = 0
+            total_unreferenced_deleted = 0
 
             # Get orphaned repositories (for both dry-run and confirmation)
             orphaned_repos = []
             if cleanup_orphaned:
                 orphaned_repos = _get_orphaned_repositories(session, config)
 
+            # Preview of unreferenced packages (items linked to no repository and
+            # no snapshot). Deleting orphaned repos below can orphan more, so this
+            # is a lower bound; the real run recomputes after that deletion.
+            unref_preview_count = 0
+            unref_preview_bytes = 0
+            if cleanup_unreferenced:
+                unref_q = unreferenced_content_items(session)
+                unref_preview_count = unref_q.count()
+                unref_preview_bytes = (
+                    sum(i.size_bytes for i in unref_q) if unref_preview_count else 0
+                )
+
             # Interactive confirmation (only if not dry-run and not force)
             if not dry_run and not force:
-                if orphaned_repos:
-                    # Count related objects
+                if not orphaned_repos and unref_preview_count == 0:
+                    click.echo("No cleanup needed.")
+                    return
+
+                click.echo("Will delete:")
+                if cleanup_orphaned and orphaned_repos:
                     total_snaps = sum(
                         session.query(Snapshot).filter_by(repository_id=r.id).count()
                         for r in orphaned_repos
@@ -254,22 +273,20 @@ def create_db_group(cli: click.Group) -> click.Group:
                         session.query(SyncHistory).filter_by(repository_id=r.id).count()
                         for r in orphaned_repos
                     )
+                    click.echo(f"  - {len(orphaned_repos)} orphaned repositories")
+                    click.echo(f"  - {total_snaps} snapshots")
+                    click.echo(f"  - {total_hist} sync history entries")
+                if cleanup_unreferenced and unref_preview_count:
+                    click.echo(
+                        f"  - {unref_preview_count} unreferenced packages "
+                        f"(at least {format_bytes(unref_preview_bytes)})"
+                    )
+                click.echo()
 
-                    click.echo("Will delete:")
-                    if cleanup_orphaned and orphaned_repos:
-                        click.echo(f"  - {len(orphaned_repos)} orphaned repositories")
-                        click.echo(f"  - {total_snaps} snapshots")
-                        click.echo(f"  - {total_hist} sync history entries")
-                    click.echo()
-
-                    # Ask for confirmation
-                    if not click.confirm("Delete these items?", default=False):
-                        click.echo("Aborted.")
-                        return
-                    click.echo()
-                else:
-                    click.echo("No cleanup needed.")
+                if not click.confirm("Delete these items?", default=False):
+                    click.echo("Aborted.")
                     return
+                click.echo()
 
             # Clean up orphaned repositories
             if cleanup_orphaned:
@@ -310,9 +327,30 @@ def create_db_group(cli: click.Group) -> click.Group:
                     click.echo("No orphaned repositories found.")
                     click.echo()
 
-            # Clean up unreferenced packages (TODO)
+            # Clean up unreferenced packages (recomputed: deleting orphaned repos
+            # above may have unlinked more content items).
             if cleanup_unreferenced:
-                click.echo("Unreferenced packages cleanup: TODO")
+                unref_items = unreferenced_content_items(session).all()
+                unref_count = len(unref_items)
+                unref_bytes = sum(i.size_bytes for i in unref_items)
+                if unref_count:
+                    click.echo(
+                        f"Unreferenced packages ({unref_count}, "
+                        f"{format_bytes(unref_bytes)} reclaimable from the pool):"
+                    )
+                    for item in unref_items:
+                        click.echo(f"  - {item.content_type}/{item.name}-{item.version}")
+                    if not dry_run:
+                        for item in unref_items:
+                            session.delete(item)
+                        session.commit()
+                        total_unreferenced_deleted = unref_count
+                        click.echo(
+                            "  Removed from the database. Run 'chantal pool cleanup' "
+                            "to reclaim the disk space."
+                        )
+                else:
+                    click.echo("No unreferenced packages found.")
                 click.echo()
 
             # Summary
@@ -333,12 +371,19 @@ def create_db_group(cli: click.Group) -> click.Group:
                         )
                         click.echo(f"  Would delete {total_snaps} snapshots")
                         click.echo(f"  Would delete {total_hist} sync history entries")
+                if cleanup_unreferenced:
+                    click.echo(
+                        f"  Would delete {unref_preview_count} unreferenced packages "
+                        f"(at least {format_bytes(unref_preview_bytes)})"
+                    )
             else:
                 click.echo("Summary:")
                 if cleanup_orphaned:
                     click.echo(f"  Deleted {total_repos_deleted} repositories")
                     click.echo(f"  Deleted {total_snapshots_deleted} snapshots")
                     click.echo(f"  Deleted {total_history_deleted} sync history entries")
+                if cleanup_unreferenced:
+                    click.echo(f"  Deleted {total_unreferenced_deleted} unreferenced packages")
 
         finally:
             session.close()

--- a/tests/test_db_cleanup.py
+++ b/tests/test_db_cleanup.py
@@ -99,3 +99,134 @@ def test_db_cleanup_orphaned_clears_snapshot_associations(tmp_path):
             assert rows == 0, f"orphaned rows left in {assoc}"
     finally:
         session.close()
+
+
+def _config(tmp_path, db_url, repositories=None):
+    cfg = {
+        "database": {"url": db_url},
+        "storage": {
+            "base_path": str(tmp_path / "data"),
+            "pool_path": str(tmp_path / "data" / "pool"),
+            "published_path": str(tmp_path / "published"),
+        },
+        "repositories": repositories or [],
+    }
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return str(p)
+
+
+def _seed_unreferenced(db_url):
+    """A repo with one referenced item + one truly unreferenced item."""
+    dbm = DatabaseManager(db_url)
+    Base.metadata.create_all(dbm.engine)
+    session = dbm.get_session()
+    repo = Repository(repo_id="keep", name="K", type="rpm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+    referenced = ContentItem(
+        content_type="rpm",
+        name="ref",
+        version="1",
+        sha256="a" * 64,
+        size_bytes=100,
+        pool_path="aa/ref",
+        filename="ref.rpm",
+        content_metadata={},
+    )
+    orphan = ContentItem(
+        content_type="rpm",
+        name="orphan",
+        version="1",
+        sha256="b" * 64,
+        size_bytes=200,
+        pool_path="bb/orphan",
+        filename="orphan.rpm",
+        content_metadata={},
+    )
+    repo.content_items.append(referenced)
+    session.add_all([referenced, orphan])
+    session.commit()
+    session.close()
+
+
+def test_cleanup_unreferenced_deletes_only_orphan_items(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    _seed_unreferenced(db_url)
+    # 'keep' is configured, so it is NOT an orphaned repo.
+    cfg = _config(
+        tmp_path, db_url, repositories=[{"id": "keep", "type": "rpm", "feed": "http://x"}]
+    )
+
+    result = CliRunner().invoke(
+        cli, ["--config", cfg, "db", "cleanup", "--unreferenced", "--force"]
+    )
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+    assert "TODO" not in result.output
+    assert "Deleted 1 unreferenced packages" in result.output
+
+    session = DatabaseManager(db_url).get_session()
+    try:
+        names = {c.name for c in session.query(ContentItem).all()}
+        assert names == {"ref"}, f"unexpected items: {names}"
+    finally:
+        session.close()
+
+
+def test_cleanup_unreferenced_dry_run_deletes_nothing(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    _seed_unreferenced(db_url)
+    cfg = _config(
+        tmp_path, db_url, repositories=[{"id": "keep", "type": "rpm", "feed": "http://x"}]
+    )
+
+    result = CliRunner().invoke(
+        cli, ["--config", cfg, "db", "cleanup", "--unreferenced", "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Would delete 1 unreferenced packages" in result.output
+    session = DatabaseManager(db_url).get_session()
+    try:
+        assert session.query(ContentItem).count() == 2  # nothing deleted
+    finally:
+        session.close()
+
+
+def test_full_cleanup_removes_items_orphaned_by_repo_deletion(tmp_path):
+    """Deleting an orphaned repo unlinks its snapshot's content item; the same
+    run's unreferenced pass (recomputed) must then remove that item too."""
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    _seed_orphan(db_url)  # orphan repo + snapshot linked to one content item
+    cfg = _config(tmp_path, db_url, repositories=[])  # repo is orphaned
+
+    result = CliRunner().invoke(cli, ["--config", cfg, "db", "cleanup", "--force"])
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+
+    session = DatabaseManager(db_url).get_session()
+    try:
+        assert session.query(Repository).count() == 0
+        # The content item that was only linked via the deleted snapshot is gone.
+        assert session.query(ContentItem).count() == 0
+    finally:
+        session.close()
+
+
+def test_cleanup_unreferenced_confirmation_abort(tmp_path):
+    """Without --force, answering 'n' aborts and deletes nothing."""
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    _seed_unreferenced(db_url)
+    cfg = _config(
+        tmp_path, db_url, repositories=[{"id": "keep", "type": "rpm", "feed": "http://x"}]
+    )
+
+    result = CliRunner().invoke(
+        cli, ["--config", cfg, "db", "cleanup", "--unreferenced"], input="n\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert "1 unreferenced packages" in result.output  # shown in the confirmation
+    assert "Aborted." in result.output
+    session = DatabaseManager(db_url).get_session()
+    try:
+        assert session.query(ContentItem).count() == 2  # nothing deleted
+    finally:
+        session.close()


### PR DESCRIPTION
## The problem

`chantal db cleanup --unreferenced` was a **no-op** — it printed `Unreferenced packages cleanup: TODO` while reporting success.

## The fix

Implement it: find content items linked to **no repository and no snapshot** (the `unreferenced_content_items` helper added in #101) and delete those DB records.

- Runs **after** orphaned-repository removal and **recomputes** the unreferenced set, because deleting an orphaned repo (and its snapshots, via the ORM cascade) can unlink further content items.
- The interactive confirmation and `--dry-run` now list unreferenced packages too, and no longer return early with "No cleanup needed" when only unreferenced work exists (the previous control flow would have skipped unref cleanup entirely).
- DB rows are removed here; `pool cleanup` reclaims the now-orphaned pool blobs — consistent with the existing db/pool command split.

## Tests

`tests/test_db_cleanup.py` adds: unreferenced-only deletion (referenced items preserved), `--dry-run` deletes nothing, the **combined orphan→unreferenced cascade** in one run (an item orphaned by repo deletion is cleaned in the same pass), and the interactive confirmation **abort** path.

Fresh-context review: LOOKS-GOOD; control flow, recompute-after-deletion, query safety and the pool-cleanup hand-off all verified. Full gate green.

Third of the four remaining clean-up items; atomic publish (the fourth) follows.