### PR TITLE
fix(publish): make publishing atomic via a staging swap

### DIFF
--- a/src/chantal/cli/publish_commands.py
+++ b/src/chantal/cli/publish_commands.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 """Publishing management commands."""
 
+import contextlib
 import json
+import os
 import shutil
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -22,6 +25,47 @@ from chantal.plugins.view_publisher import ViewPublisher
 
 # Click context settings to enable -h as alias for --help
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@contextlib.contextmanager
+def staged_publish(target_path: Path) -> Iterator[Path]:
+    """Publish into a staging directory, then atomically swap it into place.
+
+    Yields a staging directory (a sibling of ``target_path`` on the same
+    filesystem, so package hardlinks from the pool work and the final rename is
+    atomic). On a clean exit the staging tree replaces ``target_path``; if the
+    body raises, the existing published repository at ``target_path`` is left
+    untouched.
+    """
+    target_path = Path(target_path)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    staging = target_path.parent / f".{target_path.name}.staging-{os.getpid()}"
+    backup = target_path.parent / f".{target_path.name}.old-{os.getpid()}"
+    shutil.rmtree(staging, ignore_errors=True)
+    staging.mkdir(parents=True)
+
+    try:
+        yield staging
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    # Success: swap staging -> target_path. Move any existing tree aside first
+    # (rename cannot replace a non-empty directory), then clean it up.
+    shutil.rmtree(backup, ignore_errors=True)
+    moved = False
+    if target_path.exists():
+        os.replace(target_path, backup)
+        moved = True
+    try:
+        os.replace(staging, target_path)
+    except BaseException:
+        if moved and not target_path.exists():
+            os.replace(backup, target_path)  # restore the previous tree
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    finally:
+        shutil.rmtree(backup, ignore_errors=True)
 
 
 def create_publish_group(cli: click.Group) -> click.Group:
@@ -191,9 +235,10 @@ def create_publish_group(cli: click.Group) -> click.Group:
 
                 # Publish view from config (no DB view object needed)
                 click.echo(f"Collecting packages from {len(view_config.repos)} repositories...")
-                package_count = publisher.publish_view_from_config(
-                    session, view_config.repos, target_path
-                )
+                with staged_publish(target_path) as _stage:
+                    package_count = publisher.publish_view_from_config(
+                        session, view_config.repos, _stage
+                    )
 
                 click.echo()
                 click.echo("✓ View published successfully!")
@@ -407,9 +452,10 @@ def _publish_single_repository(
         rpm_publisher = RpmPublisher(storage=storage)
         # Publish repository
         try:
-            rpm_publisher.publish_repository(
-                session=session, repository=repository, config=repo_config, target_path=target_path
-            )
+            with staged_publish(target_path) as _stage:
+                rpm_publisher.publish_repository(
+                    session=session, repository=repository, config=repo_config, target_path=_stage
+                )
             click.echo("\n✓ Repository published successfully!")
             click.echo(f"  Location: {target_path}")
             click.echo(f"  Packages directory: {target_path}/Packages")
@@ -421,9 +467,10 @@ def _publish_single_repository(
         helm_publisher = HelmPublisher(storage=storage)
         # Publish repository
         try:
-            helm_publisher.publish_repository(
-                session=session, repository=repository, config=repo_config, target_path=target_path
-            )
+            with staged_publish(target_path) as _stage:
+                helm_publisher.publish_repository(
+                    session=session, repository=repository, config=repo_config, target_path=_stage
+                )
             click.echo("\n✓ Helm repository published successfully!")
             click.echo(f"  Location: {target_path}")
             click.echo(f"  Chart files: {target_path}/*.tgz")
@@ -438,9 +485,10 @@ def _publish_single_repository(
         apk_publisher = ApkPublisher(storage=storage)
         # Publish repository
         try:
-            apk_publisher.publish_repository(
-                session=session, repository=repository, config=repo_config, target_path=target_path
-            )
+            with staged_publish(target_path) as _stage:
+                apk_publisher.publish_repository(
+                    session=session, repository=repository, config=repo_config, target_path=_stage
+                )
             apk_config = repo_config.apk
             if apk_config is None:
                 raise ValueError("APK config is required for APK repositories")
@@ -461,9 +509,10 @@ def _publish_single_repository(
         apt_publisher = AptPublisher(storage=storage, config=repo_config)
         # Publish repository
         try:
-            apt_publisher.publish_repository(
-                session=session, repository=repository, config=repo_config, target_path=target_path
-            )
+            with staged_publish(target_path) as _stage:
+                apt_publisher.publish_repository(
+                    session=session, repository=repository, config=repo_config, target_path=_stage
+                )
             apt_config = repo_config.apt
             if apt_config is None:
                 raise ValueError("APT config is required for APT repositories")
@@ -564,13 +613,14 @@ def _publish_repository_snapshot(
             rpm_publisher = RpmPublisher(storage=storage)
             # Publish snapshot
             try:
-                rpm_publisher.publish_snapshot(
-                    session=session,
-                    snapshot=snap,
-                    repository=repository,
-                    config=repo_config,
-                    target_path=target_path,
-                )
+                with staged_publish(target_path) as _stage:
+                    rpm_publisher.publish_snapshot(
+                        session=session,
+                        snapshot=snap,
+                        repository=repository,
+                        config=repo_config,
+                        target_path=_stage,
+                    )
 
                 # Update snapshot metadata
                 snap.is_published = True
@@ -608,13 +658,14 @@ def _publish_repository_snapshot(
             apt_publisher = AptPublisher(storage=storage, config=repo_config)
             # Publish snapshot
             try:
-                apt_publisher.publish_snapshot(
-                    session=session,
-                    snapshot=snap,
-                    repository=repository,
-                    config=repo_config,
-                    target_path=target_path,
-                )
+                with staged_publish(target_path) as _stage:
+                    apt_publisher.publish_snapshot(
+                        session=session,
+                        snapshot=snap,
+                        repository=repository,
+                        config=repo_config,
+                        target_path=_stage,
+                    )
 
                 # Update snapshot metadata
                 snap.is_published = True
@@ -699,9 +750,10 @@ def _publish_view_snapshot(
 
         # Publish view snapshot
         try:
-            publisher.publish_view_snapshot(
-                session=session, view_snapshot=view_snapshot, target_path=target_path
-            )
+            with staged_publish(target_path) as _stage:
+                publisher.publish_view_snapshot(
+                    session=session, view_snapshot=view_snapshot, target_path=_stage
+                )
 
             # Update view snapshot metadata
             view_snapshot.is_published = True

--- a/tests/test_staged_publish.py
+++ b/tests/test_staged_publish.py
@@ -1,0 +1,94 @@
+"""Tests for the atomic staged_publish context manager.
+
+A failed publish must never corrupt or remove the existing published repository;
+a successful publish replaces it wholesale.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chantal.cli.publish_commands import staged_publish
+
+
+def _leftovers(parent):
+    """Staging/backup helper directories that must not be left behind."""
+    return [p.name for p in parent.iterdir() if p.name.startswith(".")]
+
+
+def test_successful_publish_into_fresh_target(tmp_path):
+    target = tmp_path / "repo"
+    with staged_publish(target) as stage:
+        (stage / "Packages").mkdir()
+        (stage / "Packages" / "a.rpm").write_text("new")
+    assert (target / "Packages" / "a.rpm").read_text() == "new"
+    assert _leftovers(tmp_path) == []  # no .staging/.old residue
+
+
+def test_failed_publish_into_fresh_target_leaves_no_repo(tmp_path):
+    target = tmp_path / "repo"
+    with pytest.raises(RuntimeError):
+        with staged_publish(target) as stage:
+            (stage / "half.rpm").write_text("partial")
+            raise RuntimeError("sign failed")
+    assert not target.exists()  # the failed publish produced nothing
+    assert _leftovers(tmp_path) == []
+
+
+def test_failed_publish_leaves_existing_repo_untouched(tmp_path):
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "old.rpm").write_text("old-content")
+
+    with pytest.raises(RuntimeError):
+        with staged_publish(target) as stage:
+            (stage / "new.rpm").write_text("new-content")
+            raise RuntimeError("publish blew up")
+
+    # The previously-published repo is intact; nothing from the failed run leaked.
+    assert (target / "old.rpm").read_text() == "old-content"
+    assert not (target / "new.rpm").exists()
+    assert _leftovers(tmp_path) == []
+
+
+def test_successful_republish_replaces_existing_repo(tmp_path):
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "old.rpm").write_text("old")
+
+    with staged_publish(target) as stage:
+        (stage / "new.rpm").write_text("new")
+
+    # Old content is fully gone, replaced by the new tree.
+    assert not (target / "old.rpm").exists()
+    assert (target / "new.rpm").read_text() == "new"
+    assert _leftovers(tmp_path) == []
+
+
+def test_swap_failure_restores_existing_repo(tmp_path, monkeypatch):
+    """If the final staging->target rename fails, the previous tree is restored."""
+    import os as _os
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    (target / "old.rpm").write_text("old")
+
+    real_replace = _os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src, dst):
+        # First call moves target -> backup; second (staging -> target) fails.
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise OSError("simulated rename failure")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr("chantal.cli.publish_commands.os.replace", flaky_replace)
+
+    with pytest.raises(OSError, match="simulated rename failure"):
+        with staged_publish(target) as stage:
+            (stage / "new.rpm").write_text("new")
+
+    # The previous published tree is back; nothing half-swapped.
+    assert (target / "old.rpm").read_text() == "old"
+    assert not (target / "new.rpm").exists()


### PR DESCRIPTION
## The problem

Publishers wrote directly into the **live** published directory, so a failure mid-publish (e.g. a GPG signing error) could leave a **half-written, inconsistent repository** that clients would then fetch.

## The fix

New `staged_publish` context manager: publishing happens in a **staging directory** (a sibling of the target on the same filesystem, so package hardlinks from the pool still work and the final rename is atomic). On success the staging tree replaces the target via a move-aside-and-rename swap; on **any failure the staging tree is discarded and the existing published repository is left untouched**. If the final rename itself fails, the previous tree is restored. Snapshot/view DB state is marked published only **after** a successful swap.

Applied to every publish path: the four repository types (`_publish_single_repository`), repository and view snapshots, and the from-config view publish.

## Tests

`tests/test_staged_publish.py` proves the atomic property:
- failed publish leaves an **existing** repo intact (old content survives, new content didn't leak),
- failed publish into a fresh target leaves nothing,
- successful republish replaces the old tree wholesale,
- swap-failure restores the previous tree,
- no `.staging`/`.old` residue remains.

The existing real-client publish e2e tests (rpm/apt/helm/apk) exercise the happy path end-to-end and pass.

Fresh-context review: LOOKS-GOOD — atomic property holds, no corruption path, and the staging dir name never leaks into generated metadata (Release/repomd/index/APKINDEX are config-derived).

The fourth and last of the clean-up items.