### PR TITLE
ci: gate releases on the full test suite incl. e2e

### DIFF
--- a/.github/workflows/lint-and-type-check.yml
+++ b/.github/workflows/lint-and-type-check.yml
@@ -1,108 +1,13 @@
 name: CI
 
+# Runs on pull requests only. Pushes to main are validated by the Release
+# workflow, which calls the same reusable test suite before releasing, so the
+# full lint/type/unit/e2e suite never runs twice for one merge.
 on:
-  push:
-    branches:
-      - main  # Only run on pushes to main (direct commits)
   pull_request:
     branches:
-      - main  # Run on all PRs targeting main
+      - main
 
 jobs:
-  lint-and-type-check:
-    name: Lint and Type Check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.12', '3.13', '3.14']
-      fail-fast: false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Cache pip packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Run ruff (linting)
-        run: |
-          echo "Running ruff linter..."
-          ruff check src/chantal/ tests/ --output-format=github
-        continue-on-error: false
-
-      - name: Run black (code formatting check)
-        run: |
-          echo "Checking code formatting with black..."
-          black --check --diff src/chantal/ tests/
-        continue-on-error: false
-
-      - name: Run yamllint (YAML linting)
-        run: |
-          echo "Linting YAML files..."
-          yamllint --strict examples/ .github/
-        continue-on-error: false
-
-      - name: Run mypy (type checking)
-        run: |
-          echo "Running mypy type checker..."
-          mypy src/chantal/ --ignore-missing-imports
-        continue-on-error: false
-        # Type checking is now enforced - all code must pass mypy
-        # See CONTRIBUTING.md for type annotation guidelines
-
-      - name: Run pytest (unit tests)
-        run: |
-          echo "Running pytest..."
-          pytest tests/ -v --tb=short -m "not e2e"
-        continue-on-error: false
-
-  e2e:
-    name: E2E (${{ matrix.plugin }})
-    needs: lint-and-type-check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        plugin: [rpm, apt, helm, apk]
-      fail-fast: false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Install rpm toolchain (for the real-rpm signature golden test)
-        if: matrix.plugin == 'rpm'
-        run: sudo apt-get update && sudo apt-get install -y rpm
-
-      - name: Run end-to-end sync->publish test
-        env:
-          # Require the real-rpm signature golden test to run (not skip) on the rpm leg.
-          CHANTAL_REQUIRE_RPM_E2E: ${{ matrix.plugin == 'rpm' && '1' || '' }}
-        run: |
-          echo "Running E2E sync->publish for ${{ matrix.plugin }}..."
-          pytest tests/e2e -v -s -m e2e -k ${{ matrix.plugin }}
+  test:
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,51 +12,10 @@ permissions:
   id-token: write
 
 jobs:
+  # Full lint + type check + unit + e2e suite (the same reusable workflow the
+  # CI workflow runs on PRs). A release cannot proceed unless this is green.
   test:
-    name: Test and Lint Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.12', '3.13', '3.14']
-      fail-fast: false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Cache pip packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Run ruff (linting)
-        run: ruff check src/chantal/ tests/ --output-format=github
-
-      - name: Run black (code formatting check)
-        run: black --check --diff src/chantal/ tests/
-
-      - name: Run yamllint (YAML linting)
-        run: yamllint --strict examples/ .github/
-
-      - name: Run mypy (type checking)
-        run: mypy src/chantal/ --ignore-missing-imports
-
-      - name: Run pytest (unit tests)
-        run: pytest tests/ -v --tb=short -m "not e2e"
+    uses: ./.github/workflows/test.yml
 
   build:
     name: Build Package
@@ -118,7 +77,7 @@ jobs:
           tag: true
           commit: true
           push: true
-          root_options: "-vv"
+          verbosity: 2
 
   publish-testpypi:
     name: Publish to TestPyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,102 @@
+name: Test
+
+# Reusable test suite (lint + type check + unit + e2e), called by the CI
+# workflow on pull requests and by the Release workflow on pushes to main, so
+# both gate on exactly the same checks (no duplicated definitions).
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-type-check:
+    name: Lint and Type Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12', '3.13', '3.14']
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run ruff (linting)
+        run: |
+          echo "Running ruff linter..."
+          ruff check src/chantal/ tests/ --output-format=github
+
+      - name: Run black (code formatting check)
+        run: |
+          echo "Checking code formatting with black..."
+          black --check --diff src/chantal/ tests/
+
+      - name: Run yamllint (YAML linting)
+        run: |
+          echo "Linting YAML files..."
+          yamllint --strict examples/ .github/
+
+      - name: Run mypy (type checking)
+        run: |
+          echo "Running mypy type checker..."
+          mypy src/chantal/ --ignore-missing-imports
+
+      - name: Run pytest (unit tests)
+        run: |
+          echo "Running pytest..."
+          pytest tests/ -v --tb=short -m "not e2e"
+
+  e2e:
+    name: E2E (${{ matrix.plugin }})
+    needs: lint-and-type-check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        plugin: [rpm, apt, helm, apk]
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Install rpm toolchain (for the real-rpm signature golden test)
+        if: matrix.plugin == 'rpm'
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
+      - name: Run end-to-end sync->publish test
+        env:
+          # Require the real-rpm signature golden test to run (not skip) on the rpm leg.
+          CHANTAL_REQUIRE_RPM_E2E: ${{ matrix.plugin == 'rpm' && '1' || '' }}
+        run: |
+          echo "Running E2E sync->publish for ${{ matrix.plugin }}..."
+          pytest tests/e2e -v -s -m e2e -k ${{ matrix.plugin }}


### PR DESCRIPTION
## The problem (raised in review)

The **Release** workflow ran only the unit tests (`pytest -m "not e2e"`) and was **independent** of the **CI** workflow. On a push to `main` the two ran in parallel, so a release (tag + PyPI publish) could proceed **even when the e2e suite was red**. Separately, `main` had **no branch protection** at all.

Also: the `python-semantic-release` action was passed an invalid `root_options` input (it's `verbosity`), producing a warning and being ignored.

## The fix

Extract lint + type check + unit + **e2e** into a **reusable workflow** (`test.yml`, `workflow_call`) and call it from both:
- **CI** (`lint-and-type-check.yml`) on pull requests, and
- **Release** (`release.yml`) as the `test` gate before `build` → `release` → `publish`.

A release can no longer happen unless lint, type checks, unit tests **and** the rpm/apt/helm/apk e2e legs are all green. CI now runs on **PRs only**; pushes to `main` are validated by the Release workflow calling the same suite, so e2e never runs twice for one merge.

Fixed `root_options` → `verbosity: 2`.

Validated with `actionlint` (exit 0) and `yamllint --strict`. This PR's own CI run exercises the new reusable structure.

Follow-up (separate, repo setting): enable branch protection on `main` requiring these checks before merge — I'll set that once this PR's run confirms the exact check names.