### PR TITLE
fix(sync): prune stale metadata on re-sync (RPM + APT)

### DIFF
--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -154,9 +154,15 @@ class AptSyncPlugin:
             # Build dists URL (feed should point to repository root, not dists/)
             dists_url = urljoin(self.config.feed + "/", f"dists/{self.apt_config.distribution}/")
 
+            # SHA256 of every metadata/signature file the current upstream
+            # Release references, used to prune leftovers from previous syncs.
+            current_metadata_shas: set[str] = set()
+
             # Phase 1: Download Release/InRelease files
             self.output.phase("Downloading Release metadata", number=1)
-            release_metadata = self._fetch_and_store_release(session, repository, dists_url)
+            release_metadata = self._fetch_and_store_release(
+                session, repository, dists_url, current_metadata_shas
+            )
 
             # Phase 2: Download Packages.gz/Sources.gz for all components/architectures
             self.output.phase("Downloading repository metadata", number=2)
@@ -164,14 +170,27 @@ class AptSyncPlugin:
             self.output.info(f"Found {len(metadata_files)} metadata files to download")
 
             metadata_downloaded = 0
+            metadata_download_failed = False
             for metadata_info in metadata_files:
                 try:
-                    self._download_metadata_file(session, repository, dists_url, metadata_info)
+                    file_sha = self._download_metadata_file(
+                        session, repository, dists_url, metadata_info
+                    )
+                    current_metadata_shas.add(file_sha)
                     metadata_downloaded += 1
                     self.output.verbose(f"  → Downloaded {metadata_info.relative_path}")
                 except Exception as e:
+                    metadata_download_failed = True
                     logger.warning(f"Failed to download {metadata_info.relative_path}: {e}")
                     self.output.warning(f"Failed to download {metadata_info.relative_path}: {e}")
+
+            # Unlink metadata/signature files from previous syncs that the current
+            # Release no longer references, so the published repository does not
+            # carry stale indices and the pool does not grow forever. Skip when a
+            # metadata download failed this run: the current set would be
+            # incomplete, so pruning could strip a still-valid previous copy.
+            if current_metadata_shas and not metadata_download_failed:
+                self._prune_stale_metadata(session, repository, current_metadata_shas)
 
             # Phase 3: Parse Packages files and download .deb packages
             self.output.phase("Downloading packages", number=3)
@@ -322,7 +341,11 @@ class AptSyncPlugin:
             )
 
     def _fetch_and_store_release(
-        self, session: Session, repository: Repository, dists_url: str
+        self,
+        session: Session,
+        repository: Repository,
+        dists_url: str,
+        current_metadata_shas: set[str],
     ) -> dict:
         """Download and store Release/InRelease files.
 
@@ -330,6 +353,9 @@ class AptSyncPlugin:
             session: Database session
             repository: Repository instance
             dists_url: URL to dists/SUITE/ directory
+            current_metadata_shas: The pool SHA256 of every stored
+                Release/InRelease/Release.gpg file is added to this set so the
+                caller can prune stale metadata from previous syncs.
 
         Returns:
             Parsed release metadata dict
@@ -337,6 +363,7 @@ class AptSyncPlugin:
         Raises:
             Exception: On download or parse errors
         """
+        shas = current_metadata_shas
         # Try InRelease first (contains GPG signature inline)
         inrelease_url = urljoin(dists_url, "InRelease")
         release_url = urljoin(dists_url, "Release")
@@ -359,14 +386,16 @@ class AptSyncPlugin:
             inrelease_downloaded = True
 
             # Store InRelease as RepositoryFile
-            self._store_file_as_repository_file(
-                session=session,
-                repository=repository,
-                content=response.content,
-                filename="InRelease",
-                file_type="InRelease",
-                file_category="metadata",
-                original_path="InRelease",
+            shas.add(
+                self._store_file_as_repository_file(
+                    session=session,
+                    repository=repository,
+                    content=response.content,
+                    filename="InRelease",
+                    file_type="InRelease",
+                    file_category="metadata",
+                    original_path="InRelease",
+                )
             )
             self.output.verbose("  → Downloaded InRelease")
 
@@ -384,14 +413,16 @@ class AptSyncPlugin:
                 release_bytes = response.content
 
                 # Store Release file
-                self._store_file_as_repository_file(
-                    session=session,
-                    repository=repository,
-                    content=response.content,
-                    filename="Release",
-                    file_type="Release",
-                    file_category="metadata",
-                    original_path="Release",
+                shas.add(
+                    self._store_file_as_repository_file(
+                        session=session,
+                        repository=repository,
+                        content=response.content,
+                        filename="Release",
+                        file_type="Release",
+                        file_category="metadata",
+                        original_path="Release",
+                    )
                 )
                 self.output.verbose("  → Downloaded Release")
 
@@ -401,14 +432,16 @@ class AptSyncPlugin:
                     gpg_response.raise_for_status()
                     release_gpg_bytes = gpg_response.content
 
-                    self._store_file_as_repository_file(
-                        session=session,
-                        repository=repository,
-                        content=gpg_response.content,
-                        filename="Release.gpg",
-                        file_type="Release.gpg",
-                        file_category="signature",
-                        original_path="Release.gpg",
+                    shas.add(
+                        self._store_file_as_repository_file(
+                            session=session,
+                            repository=repository,
+                            content=gpg_response.content,
+                            filename="Release.gpg",
+                            file_type="Release.gpg",
+                            file_category="signature",
+                            original_path="Release.gpg",
+                        )
                     )
                     self.output.verbose("  → Downloaded Release.gpg")
                 except Exception as gpg_error:
@@ -683,7 +716,7 @@ class AptSyncPlugin:
         repository: Repository,
         dists_url: str,
         metadata_info: MetadataFileInfo,
-    ) -> None:
+    ) -> str:
         """Download metadata file and store as RepositoryFile.
 
         Args:
@@ -691,6 +724,10 @@ class AptSyncPlugin:
             repository: Repository instance
             dists_url: Base URL to dists/SUITE/ directory
             metadata_info: Metadata file information
+
+        Returns:
+            The pool SHA256 of the stored metadata file (used to prune stale
+            metadata links from previous syncs).
 
         Raises:
             Exception: On download or storage errors
@@ -775,6 +812,8 @@ class AptSyncPlugin:
                     repo_file.repositories.append(repository)
                     session.commit()
 
+                return sha256
+
             finally:
                 # Clean up temp file
                 if tmp_path.exists():
@@ -855,6 +894,32 @@ class AptSyncPlugin:
                 if tmp_path.exists():
                     tmp_path.unlink()
 
+    def _prune_stale_metadata(
+        self, session: Session, repository: Repository, current_shas: set[str]
+    ) -> None:
+        """Unlink metadata/signature files not referenced by the current sync.
+
+        On re-sync, when upstream regenerates its indices (new checksums), the
+        previous Release/Packages/Contents/Translation files would otherwise stay
+        linked to the repository and be republished alongside the current ones
+        (stale indices; unbounded pool growth). Unlink them, and delete the row
+        when nothing else (another repository or a snapshot) still references it
+        so its pool blob becomes reclaimable by ``pool cleanup``.
+        """
+        removed = 0
+        for repo_file in list(repository.repository_files):
+            if repo_file.file_category not in ("metadata", "signature"):
+                continue
+            if repo_file.sha256 in current_shas:
+                continue
+            repository.repository_files.remove(repo_file)
+            removed += 1
+            if not repo_file.repositories and not repo_file.snapshots:
+                session.delete(repo_file)
+        if removed:
+            session.commit()
+            self.output.verbose(f"Pruned {removed} stale metadata file(s) from a previous sync")
+
     def _store_file_as_repository_file(
         self,
         session: Session,
@@ -864,7 +929,7 @@ class AptSyncPlugin:
         file_type: str,
         file_category: str,
         original_path: str,
-    ) -> None:
+    ) -> str:
         """Store arbitrary file as RepositoryFile.
 
         Args:
@@ -875,6 +940,10 @@ class AptSyncPlugin:
             file_type: File type (InRelease, Release, Release.gpg)
             file_category: Category (metadata, signature)
             original_path: Original path in repository
+
+        Returns:
+            The pool SHA256 of the stored file (used to prune stale metadata
+            links from previous syncs).
         """
         # Write to temp file
         with tempfile.NamedTemporaryFile(delete=False, suffix=f".{file_type}") as tmp_file:
@@ -913,6 +982,8 @@ class AptSyncPlugin:
                     # Link to repository
                     repo_file.repositories.append(repository)
                     session.commit()
+
+                return sha256
 
             finally:
                 # Clean up temp file

--- a/src/chantal/plugins/rpm/sync.py
+++ b/src/chantal/plugins/rpm/sync.py
@@ -323,6 +323,8 @@ class RpmSyncPlugin:
             self.output.phase("Downloading metadata files", number=3)
             metadata_files = parsers.extract_all_metadata(repomd_root)
             metadata_downloaded = 0
+            current_metadata_shas: set[str] = set()
+            metadata_download_failed = False
 
             for metadata_info in metadata_files:
                 # Store every metadata file, including primary.xml. The publisher
@@ -340,17 +342,27 @@ class RpmSyncPlugin:
                         open_size=metadata_info.get("open_size"),
                         checksum_type=metadata_info.get("checksum_type"),
                     )
-                    from_cache = self._download_metadata_file(
+                    from_cache, file_sha = self._download_metadata_file(
                         mfi, session, repository, self.config.feed
                     )
+                    current_metadata_shas.add(file_sha)
                     metadata_downloaded += 1
                     if from_cache:
                         self.output.verbose(f"  → {metadata_info['file_type']}.xml.gz (cached)")
                     else:
                         self.output.verbose(f"  → {metadata_info['file_type']}.xml.gz (downloaded)")
                 except Exception as e:
+                    metadata_download_failed = True
                     self.output.warning(f"Failed to download {metadata_info['file_type']}: {e}")
                     # Continue with next metadata file
+
+            # Unlink metadata files from previous syncs that the current repomd
+            # no longer references, so the published repomd.xml does not end up
+            # with duplicate <data> entries (and the pool does not grow forever).
+            # Skip when a metadata download failed this run: the current set would
+            # be incomplete, so pruning could strip a still-valid previous copy.
+            if current_metadata_shas and not metadata_download_failed:
+                self._prune_stale_metadata(session, repository, current_metadata_shas)
 
             # Step 8: Check for .treeinfo and download installer files
             self.output.phase("Checking for installer files (.treeinfo)", number=4)
@@ -832,13 +844,39 @@ class RpmSyncPlugin:
                 if tmp_path.exists():
                     tmp_path.unlink()
 
+    def _prune_stale_metadata(
+        self, session: Session, repository: Repository, current_shas: set[str]
+    ) -> None:
+        """Unlink metadata RepositoryFiles not referenced by the current repomd.
+
+        On re-sync, when upstream regenerates its metadata (new checksums), the
+        previous metadata files would otherwise stay linked to the repository and
+        be republished alongside the current ones (duplicate repomd <data>
+        entries; unbounded pool growth). Unlink them, and delete the row when
+        nothing else (another repository or a snapshot) still references it so its
+        pool blob becomes reclaimable by ``pool cleanup``.
+        """
+        removed = 0
+        for repo_file in list(repository.repository_files):
+            if repo_file.file_category != "metadata":
+                continue
+            if repo_file.sha256 in current_shas:
+                continue
+            repository.repository_files.remove(repo_file)
+            removed += 1
+            if not repo_file.repositories and not repo_file.snapshots:
+                session.delete(repo_file)
+        if removed:
+            session.commit()
+            self.output.verbose(f"Pruned {removed} stale metadata file(s) from a previous sync")
+
     def _download_metadata_file(
         self,
         metadata_info: MetadataFileInfo,
         session: Session,
         repository: Repository,
         base_url: str,
-    ) -> bool:
+    ) -> tuple[bool, str]:
         """Download metadata file and store as RepositoryFile.
 
         Uses metadata cache if enabled to avoid redundant downloads.
@@ -850,7 +888,9 @@ class RpmSyncPlugin:
             base_url: Base URL of repository
 
         Returns:
-            True if loaded from cache, False if downloaded
+            ``(from_cache, sha256)`` - whether the file came from the cache, and
+            the pool SHA256 of the stored metadata file (used to prune stale
+            metadata links from previous syncs).
 
         Raises:
             requests.RequestException: On HTTP errors
@@ -968,7 +1008,7 @@ class RpmSyncPlugin:
                 repo_file.repositories.append(repository)
                 session.commit()
 
-            return from_cache
+            return from_cache, sha256
 
         finally:
             # Clean up temp file (only if not from cache)

--- a/tests/e2e/test_rpm_e2e.py
+++ b/tests/e2e/test_rpm_e2e.py
@@ -11,12 +11,17 @@ import pytest
 pytestmark = pytest.mark.e2e
 
 
-def _build_rpm_upstream(root: Path) -> None:
-    """Create a minimal yum/dnf repo (repomd.xml + primary.xml.gz + one rpm)."""
+def _build_rpm_upstream(root: Path, revision: int = 1) -> None:
+    """Create a minimal yum/dnf repo (repomd.xml + primary.xml.gz + one rpm).
+
+    ``revision`` is woven into the rpm payload and the repomd <revision>, so
+    calling this twice with different revisions yields metadata with genuinely
+    different checksums (as a real upstream regenerating its repodata would).
+    """
     repodata = root / "repodata"
     repodata.mkdir(parents=True, exist_ok=True)
 
-    rpm = b"dummy rpm payload" * 16
+    rpm = b"dummy rpm payload" * 16 + f" rev{revision}".encode()
     rpm_name = "demo-1.0-1.el9.x86_64.rpm"
     (root / rpm_name).write_bytes(rpm)
     rpm_sha = hashlib.sha256(rpm).hexdigest()
@@ -52,7 +57,7 @@ def _build_rpm_upstream(root: Path) -> None:
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<repomd xmlns="http://linux.duke.edu/metadata/repo"'
         ' xmlns:rpm="http://linux.duke.edu/metadata/rpm">\n'
-        "  <revision>1</revision>\n"
+        f"  <revision>{revision}</revision>\n"
         '  <data type="primary">\n'
         f'    <checksum type="sha256">{hashlib.sha256(gz).hexdigest()}</checksum>\n'
         f'    <open-checksum type="sha256">{hashlib.sha256(primary).hexdigest()}</open-checksum>\n'
@@ -87,3 +92,39 @@ def test_rpm_sync_and_publish(tmp_path, serve, chantal_env):
     # repomd.xml was regenerated and the package was published.
     assert (target / "repodata" / "repomd.xml").exists()
     assert list(target.rglob("demo-1.0-1.el9.x86_64.rpm")), "published rpm not found"
+
+
+def test_rpm_resync_does_not_duplicate_metadata(tmp_path, serve, chantal_env):
+    """Re-syncing changed upstream metadata must not accumulate stale metadata.
+
+    When upstream regenerates its repodata (new checksums), the previous
+    metadata files used to stay linked to the repository and get republished
+    alongside the current ones, yielding duplicate ``<data type="primary">``
+    entries in repomd.xml and unbounded pool growth. The re-sync must prune the
+    stale metadata so the published repomd references exactly one primary.
+    """
+    upstream = tmp_path / "upstream"
+    _build_rpm_upstream(upstream, revision=1)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-rpm",
+            "name": "Demo RPM",
+            "type": "rpm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+        }
+    )
+
+    chantal_env.sync_and_publish("demo-rpm")
+
+    # Upstream publishes a new revision with fresh metadata checksums.
+    _build_rpm_upstream(upstream, revision=2)
+    target = chantal_env.sync_and_publish("demo-rpm")
+
+    repomd = (target / "repodata" / "repomd.xml").read_text(encoding="utf-8")
+    assert (
+        repomd.count('<data type="primary"') == 1
+    ), f"re-sync left duplicate primary <data> entries:\n{repomd}"

--- a/tests/test_metadata_prune.py
+++ b/tests/test_metadata_prune.py
@@ -1,0 +1,115 @@
+"""Regression tests for ``_prune_stale_metadata`` (RPM + APT sync plugins).
+
+On re-sync, when upstream regenerates its indices with fresh checksums, the
+previous metadata files must be unlinked from the repository so they are not
+republished alongside the current ones (duplicate indices) and so their pool
+blobs become reclaimable. A metadata file that is still referenced by a snapshot
+must be unlinked from the repository but its row kept (the snapshot still needs
+it).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chantal.core.config import AptConfig, RepositoryConfig
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import Base, Repository, RepositoryFile, Snapshot
+from chantal.plugins.apt.sync import AptSyncPlugin
+from chantal.plugins.rpm.sync import RpmSyncPlugin
+
+
+def _make_repo_file(sha: str, category: str, file_type: str) -> RepositoryFile:
+    return RepositoryFile(
+        file_category=category,
+        file_type=file_type,
+        sha256=sha,
+        size_bytes=1,
+        pool_path=f"{sha[:2]}/{sha[2:4]}/{file_type}",
+        original_path=f"repodata/{file_type}",
+        file_metadata={},
+    )
+
+
+def _rpm_plugin() -> RpmSyncPlugin:
+    config = RepositoryConfig(
+        id="demo", name="Demo", type="rpm", feed="http://example.com/repo", mode="mirror"
+    )
+    return RpmSyncPlugin(storage=None, config=config, proxy_config=None, ssl_config=None)
+
+
+def _apt_plugin() -> AptSyncPlugin:
+    config = RepositoryConfig(
+        id="demo",
+        name="Demo",
+        type="apt",
+        feed="http://example.com/repo",
+        mode="mirror",
+        apt=AptConfig(distribution="jammy", components=["main"], architectures=["amd64"]),
+    )
+    return AptSyncPlugin(storage=None, config=config, proxy_config=None, ssl_config=None)
+
+
+@pytest.mark.parametrize("plugin_factory", [_rpm_plugin, _apt_plugin])
+def test_prune_unlinks_stale_metadata_keeps_current(tmp_path, plugin_factory):
+    dbm = DatabaseManager(f"sqlite:///{tmp_path / 'chantal.db'}")
+    Base.metadata.create_all(dbm.engine)
+    session = dbm.get_session()
+
+    repo = Repository(repo_id="demo", name="Demo", type="rpm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+
+    current = _make_repo_file("c" * 64, "metadata", "primary")
+    stale_orphan = _make_repo_file("a" * 64, "metadata", "primary")
+    stale_snapshot = _make_repo_file("b" * 64, "metadata", "filelists")
+    kickstart = _make_repo_file("d" * 64, "kickstart", "treeinfo")
+    for rf in (current, stale_orphan, stale_snapshot, kickstart):
+        repo.repository_files.append(rf)
+
+    # The stale snapshot-referenced file must be preserved (unlinked from the
+    # repo but its row kept because a snapshot still needs it).
+    snap = Snapshot(repository_id=repo.id, name="snap-1")
+    snap.repository_files.append(stale_snapshot)
+    session.add(snap)
+    session.commit()
+
+    plugin_factory()._prune_stale_metadata(session, repo, {"c" * 64})
+
+    session.refresh(repo)
+    linked = {rf.sha256 for rf in repo.repository_files}
+    # Current metadata stays; non-metadata (kickstart) is untouched; both stale
+    # metadata files are unlinked from the repository.
+    assert "c" * 64 in linked
+    assert "d" * 64 in linked
+    assert "a" * 64 not in linked
+    assert "b" * 64 not in linked
+
+    # The orphaned stale file's row is deleted; the snapshot-referenced one is kept.
+    remaining = {rf.sha256 for rf in session.query(RepositoryFile).all()}
+    assert "a" * 64 not in remaining
+    assert "b" * 64 in remaining
+
+
+def test_apt_prune_also_unlinks_stale_signature(tmp_path):
+    """The APT prune covers ``signature`` files (Release.gpg), not just metadata."""
+    dbm = DatabaseManager(f"sqlite:///{tmp_path / 'chantal.db'}")
+    Base.metadata.create_all(dbm.engine)
+    session = dbm.get_session()
+
+    repo = Repository(repo_id="demo", name="Demo", type="apt", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+
+    current = _make_repo_file("c" * 64, "metadata", "InRelease")
+    stale_sig = _make_repo_file("e" * 64, "signature", "Release.gpg")
+    repo.repository_files.append(current)
+    repo.repository_files.append(stale_sig)
+    session.commit()
+
+    _apt_plugin()._prune_stale_metadata(session, repo, {"c" * 64})
+
+    session.refresh(repo)
+    linked = {rf.sha256 for rf in repo.repository_files}
+    assert linked == {"c" * 64}
+    assert session.query(RepositoryFile).filter_by(sha256="e" * 64).first() is None


### PR DESCRIPTION
## Problem

When an upstream repository regenerates its metadata with fresh checksums (a normal re-sync), the previous metadata `RepositoryFile` rows stayed linked to the repository indefinitely. Two consequences:

- **RPM:** the publisher emitted **duplicate `<data>` entries** in `repomd.xml`. `_regenerate_primary` only rewrites the *first* `primary` index, so every stale primary from a prior sync survived into the published `repomd.xml` — yielding multiple `<data type="primary">` entries (invalid for dnf/yum).
- **Both RPM and APT:** the content-addressed pool grew without bound, since stale metadata blobs were never unlinked and so never became reclaimable by `pool cleanup`.

## Fix

Both sync plugins now collect the SHA256 of every metadata/signature file the *current* upstream references, then unlink any previously-linked metadata file not in that set. The `RepositoryFile` row is deleted only when no other repository **and** no snapshot still references it (so its pool blob is reclaimable); files still referenced by a snapshot are unlinked from the repository but their row is kept.

Pruning is **skipped when a metadata download failed** during the run, so an incomplete current-set can never strip a still-valid previous copy (correctness on partial failure).

## Tests

- **e2e regression** (`test_rpm_resync_does_not_duplicate_metadata`): syncs an upstream, regenerates it with new checksums, re-syncs, and asserts the published `repomd.xml` contains exactly one `<data type="primary">`. Fails without the fix, passes with it.
- **unit** (`test_metadata_prune.py`): covers current-file retention, orphan-row deletion, snapshot-referenced preservation, non-metadata (kickstart) files left untouched, and the APT-only `signature` category — parametrized across both plugins.

Full lint/type/unit + rpm & apt e2e suites green locally.