### PR TITLE
fix(apt): harden .deb parser against ar size DoS and decompression bombs

### DIFF
--- a/src/chantal/plugins/apt/deb.py
+++ b/src/chantal/plugins/apt/deb.py
@@ -20,6 +20,12 @@ from chantal.plugins.rpm.modules import decompress_bytes
 _AR_MAGIC = b"!<arch>\n"
 _AR_HEADER_SIZE = 60
 
+# A real Debian control.tar is a few KB and virtually never exceeds a few
+# hundred KB. Cap the decompressed size well above any legitimate value so a
+# tiny but highly-compressible control.tar.* cannot expand into a memory bomb.
+# (Only control.tar is decompressed here; the large data.tar is never touched.)
+_MAX_CONTROL_TAR_BYTES = 16 * 1024 * 1024
+
 
 class DebFormatError(Exception):
     """Raised when the bytes are not a parseable ``.deb`` package."""
@@ -41,6 +47,14 @@ def _iter_ar_members(data: bytes) -> Iterator[tuple[str, bytes]]:
         except ValueError as exc:
             raise DebFormatError("corrupt ar header (bad size)") from exc
         start = offset + _AR_HEADER_SIZE
+        # A negative size would move ``offset`` backwards and loop forever; an
+        # oversized one would yield a silently-truncated payload. Rejecting both
+        # also guarantees forward progress (offset advances by >= the header size
+        # every iteration), so the loop always terminates.
+        if size < 0:
+            raise DebFormatError("corrupt ar header (negative size)")
+        if start + size > len(data):
+            raise DebFormatError("corrupt ar header (size exceeds archive)")
         payload = data[start : start + size]
         yield name, payload
         # Member data is padded to an even byte boundary.
@@ -83,7 +97,11 @@ def parse_deb_control(data: bytes) -> dict[str, str]:
         raise DebFormatError("no control.tar member found in .deb")
 
     try:
-        tar_bytes = decompress_bytes(control_bytes, _control_suffix(control_name))
+        tar_bytes = decompress_bytes(
+            control_bytes,
+            _control_suffix(control_name),
+            max_output_bytes=_MAX_CONTROL_TAR_BYTES,
+        )
         with tarfile.open(fileobj=BytesIO(tar_bytes)) as tar:
             member = next(
                 (m for m in tar.getmembers() if m.name in ("./control", "control")),

--- a/src/chantal/plugins/rpm/modules.py
+++ b/src/chantal/plugins/rpm/modules.py
@@ -23,10 +23,16 @@ import bz2
 import gzip
 import logging
 import lzma
+import zlib
 
 import yaml
 
 logger = logging.getLogger(__name__)
+
+
+class DecompressionLimitError(ValueError):
+    """Raised when decompressed output exceeds the requested ``max_output_bytes``."""
+
 
 # modulemd stream document -- the only type that binds RPM artifacts.
 _STREAM_DOCUMENT = "modulemd"
@@ -121,22 +127,65 @@ def filter_modules_yaml(yaml_bytes: bytes, available_nevras: set[str]) -> bytes 
     return dumped.encode("utf-8")
 
 
-def decompress_bytes(data: bytes, suffix: str) -> bytes:
-    """Decompress ``data`` according to a file-name ``suffix`` (e.g. ``.gz``)."""
+def _bounded(out: bytes, finished: bool, limit: int) -> bytes:
+    """Reject output that is over ``limit`` or not yet exhausted at ``limit``."""
+    if len(out) > limit or not finished:
+        raise DecompressionLimitError(
+            f"decompressed size exceeds {limit} bytes (decompression bomb?)"
+        )
+    return out
+
+
+def decompress_bytes(data: bytes, suffix: str, *, max_output_bytes: int | None = None) -> bytes:
+    """Decompress ``data`` according to a file-name ``suffix`` (e.g. ``.gz``).
+
+    When ``max_output_bytes`` is given the output is bounded incrementally and a
+    :class:`DecompressionLimitError` is raised as soon as it would exceed the
+    limit, so a small but highly-compressible input cannot expand into a memory
+    bomb. ``None`` (the default) decompresses without a cap.
+    """
+    if max_output_bytes is None:
+        if suffix == ".gz":
+            return gzip.decompress(data)
+        if suffix == ".xz":
+            return lzma.decompress(data)
+        if suffix == ".bz2":
+            return bz2.decompress(data)
+        if suffix == ".zst":
+            import io
+
+            import zstandard as zstd
+
+            # Use the streaming reader: the one-shot decompress() requires the
+            # frame to embed its content size, which streaming producers omit.
+            return zstd.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+        return data
+
+    limit = max_output_bytes
     if suffix == ".gz":
-        return gzip.decompress(data)
+        decomp = zlib.decompressobj(wbits=31)  # 31 = gzip header
+        out = decomp.decompress(data, limit + 1)
+        return _bounded(out, decomp.eof, limit)
     if suffix == ".xz":
-        return lzma.decompress(data)
+        xz = lzma.LZMADecompressor()
+        out = xz.decompress(data, max_length=limit + 1)
+        return _bounded(out, xz.eof, limit)
     if suffix == ".bz2":
-        return bz2.decompress(data)
+        bz = bz2.BZ2Decompressor()
+        out = bz.decompress(data, max_length=limit + 1)
+        return _bounded(out, bz.eof, limit)
     if suffix == ".zst":
         import io
 
         import zstandard as zstd
 
-        # Use the streaming reader: the one-shot decompress() requires the frame
-        # to embed its content size, which streaming producers often omit.
-        return zstd.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+        reader = zstd.ZstdDecompressor().stream_reader(io.BytesIO(data))
+        out = reader.read(limit + 1)
+        # A well-formed frame shorter than the cap stops at EOF; if we filled the
+        # whole (limit + 1) budget there is at least one byte too many.
+        return _bounded(out, len(out) <= limit, limit)
+    if len(data) > limit:
+        raise DecompressionLimitError(f"size exceeds {limit} bytes")
     return data
 
 

--- a/tests/test_deb_upload.py
+++ b/tests/test_deb_upload.py
@@ -128,6 +128,43 @@ def test_parse_deb_control_rejects_non_deb():
         parse_deb_control(b"not a deb at all")
 
 
+def _ar_member_raw_size(name: str, size_str: str, data: bytes) -> bytes:
+    """Build an ar member with an attacker-controlled size field."""
+    header = (
+        name.ljust(16).encode()
+        + b"0".ljust(12)
+        + b"0".ljust(6)
+        + b"0".ljust(6)
+        + b"100644".ljust(8)
+        + size_str.ljust(10).encode()
+        + b"`\n"
+    )
+    return header + data
+
+
+def test_iter_ar_members_rejects_negative_size():
+    """A negative ar size used to move the cursor backwards -> infinite loop."""
+    deb = b"!<arch>\n" + _ar_member_raw_size("debian-binary", "-100", b"2.0\n")
+    with pytest.raises(DebFormatError, match="negative size"):
+        parse_deb_control(deb)
+
+
+def test_iter_ar_members_rejects_oversized_member():
+    """A size larger than the remaining archive must be rejected, not truncated."""
+    deb = b"!<arch>\n" + _ar_member_raw_size("control.tar", "99999999", b"short")
+    with pytest.raises(DebFormatError, match="exceeds archive"):
+        parse_deb_control(deb)
+
+
+def test_parse_deb_control_rejects_decompression_bomb():
+    """A tiny control.tar.gz that expands past the cap must be refused."""
+    # ~32 MiB of highly-compressible data in ./control -> a few KB gzipped,
+    # well over the 16 MiB control.tar cap.
+    deb = _build_deb("X" * (32 * 1024 * 1024), compression="gz")
+    with pytest.raises(DebFormatError, match="decompression bomb|exceeds"):
+        parse_deb_control(deb)
+
+
 def test_upload_maps_control_fields(session, storage, repository, tmp_path):
     f = tmp_path / "demo_1.0_amd64.deb"
     f.write_bytes(_build_deb())

--- a/tests/test_decompress_bounds.py
+++ b/tests/test_decompress_bounds.py
@@ -1,0 +1,66 @@
+"""Tests for the optional ``max_output_bytes`` cap on ``decompress_bytes``.
+
+A small but highly-compressible input must not be allowed to expand into a
+multi-gigabyte buffer (decompression bomb). The cap is opt-in: callers that omit
+it (RPM primary.xml, APT Packages indices) keep decompressing without a limit.
+"""
+
+from __future__ import annotations
+
+import bz2
+import gzip
+import lzma
+
+import pytest
+
+from chantal.plugins.rpm.modules import (
+    DecompressionLimitError,
+    compress_bytes,
+    decompress_bytes,
+)
+
+_FORMATS = [".gz", ".xz", ".bz2", ".zst"]
+
+
+def _compress(payload: bytes, suffix: str) -> bytes:
+    if suffix == ".gz":
+        return gzip.compress(payload)
+    if suffix == ".xz":
+        return lzma.compress(payload)
+    if suffix == ".bz2":
+        return bz2.compress(payload)
+    return compress_bytes(payload, suffix)  # .zst
+
+
+@pytest.mark.parametrize("suffix", _FORMATS)
+def test_under_limit_round_trips(suffix):
+    payload = b"hello world\n" * 100
+    compressed = _compress(payload, suffix)
+    assert decompress_bytes(compressed, suffix, max_output_bytes=1_000_000) == payload
+
+
+@pytest.mark.parametrize("suffix", _FORMATS)
+def test_over_limit_raises_before_full_expansion(suffix):
+    # 8 MiB of zeros compresses to a tiny blob; a 1 KiB cap must reject it.
+    bomb = _compress(b"\0" * (8 * 1024 * 1024), suffix)
+    assert len(bomb) < 64 * 1024  # genuinely a "bomb": tiny on disk
+    with pytest.raises(DecompressionLimitError):
+        decompress_bytes(bomb, suffix, max_output_bytes=1024)
+
+
+@pytest.mark.parametrize("suffix", _FORMATS)
+def test_exact_limit_is_allowed(suffix):
+    payload = b"a" * 4096
+    compressed = _compress(payload, suffix)
+    # Exactly at the cap is fine; one byte under the cap is not exceeded.
+    assert decompress_bytes(compressed, suffix, max_output_bytes=4096) == payload
+    with pytest.raises(DecompressionLimitError):
+        decompress_bytes(compressed, suffix, max_output_bytes=4095)
+
+
+@pytest.mark.parametrize("suffix", _FORMATS)
+def test_no_limit_is_unbounded(suffix):
+    payload = b"x" * (2 * 1024 * 1024)
+    compressed = _compress(payload, suffix)
+    # Default (no cap) keeps the previous unbounded behavior for large metadata.
+    assert decompress_bytes(compressed, suffix) == payload


### PR DESCRIPTION
## Problem

The pure-Python `.deb` reader (`src/chantal/plugins/apt/deb.py`) trusted two untrusted size sources:

1. **ar member size DoS.** `_iter_ar_members` parsed the member size verbatim. A **negative** size moved the cursor backwards → **infinite loop**; an **oversized** size (larger than the remaining archive) was silently truncated by Python slicing and the malformed member fed onward.
2. **Decompression bomb.** `parse_deb_control` decompressed `control.tar.*` with **no size cap**, so a tiny but highly-compressible blob could expand into gigabytes of memory.

## Fix

- **ar guards:** reject `size < 0` and `start + size > len(data)` before moving the cursor. This also guarantees forward progress (offset advances by ≥ the 60-byte header every iteration), so the loop always terminates.
- **Bounded decompression:** `decompress_bytes` gains an opt-in keyword `max_output_bytes`. When set, each format (gzip/xz/bz2/zstd) is decompressed **incrementally** and a `DecompressionLimitError` is raised as soon as the output would exceed the cap — the bomb is never fully materialized. `parse_deb_control` applies a **16 MiB** cap (real control tarballs are a few KB). The cap is **opt-in**: all existing callers (RPM `primary.xml`, APT `Packages` indices) omit it and keep their unbounded behavior.

## Tests

- Negative-size and oversized-size ar members → `DebFormatError` (the negative case previously hung).
- A `control.tar.gz` that expands ~32 MiB from a few KB → rejected.
- `max_output_bytes` cap across all four formats: accepts a payload exactly at the limit, rejects one byte over, never false-positives under the limit, and stays unbounded when omitted.

Full lint/type/unit gate green locally.