### PR TITLE
fix(helm): rewrite chart URLs to the mirror in mirror mode

### DIFF
--- a/src/chantal/plugins/helm/publisher.py
+++ b/src/chantal/plugins/helm/publisher.py
@@ -141,11 +141,12 @@ class HelmPublisher(PublisherPlugin):
         charts: list[ContentItem],
         snapshot: Snapshot | None = None,
     ) -> None:
-        """Publish index.yaml: regenerate it (filtered/hosted) or hardlink it.
+        """Publish index.yaml: regenerate it (filtered/hosted) or rewrite it.
 
         Filtered mode always regenerates index.yaml from the published charts.
-        Mirror mode hardlinks the verbatim upstream index.yaml from the pool,
-        falling back to generation when none was stored.
+        Mirror mode republishes the upstream index.yaml but rewrites its chart
+        URLs to point at this mirror, falling back to generation when none was
+        stored.
 
         Args:
             session: Database session
@@ -157,9 +158,9 @@ class HelmPublisher(PublisherPlugin):
         """
         # In filtered mode the published chart set differs from upstream, so
         # always regenerate index.yaml from the published charts. Republishing
-        # the verbatim upstream index (stored unconditionally during sync) would
-        # still list charts that were filtered out. Mirror mode keeps the
-        # upstream index as-is.
+        # the upstream index (stored unconditionally during sync) would still
+        # list charts that were filtered out. Mirror mode republishes the
+        # upstream index with its chart URLs rewritten to this mirror.
         if repository.mode == RepositoryMode.FILTERED:
             self._generate_index_yaml(charts, target_path, config)
             return
@@ -181,14 +182,12 @@ class HelmPublisher(PublisherPlugin):
                     break
 
         if index_file:
-            # Mirror mode: Hardlink index.yaml from pool
+            # Mirror mode: republish the upstream index.yaml, but rewrite the
+            # chart URLs to point at this mirror. Upstream indexes (e.g. Bitnami)
+            # often use absolute URLs back to the upstream server; hardlinking
+            # them verbatim would send clients upstream, defeating the mirror.
             pool_path = self.storage.pool_path / index_file.pool_path
-            target_file = target_path / "index.yaml"
-
-            if target_file.exists():
-                target_file.unlink()
-
-            os.link(pool_path, target_file)
+            self._publish_mirror_index(pool_path, target_path, charts, config)
             logger.info(
                 f"Published index.yaml from pool (mirror mode): {index_file.sha256[:16]}..."
             )
@@ -196,6 +195,75 @@ class HelmPublisher(PublisherPlugin):
             # Fallback: Generate index.yaml from charts
             logger.info("No index.yaml in pool, generating from charts")
             self._generate_index_yaml(charts, target_path, config)
+
+    def _publish_mirror_index(
+        self,
+        index_pool_path: Path,
+        target_path: Path,
+        charts: list[ContentItem],
+        config: RepositoryConfig,
+    ) -> None:
+        """Republish the upstream index.yaml with chart URLs rewritten.
+
+        Each version entry's ``urls`` are rewritten to the bare published
+        filename (relative to the repo root, matching the regenerated/filtered
+        path and where the charts are actually published). Versions whose chart
+        was not published (download failed / digest mismatch) are dropped so the
+        index never references a missing tarball. On any parse error the index is
+        regenerated from the published charts rather than served unrewritten.
+        """
+        from chantal.plugins.helm.sync import normalize_digest
+
+        target_file = target_path / "index.yaml"
+        # Resolve each index version to the chart actually published for it. Match
+        # by content digest first (robust to cross-repo dedup, where the stored
+        # filename can differ from this index's basename) and fall back to the
+        # tarball basename. The value is the published filename to serve.
+        by_digest = {
+            normalize_digest(chart.sha256): chart.filename
+            for chart in charts
+            if normalize_digest(chart.sha256)
+        }
+        by_name = {chart.filename for chart in charts}
+
+        try:
+            data = yaml.safe_load(index_pool_path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict) or not isinstance(data.get("entries"), dict):
+                raise ValueError("index.yaml has no entries mapping")
+        except Exception as exc:  # noqa: BLE001 - any malformed index -> regenerate
+            logger.warning(f"Could not parse upstream index.yaml ({exc}); regenerating from charts")
+            self._generate_index_yaml(charts, target_path, config)
+            return
+
+        for name, versions in list(data["entries"].items()):
+            if not isinstance(versions, list):
+                continue
+            kept = []
+            for entry in versions:
+                if not isinstance(entry, dict):
+                    continue
+                urls = entry.get("urls")
+                if not isinstance(urls, list) or not urls:
+                    continue
+                basename = Path(str(urls[0])).name
+                published_name = by_digest.get(normalize_digest(entry.get("digest")))
+                if published_name is None and basename in by_name:
+                    published_name = basename
+                if published_name is None:
+                    # Not mirrored (filtered out / download failed) -> drop it so
+                    # the index never references a missing tarball.
+                    continue
+                entry["urls"] = [published_name]
+                kept.append(entry)
+            if kept:
+                data["entries"][name] = kept
+            else:
+                del data["entries"][name]
+
+        if target_file.exists():
+            target_file.unlink()
+        with open(target_file, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
     def _generate_index_yaml(
         self, charts: list[ContentItem], target_path: Path, config: RepositoryConfig

--- a/tests/e2e/test_helm_features_real_client_e2e.py
+++ b/tests/e2e/test_helm_features_real_client_e2e.py
@@ -63,20 +63,29 @@ def _build_charts(specs: list[tuple[str, str]]) -> dict[tuple[str, str], bytes]:
     return charts
 
 
-def _write_upstream(root: Path, charts: dict[tuple[str, str], bytes]) -> None:
-    """Write an upstream chart repo (the .tgz files + an index.yaml)."""
+def _write_upstream(
+    root: Path, charts: dict[tuple[str, str], bytes], url_base: str | None = None
+) -> None:
+    """Write an upstream chart repo (the .tgz files + an index.yaml).
+
+    When ``url_base`` is given the index uses absolute chart URLs (the Bitnami
+    case: ``https://charts.example.com/demo-0.1.0.tgz``); otherwise relative
+    filenames are used. The tarballs are always written under ``root`` so a
+    mirror that rewrites URLs to relative filenames can serve them locally.
+    """
     root.mkdir(parents=True, exist_ok=True)
     entries: dict[str, list] = {}
     for (name, version), data in charts.items():
         fname = f"{name}-{version}.tgz"
         (root / fname).write_bytes(data)
+        url = f"{url_base.rstrip('/')}/{fname}" if url_base else fname
         entries.setdefault(name, []).append(
             {
                 "name": name,
                 "version": version,
                 "apiVersion": "v2",
                 "digest": hashlib.sha256(data).hexdigest(),
-                "urls": [fname],
+                "urls": [url],
             }
         )
     index = {"apiVersion": "v1", "entries": entries, "generated": "2026-01-01T00:00:00Z"}
@@ -115,7 +124,7 @@ def _helm(published: Path, helm_script: str) -> subprocess.CompletedProcess:
 
 @requires_docker
 def test_helm_mirror_consumed_by_real_client(tmp_path, serve, chantal_env):
-    """A mirror-mode repo (verbatim index.yaml) is consumable by real helm."""
+    """A mirror-mode repo is consumable by real helm; URLs point at the mirror."""
     charts = _build_charts([("demo", "0.1.0")])
     upstream = tmp_path / "upstream"
     _write_upstream(upstream, charts)
@@ -132,10 +141,53 @@ def test_helm_mirror_consumed_by_real_client(tmp_path, serve, chantal_env):
     )
     target = chantal_env.sync_and_publish("demo-mirror")
 
-    # Mirror preserves the upstream index.yaml byte-for-byte.
-    assert (target / "index.yaml").read_bytes() == (
-        upstream / "index.yaml"
-    ).read_bytes(), "mirror index.yaml is not byte-identical to upstream"
+    # The mirror's index.yaml points clients at its own (relative) chart paths.
+    published = yaml.safe_load((target / "index.yaml").read_text())
+    assert published["entries"]["demo"][0]["urls"] == ["demo-0.1.0.tgz"]
+
+    ok = _helm(
+        target,
+        "helm pull local/demo --version 0.1.0; "
+        "test -f demo-0.1.0.tgz; "
+        "helm show chart local/demo | grep '^name: demo'",
+    )
+    assert ok.returncode == 0, (
+        f"real helm pull from mirror failed:\nstdout={ok.stdout.decode()[-800:]}\n"
+        f"stderr={ok.stderr.decode()[-800:]}"
+    )
+
+
+@requires_docker
+def test_helm_mirror_rewrites_absolute_urls(tmp_path, serve, chantal_env):
+    """Absolute upstream chart URLs (Bitnami-style) are rewritten to the mirror.
+
+    Without rewriting, the mirrored index would send `helm pull` back to the
+    (here unreachable) upstream host, defeating the offline mirror.
+    """
+    charts = _build_charts([("demo", "0.1.0")])
+    upstream = tmp_path / "upstream"
+    upstream.mkdir(parents=True, exist_ok=True)
+    # Absolute URLs back to the upstream server (the Bitnami pattern): reachable
+    # at sync time, but a mirror must rewrite them so offline clients use the
+    # local copy instead of being sent back upstream.
+    base = serve(upstream)
+    _write_upstream(upstream, charts, url_base=base)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-mirror-abs",
+            "name": "Demo mirror abs",
+            "type": "helm",
+            "feed": base,
+            "enabled": True,
+            "mode": "mirror",
+        }
+    )
+    target = chantal_env.sync_and_publish("demo-mirror-abs")
+
+    published = yaml.safe_load((target / "index.yaml").read_text())
+    urls = published["entries"]["demo"][0]["urls"]
+    assert urls == ["demo-0.1.0.tgz"], f"absolute URL not rewritten: {urls}"
 
     ok = _helm(
         target,

--- a/tests/test_helm_sync.py
+++ b/tests/test_helm_sync.py
@@ -428,6 +428,18 @@ class TestHelmIntegration:
         repo_files = db_session.query(RepositoryFile).all()
         assert len(repo_files) == 1
 
+        # The mirrored chart (its filename is the upstream tarball basename).
+        chart = ContentItem(
+            content_type="helm",
+            name="nginx",
+            version="1.0.0",
+            sha256="abc123def456",
+            size_bytes=1,
+            pool_path="ab/c1/nginx-1.0.0.tgz",
+            filename="nginx-1.0.0.tgz",
+            content_metadata={},
+        )
+
         # Publish
         publisher = HelmPublisher(storage=temp_storage)
         target_path = temp_storage.published_path
@@ -438,7 +450,7 @@ class TestHelmIntegration:
             repository=repository,
             target_path=target_path,
             config=repo_config,
-            charts=[],
+            charts=[chart],
             snapshot=None,
         )
 
@@ -446,6 +458,55 @@ class TestHelmIntegration:
         published_index = target_path / "index.yaml"
         assert published_index.exists()
 
-        # Verify content is byte-for-byte identical (mirror mode)
-        original_content = yaml.dump(sample_index_yaml).encode("utf-8")
-        assert published_index.read_bytes() == original_content
+        # The absolute upstream URL must be rewritten to point at this mirror
+        # (the relative chart filename), not back at charts.example.com.
+        published = yaml.safe_load(published_index.read_text())
+        assert published["entries"]["nginx"][0]["urls"] == ["nginx-1.0.0.tgz"]
+
+    def test_mirror_index_matches_by_digest_when_filename_differs(self, temp_storage):
+        """Cross-repo content dedup can make the published filename differ from
+        this index's basename; the version must still be matched (by digest) and
+        rewritten to the published filename, not dropped."""
+        index = {
+            "apiVersion": "v1",
+            "entries": {
+                "demo": [
+                    {
+                        "name": "demo",
+                        "version": "1.0.0",
+                        "digest": "sha256:" + "ab" * 32,
+                        # Upstream basename differs from the deduped pool filename.
+                        "urls": ["https://up.example.com/demo-renamed-1.0.0.tgz"],
+                    }
+                ]
+            },
+            "generated": "2026-01-01T00:00:00Z",
+        }
+        index_path = temp_storage.pool_path / "index.yaml"
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(yaml.safe_dump(index), encoding="utf-8")
+
+        # The published chart was pooled under a different filename (e.g. linked
+        # from another repo) but has the matching content digest.
+        chart = ContentItem(
+            content_type="helm",
+            name="demo",
+            version="1.0.0",
+            sha256="ab" * 32,
+            size_bytes=1,
+            pool_path="ab/ab/demo-pooled-1.0.0.tgz",
+            filename="demo-pooled-1.0.0.tgz",
+            content_metadata={},
+        )
+
+        publisher = HelmPublisher(storage=temp_storage)
+        target = temp_storage.published_path
+        target.mkdir(parents=True, exist_ok=True)
+        repo_config = RepositoryConfig(id="x", name="x", type="helm", feed="https://up.example.com")
+
+        publisher._publish_mirror_index(index_path, target, [chart], repo_config)
+
+        published = yaml.safe_load((target / "index.yaml").read_text())
+        # Matched by digest despite the differing basename -> rewritten to the
+        # actually-published filename, not dropped.
+        assert published["entries"]["demo"][0]["urls"] == ["demo-pooled-1.0.0.tgz"]


### PR DESCRIPTION
## Problem

In Helm **mirror mode** the publisher republished the upstream `index.yaml` **verbatim** (hardlink). Upstream repositories that use **absolute** chart URLs (the Bitnami pattern, e.g. `urls: [https://charts.bitnami.com/bitnami/nginx-1.2.3.tgz]`) therefore left the mirrored index pointing clients **back at the upstream server** — so the offline mirror could not actually serve those charts.

## Fix

The mirror publish path (`_publish_metadata_files`) now parses the pooled upstream `index.yaml` and rewrites every version entry's `urls` to the **published chart filename** (relative, matching the regenerated/filtered path and where charts are actually published — flat in the repo root, which Helm clients resolve against the repo base).

- **Matching is by content digest first**, falling back to the tarball basename. The digest-first match is robust to cross-repo content dedup, where the pooled `ContentItem.filename` can differ from *this* index's URL basename (same bytes, different upstream name) — without it, such a version would be wrongly dropped.
- **Versions whose chart was not published** (filtered out / failed download) are dropped, so the index never references a missing tarball.
- A **malformed upstream index** falls back to regeneration from the published charts.

## Tests

- Updated the mirror unit test (previously asserted byte-identity on an absolute URL) to assert the URL is rewritten to the relative filename.
- Updated the real-helm-client mirror e2e to assert relative URLs + real `helm pull`.
- **New e2e**: absolute upstream URLs (Bitnami-style, pointed at the served upstream) → mirror rewrites to relative → a **real helm client** pulls successfully from the mirror.
- **New unit test**: digest-based match keeps a version whose index basename differs from the published (deduped) filename.

Full lint/type/unit + helm e2e (incl. real-client docker tests) green locally.