### PR TITLE
ci: fail (not silently skip) e2e tests when docker/gpg are missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,10 +93,19 @@ jobs:
         if: matrix.plugin == 'rpm'
         run: sudo apt-get update && sudo apt-get install -y rpm
 
+      - name: Verify e2e toolchain is present
+        run: |
+          echo "docker: $(docker --version)"
+          echo "gpg: $(gpg --version | head -1)"
+
       - name: Run end-to-end sync->publish test
         env:
           # Require the real-rpm signature golden test to run (not skip) on the rpm leg.
           CHANTAL_REQUIRE_RPM_E2E: ${{ matrix.plugin == 'rpm' && '1' || '' }}
+          # Fail (not silently skip) if docker/gpg are missing on the runner, so a
+          # toolchain regression can't turn the real-client e2e tests green.
+          CHANTAL_REQUIRE_DOCKER: '1'
+          CHANTAL_REQUIRE_GPG: '1'
         run: |
           echo "Running E2E sync->publish for ${{ matrix.plugin }}..."
           pytest tests/e2e -v -s -m e2e -k ${{ matrix.plugin }}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import functools
 import http.server
+import os
+import shutil
 import socketserver
 import subprocess
 import sys
@@ -24,6 +26,32 @@ from pathlib import Path
 
 import pytest
 import yaml
+
+# Real-client e2e tests skip when an external tool (docker/gpg) is missing, which
+# is fine for local runs but dangerous in CI: a silently-skipped test is green,
+# so the gate would pass without ever exercising the real client. Setting
+# CHANTAL_REQUIRE_DOCKER / CHANTAL_REQUIRE_GPG turns "missing tool" into a hard
+# failure instead, so CI fails loudly if the toolchain regresses.
+_TOOL_PRESENT = {
+    "docker": shutil.which("docker") is not None,
+    "gpg": shutil.which("gpg") is not None or shutil.which("gpg2") is not None,
+}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _enforce_required_e2e_tools() -> None:
+    """Fail (not skip) the e2e suite when a CHANTAL_REQUIRE_*-mandated tool is absent."""
+    missing = [
+        tool
+        for tool, present in _TOOL_PRESENT.items()
+        if not present and os.environ.get(f"CHANTAL_REQUIRE_{tool.upper()}")
+    ]
+    if missing:
+        pytest.fail(
+            "Required e2e tool(s) not available but CHANTAL_REQUIRE_* is set: "
+            + ", ".join(sorted(missing)),
+            pytrace=False,
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

The real-client e2e tests (`@requires_docker` / `@requires_gpg`) **skip** when docker or gpg is absent. That's correct for local development, but in CI a **skipped test is green** — so if a runner's toolchain ever regressed (docker/gpg missing), the e2e gate would pass **without actually exercising the real client**, giving false confidence.

## Fix

- An autouse, session-scoped fixture in `tests/e2e/conftest.py` turns a missing tool into a **hard failure** when `CHANTAL_REQUIRE_DOCKER` / `CHANTAL_REQUIRE_GPG` is set. When the env var is unset (local runs), the existing per-test skips are unchanged.
- The reusable test workflow (`test.yml`) sets both vars on the e2e job and adds a preflight step printing `docker --version` / `gpg --version`, so a toolchain regression fails CI loudly.

## Verification (local)

- Tools present + both vars set → e2e runs normally (no false positive).
- docker hidden from `PATH` + `CHANTAL_REQUIRE_DOCKER=1` → the e2e test **errors** (red, non-zero exit) with `Required e2e tool(s) not available but CHANTAL_REQUIRE_* is set: docker` instead of skipping.
- yamllint `.github/` and the full unit suite pass.