### PR TITLE
fix(config): reject unknown keys in nested config sections

### DIFF
--- a/docs/schema/chantal-config.schema.json
+++ b/docs/schema/chantal-config.schema.json
@@ -1,6 +1,7 @@
 {
   "$defs": {
     "ApkConfig": {
+      "additionalProperties": false,
       "description": "Alpine APK-specific configuration.",
       "properties": {
         "branch": {
@@ -25,6 +26,7 @@
       "type": "object"
     },
     "AptConfig": {
+      "additionalProperties": false,
       "description": "APT/DEB-specific configuration.",
       "properties": {
         "distribution": {
@@ -156,6 +158,7 @@
       "type": "object"
     },
     "AuthConfig": {
+      "additionalProperties": false,
       "description": "Repository authentication configuration.",
       "properties": {
         "type": {
@@ -257,6 +260,7 @@
       "type": "object"
     },
     "CacheConfig": {
+      "additionalProperties": false,
       "description": "Metadata cache configuration.",
       "properties": {
         "enabled": {
@@ -281,6 +285,7 @@
       "type": "object"
     },
     "DatabaseConfig": {
+      "additionalProperties": false,
       "description": "Database configuration.",
       "properties": {
         "url": {
@@ -308,6 +313,7 @@
       "type": "object"
     },
     "DebFilterConfig": {
+      "additionalProperties": false,
       "description": "DEB/APT-specific filters (future support).",
       "properties": {
         "components": {
@@ -348,6 +354,7 @@
       "type": "object"
     },
     "DownloadConfig": {
+      "additionalProperties": false,
       "description": "Download configuration for file downloads.",
       "properties": {
         "backend": {
@@ -380,6 +387,7 @@
       "type": "object"
     },
     "FilterConfig": {
+      "additionalProperties": false,
       "description": "Package filtering configuration.\n\nSupports both new structure and legacy flat structure for backward compatibility.\n\nStructure:\n- metadata: Generic filters (all package types)\n- rpm/deb/helm: Plugin-specific filters\n- patterns: Generic regex patterns\n- post_processing: Applied after all filters",
       "properties": {
         "metadata": {
@@ -502,6 +510,7 @@
       "type": "object"
     },
     "GenericMetadataFilterConfig": {
+      "additionalProperties": false,
       "description": "Generic metadata filters (work for all package types).",
       "properties": {
         "size_bytes": {
@@ -542,6 +551,7 @@
       "type": "object"
     },
     "GpgConfig": {
+      "additionalProperties": false,
       "description": "GPG signing configuration for APT repositories.\n\nUsed to sign regenerated metadata (Release) in filtered mode so that\nclients can verify the repository without ``[trusted=yes]``.\n\nThe signing key can be provided in three ways (checked in this order):\n\n1. ``key_file`` - import a private (secret) key from an ASCII-armored file.\n2. ``key_id`` - use a key already present in the keyring / ``gnupg_home``.\n3. ``generate_key`` - generate a new keypair if none of the above is set.",
       "properties": {
         "enabled": {
@@ -670,6 +680,7 @@
       "type": "object"
     },
     "ListFilterConfig": {
+      "additionalProperties": false,
       "description": "Generic list-based filtering (include/exclude).",
       "properties": {
         "include": {
@@ -707,6 +718,7 @@
       "type": "object"
     },
     "MetadataConfig": {
+      "additionalProperties": false,
       "description": "Metadata generation configuration (RPM, APT, etc.).",
       "properties": {
         "compression": {
@@ -727,6 +739,7 @@
       "type": "object"
     },
     "PatternFilterConfig": {
+      "additionalProperties": false,
       "description": "Pattern-based filters (regex).",
       "properties": {
         "include": {
@@ -764,6 +777,7 @@
       "type": "object"
     },
     "PostProcessingConfig": {
+      "additionalProperties": false,
       "description": "Post-processing configuration (applied after filtering).",
       "properties": {
         "only_latest_version": {
@@ -788,6 +802,7 @@
       "type": "object"
     },
     "ProxyConfig": {
+      "additionalProperties": false,
       "description": "HTTP proxy configuration.",
       "properties": {
         "http_proxy": {
@@ -1076,6 +1091,7 @@
       "type": "object"
     },
     "RetentionConfig": {
+      "additionalProperties": false,
       "description": "Package retention policy configuration.",
       "properties": {
         "policy": {
@@ -1100,6 +1116,7 @@
       "type": "object"
     },
     "RpmFilterConfig": {
+      "additionalProperties": false,
       "description": "RPM-specific filters.",
       "properties": {
         "exclude_source_rpms": {
@@ -1156,6 +1173,7 @@
       "type": "object"
     },
     "SSLConfig": {
+      "additionalProperties": false,
       "description": "SSL/TLS configuration for HTTPS connections.",
       "properties": {
         "ca_bundle": {
@@ -1216,6 +1234,7 @@
       "type": "object"
     },
     "ScheduleConfig": {
+      "additionalProperties": false,
       "description": "Repository sync schedule configuration.",
       "properties": {
         "enabled": {
@@ -1243,6 +1262,7 @@
       "type": "object"
     },
     "SignatureVerificationConfig": {
+      "additionalProperties": false,
       "description": "Verify the authenticity of an upstream repository via GPG.\n\nThis is independent of :class:`GpgConfig` (which holds the *private* signing\nkey used to re-sign regenerated metadata). Verification needs *public* trust\nanchors - the upstream vendor's public key(s).\n\nIntegrity (SHA256) is always checked during sync; this adds *authenticity*\n(the metadata/packages were signed by a trusted key), analogous to dnf's\n``repo_gpgcheck`` / ``gpgcheck`` and apt's Release signature check.",
       "properties": {
         "enabled": {
@@ -1327,6 +1347,7 @@
       "type": "object"
     },
     "SizeFilterConfig": {
+      "additionalProperties": false,
       "description": "Size-based filtering.",
       "properties": {
         "min": {
@@ -1358,6 +1379,7 @@
       "type": "object"
     },
     "StorageConfig": {
+      "additionalProperties": false,
       "description": "Storage paths configuration.",
       "properties": {
         "base_path": {
@@ -1411,6 +1433,7 @@
       "type": "object"
     },
     "TimeFilterConfig": {
+      "additionalProperties": false,
       "description": "Time-based filtering.",
       "properties": {
         "newer_than": {
@@ -1454,6 +1477,7 @@
       "type": "object"
     },
     "ViewConfig": {
+      "additionalProperties": false,
       "description": "View configuration - groups multiple repositories into one virtual repository.",
       "properties": {
         "name": {

--- a/src/chantal/core/config.py
+++ b/src/chantal/core/config.py
@@ -17,6 +17,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 class ProxyConfig(BaseModel):
     """HTTP proxy configuration."""
 
+    model_config = ConfigDict(extra="forbid")
+
     http_proxy: str | None = None
     https_proxy: str | None = None
     no_proxy: str | None = None
@@ -26,6 +28,8 @@ class ProxyConfig(BaseModel):
 
 class SSLConfig(BaseModel):
     """SSL/TLS configuration for HTTPS connections."""
+
+    model_config = ConfigDict(extra="forbid")
 
     # Path to CA bundle file (PEM format)
     ca_bundle: str | None = None
@@ -43,6 +47,8 @@ class SSLConfig(BaseModel):
 
 class AuthConfig(BaseModel):
     """Repository authentication configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     type: str  # client_cert, basic, bearer, custom
 
@@ -68,6 +74,8 @@ class AuthConfig(BaseModel):
 class RetentionConfig(BaseModel):
     """Package retention policy configuration."""
 
+    model_config = ConfigDict(extra="forbid")
+
     policy: str = "mirror"  # mirror, newest-only, keep-all, keep-last-n
     keep_count: int | None = None  # For keep-last-n policy
 
@@ -84,6 +92,8 @@ class RetentionConfig(BaseModel):
 class ScheduleConfig(BaseModel):
     """Repository sync schedule configuration."""
 
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool = False
     cron: str = "0 2 * * *"  # Daily at 2:00 AM by default
     create_snapshot: bool = False
@@ -93,12 +103,16 @@ class ScheduleConfig(BaseModel):
 class SizeFilterConfig(BaseModel):
     """Size-based filtering."""
 
+    model_config = ConfigDict(extra="forbid")
+
     min: int | None = None  # Minimum size in bytes
     max: int | None = None  # Maximum size in bytes
 
 
 class TimeFilterConfig(BaseModel):
     """Time-based filtering."""
+
+    model_config = ConfigDict(extra="forbid")
 
     newer_than: str | None = None  # ISO date string (e.g., "2025-01-01")
     older_than: str | None = None  # ISO date string
@@ -108,12 +122,16 @@ class TimeFilterConfig(BaseModel):
 class ListFilterConfig(BaseModel):
     """Generic list-based filtering (include/exclude)."""
 
+    model_config = ConfigDict(extra="forbid")
+
     include: list[str] | None = None
     exclude: list[str] | None = None
 
 
 class GenericMetadataFilterConfig(BaseModel):
     """Generic metadata filters (work for all package types)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     size_bytes: SizeFilterConfig | None = None
     build_time: TimeFilterConfig | None = None
@@ -122,6 +140,8 @@ class GenericMetadataFilterConfig(BaseModel):
 
 class RpmFilterConfig(BaseModel):
     """RPM-specific filters."""
+
+    model_config = ConfigDict(extra="forbid")
 
     exclude_source_rpms: bool = False  # Skip .src.rpm packages
     groups: ListFilterConfig | None = None
@@ -133,6 +153,8 @@ class RpmFilterConfig(BaseModel):
 class DebFilterConfig(BaseModel):
     """DEB/APT-specific filters (future support)."""
 
+    model_config = ConfigDict(extra="forbid")
+
     components: ListFilterConfig | None = None  # main, contrib, non-free
     priorities: ListFilterConfig | None = None  # required, important, standard
     sections: ListFilterConfig | None = None  # admin, devel, libs
@@ -141,6 +163,8 @@ class DebFilterConfig(BaseModel):
 class ApkConfig(BaseModel):
     """Alpine APK-specific configuration."""
 
+    model_config = ConfigDict(extra="forbid")
+
     branch: str  # Alpine branch (v3.19, v3.18, edge, etc.)
     repository: str = "main"  # Repository (main, community, testing)
     architecture: str = "x86_64"  # Architecture (x86_64, aarch64, armhf, armv7, x86)
@@ -148,6 +172,8 @@ class ApkConfig(BaseModel):
 
 class AptConfig(BaseModel):
     """APT/DEB-specific configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     distribution: str  # Distribution/suite (jammy, bookworm, focal, bullseye, etc.)
     components: list[str] = Field(
@@ -230,6 +256,8 @@ class GpgConfig(BaseModel):
     3. ``generate_key`` - generate a new keypair if none of the above is set.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     # Enable/disable signing (allows keeping config while turning signing off)
     enabled: bool = True
 
@@ -307,6 +335,8 @@ class SignatureVerificationConfig(BaseModel):
     ``repo_gpgcheck`` / ``gpgcheck`` and apt's Release signature check.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool = False
 
     # What to verify
@@ -376,6 +406,8 @@ class SignatureVerificationConfig(BaseModel):
 class MetadataConfig(BaseModel):
     """Metadata generation configuration (RPM, APT, etc.)."""
 
+    model_config = ConfigDict(extra="forbid")
+
     compression: Literal["auto", "gzip", "zstandard", "bzip2", "none"] = Field(
         default="auto",
         description="Compression format for generated metadata. 'auto' uses same as upstream.",
@@ -393,6 +425,8 @@ class MetadataConfig(BaseModel):
 
 class PatternFilterConfig(BaseModel):
     """Pattern-based filters (regex)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     include: list[str] | None = None  # Include patterns
     exclude: list[str] | None = None  # Exclude patterns
@@ -415,6 +449,8 @@ class PatternFilterConfig(BaseModel):
 class PostProcessingConfig(BaseModel):
     """Post-processing configuration (applied after filtering)."""
 
+    model_config = ConfigDict(extra="forbid")
+
     only_latest_version: bool = False  # Keep only latest version per (name, arch)
     only_latest_n_versions: int | None = None  # Keep last N versions
 
@@ -430,6 +466,8 @@ class FilterConfig(BaseModel):
     - patterns: Generic regex patterns
     - post_processing: Applied after all filters
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     # Generic filters (all package types)
     metadata: GenericMetadataFilterConfig | None = None
@@ -587,6 +625,8 @@ class RepositoryConfig(BaseModel):
 class DatabaseConfig(BaseModel):
     """Database configuration."""
 
+    model_config = ConfigDict(extra="forbid")
+
     url: str = "sqlite:///chantal.db"
     pool_size: int = 5
     max_overflow: int = 10
@@ -595,6 +635,8 @@ class DatabaseConfig(BaseModel):
 
 class CacheConfig(BaseModel):
     """Metadata cache configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     enabled: bool = False  # Global default
     max_age_hours: int | None = None  # Optional TTL for cache invalidation
@@ -610,6 +652,8 @@ class CacheConfig(BaseModel):
 
 class StorageConfig(BaseModel):
     """Storage paths configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     base_path: str = "/var/lib/chantal"
     pool_path: str | None = None  # Defaults to {base_path}/pool
@@ -638,6 +682,8 @@ class StorageConfig(BaseModel):
 
 class ViewConfig(BaseModel):
     """View configuration - groups multiple repositories into one virtual repository."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     description: str | None = None
@@ -677,6 +723,8 @@ class ViewConfig(BaseModel):
 
 class DownloadConfig(BaseModel):
     """Download configuration for file downloads."""
+
+    model_config = ConfigDict(extra="forbid")
 
     backend: str = "requests"  # requests, aria2c (future)
     parallel: int = 1  # Parallel downloads (backend-dependent)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -25,6 +25,25 @@ def test_unknown_top_level_key_is_rejected():
         GlobalConfig(databse={"url": "sqlite://"})
 
 
+@pytest.mark.parametrize(
+    "section, payload",
+    [
+        ("ssl", {"verifyy": False}),  # SSLConfig typo
+        ("apt", {"distribution": "jammy", "componentss": ["main"]}),  # AptConfig typo
+        ("schedule", {"enabledd": True}),  # ScheduleConfig typo
+        ("storage", {"base_pathh": "/tmp"}),  # StorageConfig typo (top-level section)
+    ],
+)
+def test_unknown_key_on_nested_model_is_rejected(section, payload):
+    """A typo in a nested config section must fail loudly, not be silently dropped."""
+    if section == "storage":
+        with pytest.raises(ValidationError, match="Extra inputs|base_pathh"):
+            GlobalConfig(storage=payload)
+    else:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            RepositoryConfig(**_repo(**{section: payload}))
+
+
 def test_view_referencing_unknown_repo_is_rejected():
     with pytest.raises(ValidationError, match="unknown repository"):
         GlobalConfig(


### PR DESCRIPTION
## Problem

Only the two top-level config models (`RepositoryConfig`, `GlobalConfig`) set `extra="forbid"`. Every **nested** config model still defaulted to `extra="ignore"`, so a typo in a nested section was **silently dropped** and the intended setting never applied — e.g.:

- `ssl: { verifyy: false }` → SSL verification stays on
- `apt: { componentss: [main] }` → component list ignored
- `schedule: { enabledd: true }` → schedule stays disabled
- `storage: { base_pathh: ... }` → path ignored

## Fix

Add `model_config = ConfigDict(extra="forbid")` to all **24 nested config models** in `src/chantal/core/config.py`. A misspelled nested key now fails loudly at load time with a path-precise Pydantic error (the loader already surfaces these cleanly via the CLI as `Error: ...`, no traceback).

## Notes

- **No model that needs dynamic keys is affected** — the only dict-typed field (`AuthConfig.headers`) is a field *value*, not extra model keys, and still accepts arbitrary header names.
- **All 38 shipped example configs still validate.**
- Regenerated the committed JSON schema (`docs/schema/chantal-config.schema.json` — nested `$defs` now carry `additionalProperties: false`).
- Added regression tests for nested-key rejection (`tests/test_config_validation.py`).

Backward-compat: intentional behavior change — a previously-silently-ignored typo now hard-fails. No field is a legitimately-dynamic map, so there is no false-positive surface.

Full lint/type/unit gate green locally.