### PR TITLE
fix(helm): survive digest-less re-sync and cap Chart.yaml size

### DIFF
--- a/src/chantal/plugins/helm/chart.py
+++ b/src/chantal/plugins/helm/chart.py
@@ -19,6 +19,12 @@ class ChartFormatError(Exception):
     """Raised when the bytes are not a parseable Helm chart archive."""
 
 
+# A real Chart.yaml is a few KB. Cap the member well above any legitimate value
+# so a crafted archive declaring a huge Chart.yaml cannot exhaust memory when we
+# read it.
+_MAX_CHART_YAML_BYTES = 1 * 1024 * 1024
+
+
 def parse_chart_metadata(path: Path) -> dict:
     """Extract the ``Chart.yaml`` metadata from a packaged chart ``.tgz``.
 
@@ -42,6 +48,14 @@ def parse_chart_metadata(path: Path) -> dict:
             # The top-level Chart.yaml is the shallowest ("<chart>/Chart.yaml");
             # deeper ones belong to bundled subcharts (charts/<dep>/Chart.yaml).
             member = min(members, key=lambda m: m.name.count("/"))
+            # Reject an oversized Chart.yaml before reading it into memory so a
+            # crafted archive cannot exhaust memory. ``extractfile().read()`` is
+            # bounded by the (now-capped) member size.
+            if member.size > _MAX_CHART_YAML_BYTES:
+                raise ChartFormatError(
+                    f"Chart.yaml is too large ({member.size} bytes; "
+                    f"limit {_MAX_CHART_YAML_BYTES})"
+                )
             extracted = tar.extractfile(member)
             if extracted is None:
                 raise ChartFormatError("could not read Chart.yaml from chart archive")

--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -156,7 +156,7 @@ class HelmSyncer:
                         stats["charts_updated"] += 1
                     else:
                         stats["charts_skipped"] += 1
-                    self.output.update_progress()
+                    # Progress is advanced once by the finally block below.
                     continue
 
                 # Download chart
@@ -187,6 +187,23 @@ class HelmSyncer:
                         f"digest mismatch for {chart_name}: index.yaml advertises "
                         f"{expected_digest}, downloaded content is {sha256} (possible tampering)"
                     )
+
+                # Deduplicate by the actual downloaded content. When index.yaml
+                # omits a digest the pre-download check above is skipped, so a
+                # re-sync would otherwise try to insert a second ContentItem with
+                # the same sha256 and hit the unique constraint (IntegrityError).
+                # Autoflush makes this also catch a duplicate added earlier in
+                # this same run. Link to the pooled chart instead of re-inserting.
+                existing_by_content = (
+                    session.query(ContentItem).filter_by(content_type="helm", sha256=sha256).first()
+                )
+                if existing_by_content:
+                    if repository not in existing_by_content.repositories:
+                        existing_by_content.repositories.append(repository)
+                        stats["charts_updated"] += 1
+                    else:
+                        stats["charts_skipped"] += 1
+                    continue
 
                 # Create metadata
                 metadata = HelmMetadata(**chart_entry)

--- a/tests/test_helm_sync.py
+++ b/tests/test_helm_sync.py
@@ -463,6 +463,71 @@ class TestHelmIntegration:
         published = yaml.safe_load(published_index.read_text())
         assert published["entries"]["nginx"][0]["urls"] == ["nginx-1.0.0.tgz"]
 
+    @patch("chantal.plugins.helm.sync.HelmSyncer._store_index_file")
+    @patch("chantal.plugins.helm.sync.HelmSyncer._download_chart")
+    @patch("chantal.plugins.helm.sync.HelmSyncer._fetch_index")
+    def test_resync_digestless_index_does_not_crash(
+        self, mock_fetch, mock_download, mock_store, temp_storage, db_session, repository
+    ):
+        """An index.yaml without digests must be re-syncable.
+
+        With no digest the pre-download dedup is skipped, so a second sync used
+        to insert a duplicate ContentItem (same sha256) and hit the unique
+        constraint. The post-download dedup-by-content must link instead.
+        """
+        # index.yaml entry WITHOUT a digest field.
+        mock_fetch.return_value = {
+            "apiVersion": "v1",
+            "entries": {"demo": [{"name": "demo", "version": "0.1.0", "urls": ["demo-0.1.0.tgz"]}]},
+        }
+        mock_download.return_value = (Path("ab/cd/demo-0.1.0.tgz"), "ab" * 32, 123)
+
+        repo_config = RepositoryConfig(
+            id="test-helm", name="Test", type="helm", feed="https://charts.example.com"
+        )
+        syncer = HelmSyncer(storage=temp_storage, config=repo_config)
+
+        first = syncer.sync_repository(db_session, repository, repo_config)
+        assert first["charts_added"] == 1
+
+        # Second sync must not raise IntegrityError; it links the existing chart.
+        second = syncer.sync_repository(db_session, repository, repo_config)
+        assert second["charts_added"] == 0
+        assert second["charts_skipped"] + second["charts_updated"] == 1
+
+        charts = db_session.query(ContentItem).filter_by(content_type="helm").all()
+        assert len(charts) == 1
+
+    @patch("chantal.plugins.helm.sync.HelmSyncer._store_index_file")
+    @patch("chantal.plugins.helm.sync.HelmSyncer._download_chart")
+    @patch("chantal.plugins.helm.sync.HelmSyncer._fetch_index")
+    def test_digestless_duplicate_entries_in_one_sync_dedup(
+        self, mock_fetch, mock_download, mock_store, temp_storage, db_session, repository
+    ):
+        """Two digest-less index entries resolving to identical bytes in ONE sync
+        must dedup via autoflush, not hit the unique constraint."""
+        mock_fetch.return_value = {
+            "apiVersion": "v1",
+            "entries": {
+                "demo": [
+                    {"name": "demo", "version": "0.1.0", "urls": ["demo-0.1.0.tgz"]},
+                    {"name": "demo", "version": "0.1.0-dup", "urls": ["demo-0.1.0-dup.tgz"]},
+                ]
+            },
+        }
+        # Both "downloads" yield the same content (same sha256).
+        mock_download.return_value = (Path("ab/cd/demo.tgz"), "cd" * 32, 123)
+
+        repo_config = RepositoryConfig(
+            id="test-helm", name="Test", type="helm", feed="https://charts.example.com"
+        )
+        syncer = HelmSyncer(storage=temp_storage, config=repo_config)
+
+        stats = syncer.sync_repository(db_session, repository, repo_config)
+        assert stats["charts_added"] == 1  # second entry deduped within the run
+        charts = db_session.query(ContentItem).filter_by(content_type="helm").all()
+        assert len(charts) == 1
+
     def test_mirror_index_matches_by_digest_when_filename_differs(self, temp_storage):
         """Cross-repo content dedup can make the published filename differ from
         this index's basename; the version must still be matched (by digest) and

--- a/tests/test_helm_upload.py
+++ b/tests/test_helm_upload.py
@@ -139,6 +139,18 @@ def test_parse_chart_rejects_non_dict_chart_yaml():
         _parse_bytes(buf.getvalue())
 
 
+def test_parse_chart_rejects_oversized_chart_yaml():
+    """A chart whose Chart.yaml expands to a huge size must be refused, not read."""
+    # ~4 MiB of highly-compressible YAML -> a few KB gzipped (a bomb), over the
+    # 1 MiB Chart.yaml cap.
+    bomb = ("a: " + "A" * (4 * 1024 * 1024) + "\nname: demo\nversion: 0.1.0\n").encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        _add(tar, "demo/Chart.yaml", bomb)
+    with pytest.raises(ChartFormatError, match="too large|maximum allowed size"):
+        _parse_bytes(buf.getvalue())
+
+
 def test_upload_maps_chart_fields(session, storage, repository, tmp_path):
     f = tmp_path / "demo-0.1.0.tgz"
     f.write_bytes(_build_chart())


### PR DESCRIPTION
## Problems

1. **Digest-less re-sync crash.** When an upstream `index.yaml` omits a chart `digest`, the pre-download dedup (keyed on the digest) is skipped. So a **second sync** re-downloaded the chart and tried to insert a *second* `ContentItem` with the same content `sha256` → **`IntegrityError`** on the global unique constraint. The re-sync failed outright.
2. **Chart.yaml decompression bomb.** `parse_chart_metadata` read the selected `Chart.yaml` tar member with an **unbounded** `read()`, so a crafted chart archive declaring a huge `Chart.yaml` could exhaust memory.

## Fixes

1. After `_download_chart` returns the actual `sha256`, dedup by content: if a `ContentItem` with that `sha256` already exists, **link it to the repository** (updated/skipped) instead of re-inserting. SQLAlchemy autoflush makes this also catch duplicate entries **within a single sync**.
2. Reject a `Chart.yaml` whose declared tar member size exceeds a **1 MiB** cap before reading it (real `Chart.yaml` is a few KB). `extractfile().read()` is then bounded by the capped member size.

## Notes / scope

- `parse_chart_metadata` is reachable only from the operator **upload** path (`chantal package upload`), not from untrusted remote sync — so the bomb cap is defense-in-depth. The dedup fix is on the remote-sync path and is the more impactful correctness fix.

## Tests

- Digest-less index synced **twice** → no IntegrityError, exactly one `ContentItem` (fails without the fix).
- Two digest-less entries resolving to identical bytes in **one** sync → deduped via autoflush.
- Oversized `Chart.yaml` (~4 MiB, tiny gzipped) → `ChartFormatError`.

Also drops a stray double progress-bar advance in the pre-download dedup branch. Full lint/type/unit + helm e2e green locally.