### PR TITLE
fix(rpm): robust zstd decompress and NVRA matching when filtering metadata

### DIFF
--- a/src/chantal/plugins/rpm/parsers.py
+++ b/src/chantal/plugins/rpm/parsers.py
@@ -10,6 +10,7 @@ import bz2
 import configparser
 import gzip
 import hashlib
+import io
 import logging
 import lzma
 import xml.etree.ElementTree as ET
@@ -294,8 +295,9 @@ def _decompress_metadata(compressed_content: bytes, filename: str) -> bytes:
     elif filename.endswith(".gz"):
         return gzip.decompress(compressed_content)
     elif filename.endswith(".zst"):
-        dctx = zstd.ZstdDecompressor()
-        return dctx.decompress(compressed_content)
+        # Streaming reader: the one-shot decompress() needs the frame to embed
+        # its content size, which createrepo_c/zstd often omit.
+        return zstd.ZstdDecompressor().stream_reader(io.BytesIO(compressed_content)).read()
     elif filename.endswith(".bz2"):
         return bz2.decompress(compressed_content)
 
@@ -305,8 +307,9 @@ def _decompress_metadata(compressed_content: bytes, filename: str) -> bytes:
     elif compressed_content[:6] == b"\xfd7zXZ\x00":  # xz magic
         return lzma.decompress(compressed_content)
     elif compressed_content[:4] == b"\x28\xb5\x2f\xfd":  # zstandard magic
-        dctx = zstd.ZstdDecompressor()
-        return dctx.decompress(compressed_content)
+        # Streaming reader: the one-shot decompress() needs the frame to embed
+        # its content size, which createrepo_c/zstd often omit.
+        return zstd.ZstdDecompressor().stream_reader(io.BytesIO(compressed_content)).read()
     elif compressed_content[:3] == b"BZh":  # bzip2 magic
         return bz2.decompress(compressed_content)
     else:

--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -9,6 +9,8 @@ This module implements publishing for RPM repositories with yum/dnf metadata.
 import bz2
 import gzip
 import hashlib
+import io
+import lzma
 import shutil
 import xml.etree.ElementTree as ET
 from datetime import UTC, datetime
@@ -805,16 +807,25 @@ class RpmPublisher(PublisherPlugin):
 
         return nvras
 
-    def _build_package_pkgid_set(self, packages: list[ContentItem]) -> set[str]:
-        """Build set of package IDs (SHA256) for filtering.
+    @staticmethod
+    def _package_elem_nvra(package_elem: ET.Element, ns: str) -> str | None:
+        """NVRA of a filelists/other ``<package>`` element, or None if incomplete.
 
-        Args:
-            packages: List of ContentItem packages
-
-        Returns:
-            Set of pkgid strings (SHA256 checksums)
+        filelists.xml/other.xml ``<package>`` carry ``name``/``arch`` attributes
+        and a ``<version epoch ver rel/>`` child - the same fields used to build
+        the surviving-package NVRA set, so matching is algorithm-agnostic (works
+        for sha1/sha256/sha512 repos, unlike the pkgid checksum).
         """
-        return {pkg.sha256 for pkg in packages}
+        name = package_elem.get("name")
+        arch = package_elem.get("arch")
+        version_elem = package_elem.find(f"{{{ns}}}version")
+        if version_elem is None or not name or not arch:
+            return None
+        ver = version_elem.get("ver")
+        rel = version_elem.get("rel")
+        if not ver or not rel:
+            return None
+        return f"{name}-{ver}-{rel}.{arch}"
 
     def _build_module_artifact_nevra_set(self, packages: list[ContentItem]) -> set[str]:
         """Build the modulemd-style NEVRA set used to filter ``modules.yaml``.
@@ -951,43 +962,27 @@ class RpmPublisher(PublisherPlugin):
         filelists_path = filelists_entry[1]
 
         try:
-            # Build set of available package IDs
-            available_pkgids = self._build_package_pkgid_set(packages)
+            # Match by NVRA (not pkgid): the filelists pkgid is the package
+            # checksum in the repo's algorithm (sha1/sha256/sha512), which need
+            # not equal the locally-computed sha256 we store. NVRA matches the
+            # primary filter exactly, so primary and filelists always agree.
+            available_nvras = self._build_package_nvra_set(packages)
+            ns = "http://linux.duke.edu/metadata/filelists"
 
-            # Parse and filter filelists.xml
-            import lzma
-            import xml.etree.ElementTree as ET
-
-            # Decompress based on extension
-            if filelists_path.suffix == ".xz":
-                with lzma.open(filelists_path, "rb") as f:
-                    tree = ET.parse(f)
-            elif filelists_path.suffix == ".bz2":
-                with bz2.open(filelists_path, "rb") as f:
-                    tree = ET.parse(f)
-            elif filelists_path.suffix == ".gz":
-                with gzip.open(filelists_path, "rb") as f:
-                    tree = ET.parse(f)
-            elif filelists_path.suffix == ".zst":
-                import io
-
-                import zstandard as zstd
-
-                with open(filelists_path, "rb") as f:
-                    dctx = zstd.ZstdDecompressor()
-                    decompressed = dctx.decompress(f.read())
-                    tree = ET.parse(io.BytesIO(decompressed))
-            else:
-                tree = ET.parse(filelists_path)
+            # Stream-decompress (the one-shot zstd path fails on frames without an
+            # embedded content size, which createrepo_c often omits).
+            tree = ET.parse(
+                io.BytesIO(decompress_bytes(filelists_path.read_bytes(), filelists_path.suffix))
+            )
 
             root = tree.getroot()
             original_count = int(root.get("packages", "0"))
 
-            # Filter packages by pkgid
+            # Filter packages by NVRA
             packages_to_remove = []
-            for package_elem in root.findall("{http://linux.duke.edu/metadata/filelists}package"):
-                pkgid = package_elem.get("pkgid")
-                if pkgid not in available_pkgids:
+            for package_elem in root.findall(f"{{{ns}}}package"):
+                nvra = self._package_elem_nvra(package_elem, ns)
+                if nvra is None or nvra not in available_nvras:
                     packages_to_remove.append(package_elem)
 
             for package_elem in packages_to_remove:
@@ -1088,43 +1083,24 @@ class RpmPublisher(PublisherPlugin):
         other_path = other_entry[1]
 
         try:
-            # Build set of available package IDs
-            available_pkgids = self._build_package_pkgid_set(packages)
+            # Match by NVRA (not pkgid) - see _filter_and_regenerate_filelists.
+            available_nvras = self._build_package_nvra_set(packages)
+            ns = "http://linux.duke.edu/metadata/other"
 
-            # Parse and filter other.xml
-            import lzma
-            import xml.etree.ElementTree as ET
-
-            # Decompress based on extension
-            if other_path.suffix == ".xz":
-                with lzma.open(other_path, "rb") as f:
-                    tree = ET.parse(f)
-            elif other_path.suffix == ".bz2":
-                with bz2.open(other_path, "rb") as f:
-                    tree = ET.parse(f)
-            elif other_path.suffix == ".gz":
-                with gzip.open(other_path, "rb") as f:
-                    tree = ET.parse(f)
-            elif other_path.suffix == ".zst":
-                import io
-
-                import zstandard as zstd
-
-                with open(other_path, "rb") as f:
-                    dctx = zstd.ZstdDecompressor()
-                    decompressed = dctx.decompress(f.read())
-                    tree = ET.parse(io.BytesIO(decompressed))
-            else:
-                tree = ET.parse(other_path)
+            # Stream-decompress (the one-shot zstd path fails on frames without an
+            # embedded content size, which createrepo_c often omits).
+            tree = ET.parse(
+                io.BytesIO(decompress_bytes(other_path.read_bytes(), other_path.suffix))
+            )
 
             root = tree.getroot()
             original_count = int(root.get("packages", "0"))
 
-            # Filter packages by pkgid
+            # Filter packages by NVRA
             packages_to_remove = []
-            for package_elem in root.findall("{http://linux.duke.edu/metadata/other}package"):
-                pkgid = package_elem.get("pkgid")
-                if pkgid not in available_pkgids:
+            for package_elem in root.findall(f"{{{ns}}}package"):
+                nvra = self._package_elem_nvra(package_elem, ns)
+                if nvra is None or nvra not in available_nvras:
                     packages_to_remove.append(package_elem)
 
             for package_elem in packages_to_remove:

--- a/src/chantal/plugins/rpm/updateinfo.py
+++ b/src/chantal/plugins/rpm/updateinfo.py
@@ -7,12 +7,11 @@ This module provides parsing and filtering for updateinfo.xml files,
 which contain security advisories, bug fixes, and enhancement information.
 """
 
-import bz2
-import gzip
-import lzma
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
+
+from chantal.plugins.rpm.modules import decompress_bytes
 
 
 @dataclass
@@ -51,7 +50,7 @@ class UpdateInfoParser:
     def parse_file(self, file_path: Path) -> list[Update]:
         """Parse updateinfo.xml file.
 
-        Supports .xml, .xml.gz, .xml.bz2, and .xml.xz compression.
+        Supports .xml, .xml.gz, .xml.bz2, .xml.xz and .xml.zst compression.
 
         Args:
             file_path: Path to updateinfo file
@@ -59,22 +58,12 @@ class UpdateInfoParser:
         Returns:
             List of Update objects
         """
-        # Decompress based on extension
-        if file_path.suffix == ".bz2":
-            with bz2.open(file_path, "rt", encoding="utf-8") as f:
-                xml_content = f.read()
-        elif file_path.suffix == ".gz":
-            with gzip.open(file_path, "rt", encoding="utf-8") as f:
-                xml_content = f.read()
-        elif file_path.suffix == ".xz":
-            with lzma.open(file_path, "rt", encoding="utf-8") as f:
-                xml_content = f.read()
-        else:
-            with open(file_path, encoding="utf-8") as f:
-                xml_content = f.read()
+        # Stream-decompress by suffix (the shared helper handles zstd frames
+        # without an embedded content size, which the one-shot path cannot).
+        xml_bytes = decompress_bytes(file_path.read_bytes(), file_path.suffix)
 
         # Parse XML
-        root = ET.fromstring(xml_content)
+        root = ET.fromstring(xml_bytes)
 
         return self._parse_updates(root)
 

--- a/tests/test_rpm_filtered_secondary.py
+++ b/tests/test_rpm_filtered_secondary.py
@@ -1,0 +1,110 @@
+"""Regression tests for filtering RPM secondary metadata (filelists/other).
+
+Two bugs are covered:
+
+* **zstd one-shot decompression** - a ``filelists.xml.zst`` whose frame omits the
+  embedded content size (what createrepo_c/streaming producers emit) used to make
+  the one-shot ``ZstdDecompressor().decompress()`` raise, so the filter silently
+  republished the *unfiltered* upstream file.
+* **pkgid checksum algorithm** - filelists/other were matched against the
+  surviving packages by ``pkgid`` (the package checksum in the repo's algorithm,
+  which may be sha1/sha512), compared to the locally-computed sha256. For a
+  sha1/sha512 repo that mismatch dropped *every* package from filelists/other.
+  Matching by NVRA fixes both algorithms.
+"""
+
+from __future__ import annotations
+
+import io
+import xml.etree.ElementTree as ET
+
+import pytest
+import zstandard as zstd
+
+from chantal.core.config import StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.models import ContentItem
+from chantal.plugins.rpm.publisher import RpmPublisher
+
+FILELISTS_NS = "http://linux.duke.edu/metadata/filelists"
+
+
+def _zst_sizeless(data: bytes) -> bytes:
+    """zstd-compress without an embedded content-size header (streaming frame)."""
+    buf = io.BytesIO()
+    with zstd.ZstdCompressor().stream_writer(buf, closefd=False) as w:
+        w.write(data)
+    return buf.getvalue()
+
+
+def _filelists_xml(pkgid: str, checksum_type: str) -> bytes:
+    """A one-package filelists.xml whose pkgid uses the given checksum algorithm."""
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f'<filelists xmlns="{FILELISTS_NS}" packages="2">\n'
+        f'  <package pkgid="{pkgid}" name="demo" arch="x86_64">\n'
+        '    <version epoch="0" ver="1.0" rel="1.el9"/>\n'
+        "    <file>/usr/bin/demo</file>\n"
+        "  </package>\n"
+        f'  <package pkgid="{"f" * len(pkgid)}" name="gone" arch="x86_64">\n'
+        '    <version epoch="0" ver="2.0" rel="1.el9"/>\n'
+        "    <file>/usr/bin/gone</file>\n"
+        "  </package>\n"
+        "</filelists>\n"
+    ).encode()
+
+
+@pytest.fixture
+def publisher(tmp_path):
+    storage = StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(tmp_path / "pool"),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+    return RpmPublisher(storage=storage)
+
+
+@pytest.mark.parametrize(
+    "checksum_type, pkgid",
+    [
+        ("sha1", "a" * 40),  # older repos
+        ("sha256", "b" * 64),
+        ("sha512", "c" * 128),  # newer EL9/Fedora
+    ],
+)
+def test_filter_filelists_zst_matches_by_nvra(publisher, tmp_path, checksum_type, pkgid):
+    """A sha1/sha256/sha512 repo with a size-less .zst filelists must keep the
+    surviving package (matched by NVRA) and drop the removed one."""
+    repodata = tmp_path / "repodata"
+    repodata.mkdir()
+    filelists_path = repodata / "filelists.xml.zst"
+    filelists_path.write_bytes(_zst_sizeless(_filelists_xml(pkgid, checksum_type)))
+
+    # The surviving package: same NVRA as the 'demo' entry, but its stored sha256
+    # deliberately differs from the upstream pkgid (which may be sha1/sha512).
+    survivor = ContentItem(
+        content_type="rpm",
+        name="demo",
+        version="1.0",
+        sha256="d" * 64,
+        size_bytes=1,
+        pool_path="dd/dd/demo.rpm",
+        filename="demo-1.0-1.el9.x86_64.rpm",
+        content_metadata={"release": "1.el9", "arch": "x86_64"},
+    )
+
+    result = publisher._filter_and_regenerate_filelists(
+        [survivor], repodata, [("filelists", filelists_path)]
+    )
+
+    # The filter must have produced a regenerated file (not fallen back to the
+    # unfiltered original on a decompression error).
+    _, out_path = next(ft for ft in result if ft[0] == "filelists")
+    from chantal.plugins.rpm.modules import decompress_bytes
+
+    root = ET.fromstring(decompress_bytes(out_path.read_bytes(), out_path.suffix))
+    names = [p.get("name") for p in root.findall(f"{{{FILELISTS_NS}}}package")]
+    assert names == ["demo"], f"expected only the surviving NVRA, got {names}"
+    assert root.get("packages") == "1"

--- a/tests/test_rpm_parsers_zstd.py
+++ b/tests/test_rpm_parsers_zstd.py
@@ -82,6 +82,22 @@ class TestZstdDecompression:
         with pytest.raises(ValueError, match="Unknown compression format"):
             _decompress_metadata(b"invalid data", "unknown.xyz")
 
+    def test_decompress_zst_frame_without_content_size(self) -> None:
+        """A zstd frame without an embedded content size (what createrepo_c and
+        streaming producers emit) must still decompress - the one-shot
+        decompress() used to raise 'could not determine content size'."""
+        import io
+
+        buf = io.BytesIO()
+        # stream_writer produces a frame WITHOUT a content-size header.
+        with zstd.ZstdCompressor().stream_writer(buf, closefd=False) as w:
+            w.write(self.TEST_XML)
+        sizeless = buf.getvalue()
+
+        assert _decompress_metadata(sizeless, "primary.xml.zst") == self.TEST_XML
+        # Also via magic-byte detection (no suffix hint).
+        assert _decompress_metadata(sizeless, "unknown.bin") == self.TEST_XML
+
 
 class TestZstdVariousLevels:
     """Test zstandard decompression at various compression levels."""


### PR DESCRIPTION
## Problems

Two bugs in **filtered-mode** RPM secondary-metadata handling:

1. **zstd one-shot decompression.** `filelists.xml`/`other.xml` were decompressed with the one-shot `ZstdDecompressor().decompress()`, and `updateinfo.xml` had **no `.zst` branch at all**. The one-shot path raises `could not determine content size in frame header` on zstd frames that omit the embedded content size — exactly what `createrepo_c` / streaming producers emit. The filter then silently fell back to republishing the **unfiltered** upstream file (stale; listing removed packages).
2. **pkgid checksum algorithm.** `filelists`/`other` were filtered by matching the `pkgid` attribute (the package checksum in the **repo's** algorithm — sha1/sha256/sha512) against the **locally-computed sha256** of surviving packages. On a sha1 or sha512 repo, that mismatch dropped **every** package from `filelists`/`other`, leaving a `primary` that references packages with no file lists (dnf loses file-provides/changelogs).

## Fixes

1. Route `filelists`/`other`/`updateinfo` decompression (and `parsers._decompress_metadata`'s two zstd sites) through the **streaming** reader / shared `decompress_bytes`, which handles size-less frames.
2. Match `filelists`/`other` `<package>` elements by **NVRA** (`name-version-release.arch`) via the existing `_build_package_nvra_set` — the same key the `primary` filter uses — so matching is algorithm-agnostic and `primary` and `filelists`/`other` always agree. Removed the sha256-only `_build_package_pkgid_set`.

## Tests

- Filter a **sha1**, **sha256**, and **sha512** repo whose `filelists.xml.zst` uses a **content-size-less** zstd frame → the surviving package (matched by NVRA, its stored sha256 deliberately ≠ the pkgid) is **kept** and the removed one dropped. Fails on the old code (zstd raises / pkgid mismatch drops everything).
- `_decompress_metadata` on a size-less zstd frame (by suffix and by magic bytes).

Full lint/type/unit + RPM e2e green locally.