### PR TITLE
fix(rpm): confine installer/.treeinfo paths to the repository tree

### DIFF
--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -593,7 +593,17 @@ class RpmPublisher(PublisherPlugin):
                 target_file_path = target_path / ".treeinfo"
             else:
                 # original_path like "images/boot.iso" or "images/pxeboot/vmlinuz"
-                target_file_path = target_path / repo_file.original_path
+                # original_path is taken verbatim from the upstream .treeinfo, so
+                # confine it to the repository tree: a malicious entry like
+                # "../../etc/cron.d/x" or an absolute path would otherwise hardlink
+                # attacker-controlled content outside the published repo.
+                target_file_path = (target_path / repo_file.original_path).resolve()
+                if not target_file_path.is_relative_to(target_path.resolve()):
+                    print(
+                        f"Warning: skipping installer file with unsafe path: "
+                        f"{repo_file.original_path!r}"
+                    )
+                    continue
 
             # Create parent directories
             target_file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_rpm_kickstart_path.py
+++ b/tests/test_rpm_kickstart_path.py
@@ -1,0 +1,80 @@
+"""Regression test: installer/.treeinfo paths from upstream must be confined.
+
+``original_path`` for kickstart/installer files comes verbatim from the upstream
+``.treeinfo``. A malicious entry (``../../etc/cron.d/x`` or an absolute path)
+must not let the publisher hardlink attacker-controlled content outside the
+published repository tree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chantal.core.config import StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.models import RepositoryFile
+from chantal.plugins.rpm.publisher import RpmPublisher
+
+
+@pytest.fixture
+def publisher_and_pool(tmp_path):
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    storage = StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(pool),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+    # A pooled blob the kickstart files point at.
+    blob_dir = pool / "ab" / "cd"
+    blob_dir.mkdir(parents=True)
+    (blob_dir / "blob.bin").write_bytes(b"payload")
+    return RpmPublisher(storage=storage), tmp_path
+
+
+def _kickstart(original_path: str) -> RepositoryFile:
+    return RepositoryFile(
+        file_category="kickstart",
+        file_type="boot.iso",
+        sha256="a" * 64,
+        pool_path="ab/cd/blob.bin",
+        size_bytes=7,
+        original_path=original_path,
+        file_metadata={},
+    )
+
+
+def test_kickstart_relative_traversal_is_skipped(publisher_and_pool):
+    publisher, tmp_path = publisher_and_pool
+    target = tmp_path / "published"
+    target.mkdir(exist_ok=True)
+
+    publisher._publish_kickstart_files([_kickstart("../escaped.bin")], target)
+
+    # The escaping write must not have happened anywhere outside the repo tree.
+    assert not (tmp_path / "escaped.bin").exists()
+    assert list(target.rglob("*")) == []  # nothing published either
+
+
+def test_kickstart_absolute_path_is_skipped(publisher_and_pool):
+    publisher, tmp_path = publisher_and_pool
+    target = tmp_path / "published"
+    target.mkdir(exist_ok=True)
+    evil = tmp_path / "evil_abs.bin"
+
+    publisher._publish_kickstart_files([_kickstart(str(evil))], target)
+
+    assert not evil.exists()
+
+
+def test_kickstart_safe_relative_path_is_published(publisher_and_pool):
+    publisher, tmp_path = publisher_and_pool
+    target = tmp_path / "published"
+    target.mkdir(exist_ok=True)
+
+    publisher._publish_kickstart_files([_kickstart("images/pxeboot/vmlinuz")], target)
+
+    out = target / "images" / "pxeboot" / "vmlinuz"
+    assert out.exists() and out.read_bytes() == b"payload"


### PR DESCRIPTION
## Problem (security — path traversal / arbitrary file write)

Installer/kickstart file paths (`boot.iso`, `pxeboot/vmlinuz`, …) are taken **verbatim** from the upstream `.treeinfo` and stored as `RepositoryFile.original_path`. At publish time `_publish_kickstart_files` joined that to the target dir **without sanitization**:

```python
target_file_path = target_path / repo_file.original_path
...
os.link(pool_file_path, target_file_path)
```

A malicious upstream serving a `.treeinfo` with `boot.iso = ../../../../etc/cron.d/pwn` (or an absolute path) makes the publisher **hardlink attacker-controlled content outside the published repository tree** — `Path(base) / '/abs'` discards the base, and `../` escapes. The pool blob is attacker-controlled (their server answers the download). The pool itself was safe (keys on basename); only the publish step was exploitable, and it runs on every publish of a repo shipping a `.treeinfo`.

## Fix

Resolve the target and require it to stay under the repository root before linking — the same `resolve()` + `is_relative_to()` guard already used for the published client key (`publisher.py:271`). Installer entries whose path escapes are skipped with a warning.

## Tests

- Relative `../escaped.bin` and **absolute**-path installer entries — both previously wrote outside the tree — are now skipped (regression; fail without the guard).
- A safe nested path (`images/pxeboot/vmlinuz`) still publishes correctly.