### PR TITLE
fix(apk): dedup by content sha256 so a duplicate index entry can't abort sync

### DIFF
--- a/src/chantal/plugins/apk/sync.py
+++ b/src/chantal/plugins/apk/sync.py
@@ -140,6 +140,13 @@ class ApkSyncer:
 
         self.output.start_progress(len(filtered_packages), "Downloading packages", "packages")
 
+        # ContentItem.sha256 is globally unique. The DB session is autoflush=False,
+        # so a query cannot see a ContentItem added earlier in this same run;
+        # track in-run inserts here so a duplicate APKINDEX record (or two names
+        # for identical bytes) links instead of inserting a second row and
+        # aborting the whole sync with an IntegrityError at commit.
+        inserted_by_sha: dict[str, ContentItem] = {}
+
         for i, pkg_entry in enumerate(filtered_packages, 1):
             try:
                 # Create metadata
@@ -195,6 +202,20 @@ class ApkSyncer:
                         "possible tampering or a stale upstream APKINDEX"
                     )
 
+                # Deduplicate by the actual content sha256 (the unique key),
+                # covering both a row committed by a previous sync and one added
+                # earlier in this same run (see inserted_by_sha above).
+                existing_by_sha = inserted_by_sha.get(sha256) or (
+                    session.query(ContentItem).filter_by(sha256=sha256).first()
+                )
+                if existing_by_sha is not None:
+                    if repository not in existing_by_sha.repositories:
+                        existing_by_sha.repositories.append(repository)
+                        stats["packages_updated"] += 1
+                    else:
+                        stats["packages_skipped"] += 1
+                    continue
+
                 # Create ContentItem
                 content_item = ContentItem(
                     name=metadata.name,
@@ -209,6 +230,7 @@ class ApkSyncer:
                 content_item.repositories.append(repository)
 
                 session.add(content_item)
+                inserted_by_sha[sha256] = content_item
                 stats["packages_added"] += 1
                 stats["bytes_downloaded"] += size
 
@@ -497,28 +519,26 @@ class ApkSyncer:
                 tmp.write(chunk)
             tmp_path = Path(tmp.name)
 
-        # Verify the package against the APKINDEX C: checksum (Q1 + base64(SHA1)
-        # of the control segment). Verify BEFORE pooling so a tampered/corrupt
-        # package never enters the content pool.
-        calculated_sha1 = compute_apk_control_checksum(tmp_path.read_bytes())
-        sha1_ok = calculated_sha1 is not None and calculated_sha1 == expected_sha1
+        try:
+            # Verify the package against the APKINDEX C: checksum (Q1 +
+            # base64(SHA1) of the control segment). Verify BEFORE pooling so a
+            # tampered/corrupt package never enters the content pool.
+            calculated_sha1 = compute_apk_control_checksum(tmp_path.read_bytes())
+            sha1_ok = calculated_sha1 is not None and calculated_sha1 == expected_sha1
 
-        if not sha1_ok:
-            logger.warning(
-                f"APK checksum mismatch for {Path(url).name}: "
-                f"expected {expected_sha1}, got {calculated_sha1}"
-            )
+            if not sha1_ok:
+                logger.warning(
+                    f"APK checksum mismatch for {Path(url).name}: "
+                    f"expected {expected_sha1}, got {calculated_sha1}"
+                )
+                return None, None, None, False
+
+            filename = Path(url).name
+
+            # Add to pool (this calculates SHA256, deduplicates, and moves file)
+            sha256, pool_path, size = self.storage.add_package(tmp_path, filename)
+            logger.debug(f"Stored package in pool: {pool_path}")
+            return pool_path, sha256, size, sha1_ok
+        finally:
+            # Always clean up the temp file, even if checksum/pooling raised.
             tmp_path.unlink(missing_ok=True)
-            return None, None, None, False
-
-        filename = Path(url).name
-
-        # Add to pool (this calculates SHA256, deduplicates, and moves file)
-        sha256, pool_path, size = self.storage.add_package(tmp_path, filename)
-
-        # Clean up temp file
-        tmp_path.unlink(missing_ok=True)
-
-        logger.debug(f"Stored package in pool: {pool_path}")
-
-        return pool_path, sha256, size, sha1_ok

--- a/tests/test_apk_sync_dedup.py
+++ b/tests/test_apk_sync_dedup.py
@@ -1,0 +1,93 @@
+"""Regression: a duplicate/identical-content APKINDEX entry must not abort sync.
+
+ContentItem.sha256 is globally unique and the production DB session is
+autoflush=False, so a naive "query before insert" dedup misses a row added
+earlier in the same run. Previously a repeated APKINDEX record (or two names for
+one file) inserted a second row with the same sha256 and raised IntegrityError
+at the final commit, rolling back the entire sync.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from chantal.core.config import ApkConfig, RepositoryConfig
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import Base, ContentItem, Repository
+from chantal.plugins.apk.sync import ApkSyncer
+
+
+def _config():
+    return RepositoryConfig(
+        id="alpine",
+        name="Alpine",
+        type="apk",
+        feed="http://example.com/alpine",
+        apk=ApkConfig(branch="v3.19", repository="main", architecture="x86_64"),
+    )
+
+
+def _entry():
+    return {
+        "name": "demo",
+        "version": "1.0-r0",
+        "architecture": "x86_64",
+        "checksum": "Q1" + "A" * 27,
+        "size": "100",
+    }
+
+
+@pytest.fixture
+def session(tmp_path):
+    # Use the real DatabaseManager session (autoflush=False) to reproduce the bug.
+    dbm = DatabaseManager(f"sqlite:///{tmp_path / 'chantal.db'}")
+    Base.metadata.create_all(dbm.engine)
+    return dbm.get_session()
+
+
+def _run(session, syncer, config, repo, parsed):
+    with (
+        patch.object(syncer, "_fetch_apkindex", return_value=b""),
+        patch.object(syncer, "_store_apkindex_file"),
+        patch.object(syncer, "_parse_apkindex", return_value=parsed),
+        patch.object(
+            syncer,
+            "_download_package",
+            return_value=("ab/cd/demo.apk", "ab" * 32, 100, True),
+        ),
+    ):
+        return syncer.sync_repository(session, repo, config)
+
+
+def test_duplicate_entries_in_one_sync_do_not_abort(session):
+    repo = Repository(repo_id="alpine", name="Alpine", type="apk", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.commit()
+
+    config = _config()
+    syncer = ApkSyncer(storage=None, config=config)
+
+    # Same record listed twice in one APKINDEX -> identical downloaded bytes.
+    stats = _run(session, syncer, config, repo, [_entry(), _entry()])
+
+    assert stats["packages_added"] == 1  # second deduped, no IntegrityError
+    items = session.query(ContentItem).filter_by(content_type="apk").all()
+    assert len(items) == 1
+
+
+def test_resync_links_instead_of_reinserting(session):
+    repo = Repository(repo_id="alpine", name="Alpine", type="apk", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.commit()
+
+    config = _config()
+    syncer = ApkSyncer(storage=None, config=config)
+
+    first = _run(session, syncer, config, repo, [_entry()])
+    assert first["packages_added"] == 1
+
+    second = _run(session, syncer, config, repo, [_entry()])
+    assert second["packages_added"] == 0
+    assert session.query(ContentItem).filter_by(content_type="apk").count() == 1


### PR DESCRIPTION
## Problem

The pre-download dedup matched on `(name, version, architecture)`, **not** the globally-unique `ContentItem.sha256`, and the production DB session is `autoflush=False` (`db/connection.py:31`) so a query can't see a row `add()`-ed earlier in the same run. A **repeated APKINDEX record** (common in third-party/custom Alpine repos), or two package names pointing at identical bytes, therefore inserted a second `ContentItem` with a duplicate `sha256` — and the `IntegrityError` fired at the **final `session.commit()`, outside the per-package `try`** — rolling back the **entire sync**. Total-sync-failure DoS from upstream-controlled data, with no per-package error.

## Fix

After checksum verification, deduplicate by the downloaded `sha256`, tracking in-run inserts in a dict (necessary because autoflush is off), and **link** the existing pooled package instead of inserting a duplicate. Also wraps the download temp-file cleanup in `try/finally` so a failed checksum/pool step doesn't leak it.

## Tests

- Two identical APKINDEX records in **one** sync → 1 package, no `IntegrityError` (reproduces the abort without the fix).
- Cross-run re-sync links instead of re-inserting.

(Same dedup-by-content class as #105/#110; this is the APK gap the per-plugin review surfaced.)