### PR TITLE
fix(helm): prune stale index.yaml on re-sync and dedup charts safely

### DIFF
--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -107,9 +107,11 @@ class HelmSyncer:
         index_data = self._fetch_index(index_url, config)
 
         # Store the upstream index.yaml as a RepositoryFile so mirror mode can
-        # republish it verbatim. Filtered mode ignores it and regenerates the
-        # index from the published charts at publish time.
-        self._store_index_file(index_url, config, session, repository)
+        # republish it. Filtered mode ignores it and regenerates the index from
+        # the published charts at publish time. Prune the previous sync's index
+        # so the mirror publisher doesn't pick up a stale one.
+        index_sha = self._store_index_file(index_url, config, session, repository)
+        self._prune_stale_index(session, repository, index_sha)
 
         # Parse charts from index
         all_charts = self._parse_index(index_data)
@@ -131,6 +133,12 @@ class HelmSyncer:
         }
 
         self.output.start_progress(len(filtered_charts), "Downloading charts", "charts")
+
+        # ContentItem.sha256 is globally unique. The DB session is
+        # autoflush=False, so a query can't see a chart added earlier in this
+        # same run; track in-run inserts so a digest-less duplicate links instead
+        # of inserting a second row and aborting the sync at commit.
+        inserted_by_sha: dict[str, ContentItem] = {}
 
         for i, chart_entry in enumerate(filtered_charts, 1):
             try:
@@ -192,9 +200,9 @@ class HelmSyncer:
                 # omits a digest the pre-download check above is skipped, so a
                 # re-sync would otherwise try to insert a second ContentItem with
                 # the same sha256 and hit the unique constraint (IntegrityError).
-                # Autoflush makes this also catch a duplicate added earlier in
-                # this same run. Link to the pooled chart instead of re-inserting.
-                existing_by_content = (
+                # The in-run dict covers a duplicate added earlier in this same
+                # run (the session is autoflush=False, so a query can't see it).
+                existing_by_content = inserted_by_sha.get(sha256) or (
                     session.query(ContentItem).filter_by(content_type="helm", sha256=sha256).first()
                 )
                 if existing_by_content:
@@ -222,6 +230,7 @@ class HelmSyncer:
                 content_item.repositories.append(repository)
 
                 session.add(content_item)
+                inserted_by_sha[sha256] = content_item
                 stats["charts_added"] += 1
                 stats["bytes_downloaded"] += size
 
@@ -306,7 +315,7 @@ class HelmSyncer:
         config: RepositoryConfig,
         session: Session,
         repository: Repository,
-    ) -> None:
+    ) -> str:
         """Download and store index.yaml as RepositoryFile for mirror mode.
 
         Args:
@@ -314,6 +323,10 @@ class HelmSyncer:
             config: Repository configuration
             session: Database session
             repository: Repository model instance
+
+        Returns:
+            The pool SHA256 of the stored index.yaml (used to prune the previous
+            sync's index from the repository).
         """
         logger.info("Storing index.yaml as RepositoryFile")
 
@@ -363,9 +376,37 @@ class HelmSyncer:
 
                 logger.info(f"Stored index.yaml in pool: {sha256[:16]}... ({size_bytes} bytes)")
 
+            return sha256
+
         finally:
             # Clean up temp file
             tmp_path.unlink(missing_ok=True)
+
+    def _prune_stale_index(
+        self, session: Session, repository: Repository, current_sha: str
+    ) -> None:
+        """Unlink index.yaml files from previous syncs.
+
+        On every sync the upstream index.yaml is re-stored; without pruning, each
+        changed index accumulates another ``file_type="index"`` link and the
+        mirror publisher (which picks the first match) would republish a stale
+        index. Unlink any index file whose sha differs from the current one, and
+        delete the row when nothing else (another repository or a snapshot) still
+        references it so its pool blob is reclaimable.
+        """
+        removed = 0
+        for repo_file in list(repository.repository_files):
+            if repo_file.file_category != "metadata" or repo_file.file_type != "index":
+                continue
+            if repo_file.sha256 == current_sha:
+                continue
+            repository.repository_files.remove(repo_file)
+            removed += 1
+            if not repo_file.repositories and not repo_file.snapshots:
+                session.delete(repo_file)
+        if removed:
+            session.commit()
+            logger.info(f"Pruned {removed} stale index.yaml file(s) from a previous sync")
 
     def _apply_filters(self, charts: list[dict], config: RepositoryConfig) -> list[dict]:
         """Apply filters to chart list.

--- a/tests/test_helm_sync_dedup.py
+++ b/tests/test_helm_sync_dedup.py
@@ -1,0 +1,91 @@
+"""Helm: stale index.yaml pruning and autoflush-safe in-run chart dedup."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from chantal.core.config import RepositoryConfig
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import Base, ContentItem, Repository, RepositoryFile, Snapshot
+from chantal.plugins.helm.sync import HelmSyncer
+
+
+def _config():
+    return RepositoryConfig(id="demo", name="Demo", type="helm", feed="http://example.com/charts")
+
+
+@pytest.fixture
+def session(tmp_path):
+    dbm = DatabaseManager(f"sqlite:///{tmp_path / 'chantal.db'}")
+    Base.metadata.create_all(dbm.engine)
+    return dbm.get_session()
+
+
+def _index_file(sha: str) -> RepositoryFile:
+    return RepositoryFile(
+        file_category="metadata",
+        file_type="index",
+        sha256=sha,
+        size_bytes=1,
+        pool_path=f"{sha[:2]}/{sha[2:4]}/index.yaml",
+        original_path="index.yaml",
+        file_metadata={},
+    )
+
+
+def test_prune_stale_index_unlinks_old_keeps_current(session):
+    repo = Repository(repo_id="demo", name="Demo", type="helm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+
+    current = _index_file("c" * 64)
+    stale_orphan = _index_file("a" * 64)
+    stale_snapshot = _index_file("b" * 64)
+    for rf in (current, stale_orphan, stale_snapshot):
+        repo.repository_files.append(rf)
+    snap = Snapshot(repository_id=repo.id, name="snap-1")
+    snap.repository_files.append(stale_snapshot)
+    session.add(snap)
+    session.commit()
+
+    syncer = HelmSyncer(storage=None, config=_config())
+    syncer._prune_stale_index(session, repo, "c" * 64)
+
+    session.refresh(repo)
+    linked = {rf.sha256 for rf in repo.repository_files}
+    assert linked == {"c" * 64}  # only the current index remains linked
+    remaining = {rf.sha256 for rf in session.query(RepositoryFile).all()}
+    assert "a" * 64 not in remaining  # orphan deleted
+    assert "b" * 64 in remaining  # snapshot-referenced kept
+
+
+def test_digestless_duplicate_in_one_sync_dedup_autoflush_off(session):
+    """Two digest-less entries with identical bytes in one sync must dedup even
+    though the production session is autoflush=False."""
+    repo = Repository(repo_id="demo", name="Demo", type="helm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.commit()
+
+    config = _config()
+    syncer = HelmSyncer(storage=None, config=config)
+
+    index = {
+        "apiVersion": "v1",
+        "entries": {
+            "demo": [
+                {"name": "demo", "version": "0.1.0", "urls": ["demo-0.1.0.tgz"]},
+                {"name": "demo", "version": "0.1.0-dup", "urls": ["demo-0.1.0-dup.tgz"]},
+            ]
+        },
+    }
+    with (
+        patch.object(syncer, "_fetch_index", return_value=index),
+        patch.object(syncer, "_store_index_file", return_value="e" * 64),
+        patch.object(syncer, "_download_chart", return_value=("ab/cd/demo.tgz", "cd" * 32, 123)),
+    ):
+        stats = syncer.sync_repository(session, repo, config)
+
+    assert stats["charts_added"] == 1  # second deduped, no IntegrityError
+    assert session.query(ContentItem).filter_by(content_type="helm").count() == 1


### PR DESCRIPTION
## Problems

1. **Stale `index.yaml` served + unbounded pool growth.** Helm never pruned the previous sync's index `RepositoryFile` (the RPM/APT plugins do, since #105). Every time upstream changed its index, another `file_type="index"` link accumulated, and the mirror publisher picks the **first** match — which, with no ordering, is the **oldest**. So after upstream changes the mirror republished a **stale** index, and old index blobs grew the pool forever.
2. **In-run chart dedup broken under `autoflush=False`.** The production session is `autoflush=False`, so the post-download "query by sha256" couldn't see a chart `add()`-ed earlier in the same run; two digest-less entries with identical bytes hit the unique constraint at commit (same class as the APK fix).

## Fix

1. `_store_index_file` returns the stored sha; `sync_repository` then calls `_prune_stale_index`, unlinking index files whose sha differs from the current one and deleting the row when no other repository/snapshot references it.
2. Track in-run inserts in a dict so a duplicate links instead of inserting (as the APK plugin now does).

## Tests

- `_prune_stale_index`: orphan deleted, snapshot-referenced index kept, current retained.
- Autoflush=`False` in-run duplicate (digest-less) dedups to one `ContentItem`.

Both fail without the fix.