### PR TITLE
fix(rpm): recompress filtered updateinfo as xz; normalize .treeinfo feed URL

### DIFF
--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -766,6 +766,10 @@ class RpmPublisher(PublisherPlugin):
                 with open(tmp_xml_path, "rb") as f_in:
                     with gzip.open(filtered_updateinfo_path, "wb") as f_out:
                         shutil.copyfileobj(f_in, f_out)
+            elif updateinfo_path.suffix == ".xz":
+                with open(tmp_xml_path, "rb") as f_in:
+                    with lzma.open(filtered_updateinfo_path, "wb") as f_out:
+                        shutil.copyfileobj(f_in, f_out)
             elif updateinfo_path.suffix == ".zst":
                 import zstandard as zstd
 

--- a/src/chantal/plugins/rpm/sync.py
+++ b/src/chantal/plugins/rpm/sync.py
@@ -366,7 +366,13 @@ class RpmSyncPlugin:
 
             # Step 8: Check for .treeinfo and download installer files
             self.output.phase("Checking for installer files (.treeinfo)", number=4)
-            treeinfo_url = urljoin(self.config.feed, ".treeinfo")
+            # Normalize the feed to a directory URL: without a trailing slash
+            # urljoin drops the last path segment (e.g. ".../el9" -> ".../"),
+            # fetching .treeinfo and the installer images from the wrong place.
+            feed_url = (
+                self.config.feed if self.config.feed.endswith("/") else self.config.feed + "/"
+            )
+            treeinfo_url = urljoin(feed_url, ".treeinfo")
             try:
                 response = self.session.get(treeinfo_url, timeout=30)
                 response.raise_for_status()
@@ -383,7 +389,7 @@ class RpmSyncPlugin:
                             self._download_installer_file(
                                 session=session,
                                 repository=repository,
-                                base_url=self.config.feed,
+                                base_url=feed_url,
                                 file_info=file_info,
                             )
                             installer_downloaded += 1

--- a/tests/test_rpm_filtered_secondary.py
+++ b/tests/test_rpm_filtered_secondary.py
@@ -108,3 +108,53 @@ def test_filter_filelists_zst_matches_by_nvra(publisher, tmp_path, checksum_type
     names = [p.get("name") for p in root.findall(f"{{{FILELISTS_NS}}}package")]
     assert names == ["demo"], f"expected only the surviving NVRA, got {names}"
     assert root.get("packages") == "1"
+
+
+def _updateinfo_xml() -> str:
+    return (
+        "<updates>\n"
+        '  <update type="security" status="stable">\n'
+        "    <id>TEST-1</id>\n"
+        "    <title>demo advisory</title>\n"
+        '    <issued date="2026-01-01 00:00:00"/>\n'
+        "    <pkglist>\n"
+        "      <collection>\n"
+        '        <package name="demo" version="1.0" release="1.el9" epoch="0" arch="x86_64">\n'
+        "          <filename>demo-1.0-1.el9.x86_64.rpm</filename>\n"
+        "        </package>\n"
+        "      </collection>\n"
+        "    </pkglist>\n"
+        "  </update>\n"
+        "</updates>\n"
+    )
+
+
+def test_filter_updateinfo_xz_stays_xz_compressed(publisher, tmp_path):
+    """An xz updateinfo must be rewritten as valid xz, not plaintext under a .xz
+    name (the missing .xz branch corrupted errata)."""
+    import lzma
+
+    repodata = tmp_path / "repodata"
+    repodata.mkdir()
+    ui_path = repodata / "updateinfo.xml.xz"
+    ui_path.write_bytes(lzma.compress(_updateinfo_xml().encode()))
+
+    survivor = ContentItem(
+        content_type="rpm",
+        name="demo",
+        version="1.0",
+        sha256="d" * 64,
+        size_bytes=1,
+        pool_path="dd/dd/demo.rpm",
+        filename="demo-1.0-1.el9.x86_64.rpm",
+        content_metadata={"release": "1.el9", "arch": "x86_64"},
+    )
+
+    result = publisher._filter_and_regenerate_updateinfo(
+        [survivor], repodata, [("updateinfo", ui_path)]
+    )
+
+    _, out_path = next(ft for ft in result if ft[0] == "updateinfo")
+    # Must be genuinely xz-compressed; lzma raises on plaintext.
+    data = lzma.open(out_path, "rb").read()
+    assert b"TEST-1" in data  # the advisory survived the filter


### PR DESCRIPTION
## Problems

1. **Filtered `updateinfo.xml.xz` corrupted.** `_filter_and_regenerate_updateinfo` recompressed the filtered XML for `.bz2`/`.gz`/`.zst` but **not `.xz`** — it fell through to the `else` (plaintext copy), writing plaintext XML under a `.xz` filename. The regenerated `repomd.xml` then advertises an xz-compressed updateinfo that dnf can't decode → **errata/security advisories break** in filtered repos (common on SUSE/EPEL/Rocky/Alma xz repos). `filelists`/`other` already have the `.xz` branch; `updateinfo` was missing it.
2. **`.treeinfo`/installer fetched from the wrong URL.** Every other fetch normalizes the feed to a trailing slash, but `.treeinfo` (`urljoin(self.config.feed, ".treeinfo")`) and the installer downloads used the raw feed. For a feed without a trailing slash (e.g. `.../el9`), `urljoin` drops the last segment → fetches `.treeinfo` / images from `.../` instead of `.../el9/`.

## Fix

Add the `lzma` recompress branch for `.xz`; compute a trailing-slash-normalized `feed_url` once and use it for both the `.treeinfo` fetch and the installer base URL.

## Tests

- An xz `updateinfo` is rewritten as **valid xz** (lzma-readable) with the advisory preserved — fails (plaintext) without the fix.