### PR TITLE
fix(apt): reject an expired Release (enforce Valid-Until)

### DIFF
--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -10,6 +10,8 @@ Supports mirror mode (1:1 copy with all metadata and GPG signatures preserved).
 import logging
 import tempfile
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from pathlib import Path, PurePosixPath
 from urllib.parse import urljoin
 
@@ -487,6 +489,13 @@ class AptSyncPlugin:
                     release_text = "\n".join(content_lines)
 
             release_metadata = parse_release_file(release_text)
+
+            # Reject a stale (but validly-signed) Release: signature verification
+            # proves authenticity, not freshness, so an attacker/mirror could
+            # replay an old signed Release to freeze the repo at a vulnerable
+            # state. Enforce Valid-Until when verification is enabled.
+            self._enforce_release_freshness(release_metadata.valid_until)
+
             self.output.verbose(
                 f"  → Parsed Release: {release_metadata.suite}/{release_metadata.codename}"
             )
@@ -573,6 +582,34 @@ class AptSyncPlugin:
         if policy == "warn":
             self.output.warning(f"Signature verification: {message}")
         # "skip": silently continue
+
+    def _enforce_release_freshness(self, valid_until: str | None) -> None:
+        """Reject an expired Release (Valid-Until in the past) when verifying.
+
+        A valid signature proves authenticity but not freshness; ``Valid-Until``
+        is what apt uses to refuse a replayed/rolled-back Release. Only enforced
+        when signature verification is enabled (an unverified Release is not
+        trusted anyway), applying the ``on_invalid_signature`` policy.
+        """
+        verify = self.config.verify
+        if not verify or not verify.enabled or not verify.repo_gpgcheck:
+            return
+        if not valid_until:
+            return
+        try:
+            expiry = parsedate_to_datetime(valid_until)
+        except (TypeError, ValueError):
+            expiry = None
+        if expiry is None:
+            self.output.warning(f"Could not parse Release Valid-Until: {valid_until!r}")
+            return
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=UTC)
+        if datetime.now(UTC) > expiry:
+            self._handle_verify_policy(
+                verify.on_invalid_signature,
+                f"upstream Release has expired (Valid-Until: {valid_until})",
+            )
 
     def _build_metadata_file_list(
         self, release_metadata: dict, mode: str = "mirror"

--- a/tests/test_apt_valid_until.py
+++ b/tests/test_apt_valid_until.py
@@ -1,0 +1,59 @@
+"""APT: a stale (but validly-signed) Release must be rejected via Valid-Until.
+
+Signature verification proves authenticity, not freshness; without enforcing
+Valid-Until an attacker/mirror can replay an old signed Release to freeze the
+repository at a vulnerable state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chantal.core.config import AptConfig, RepositoryConfig, SignatureVerificationConfig
+from chantal.core.gpg_verify import SignatureVerificationError
+from chantal.plugins.apt.sync import AptSyncPlugin
+
+_PAST = "Thu, 01 Jan 2009 00:00:00 UTC"
+_FUTURE = "Thu, 01 Jan 2099 00:00:00 UTC"
+
+
+def _syncer(*, enabled=True, policy="fail"):
+    verify = SignatureVerificationConfig(
+        enabled=enabled, keys=["dummy"], on_invalid_signature=policy
+    )
+    config = RepositoryConfig(
+        id="deb",
+        name="Deb",
+        type="apt",
+        feed="http://example.com/ubuntu",
+        apt=AptConfig(distribution="jammy", components=["main"], architectures=["amd64"]),
+        verify=verify,
+    )
+    return AptSyncPlugin(storage=None, config=config)
+
+
+def test_expired_release_fails_under_fail_policy():
+    with pytest.raises(SignatureVerificationError, match="expired"):
+        _syncer(policy="fail")._enforce_release_freshness(_PAST)
+
+
+def test_expired_release_warns_under_warn_policy():
+    # warn policy logs but does not raise.
+    _syncer(policy="warn")._enforce_release_freshness(_PAST)
+
+
+def test_future_release_is_accepted():
+    _syncer(policy="fail")._enforce_release_freshness(_FUTURE)
+
+
+def test_no_valid_until_is_accepted():
+    _syncer(policy="fail")._enforce_release_freshness(None)
+
+
+def test_unparseable_valid_until_does_not_raise():
+    _syncer(policy="fail")._enforce_release_freshness("not a date")
+
+
+def test_verification_disabled_skips_enforcement():
+    # With verification off the Release isn't trusted anyway -> no enforcement.
+    _syncer(enabled=False, policy="fail")._enforce_release_freshness(_PAST)


### PR DESCRIPTION
## Problem (security — replay / rollback)

Release signature verification proves **authenticity**, not **freshness**. The parsed `Valid-Until` was dropped (`_fetch_and_store_release` never returned or checked it), so a **validly-signed but stale** Release — replayed by an on-path attacker or served by a compromised/stale mirror — was accepted. That's the freeze/rollback attack `Valid-Until` exists to stop, and which apt itself rejects.

Worse: in filtered/hosted mode chantal regenerates `Release` with its **own fresh** `Valid-Until`, so downstream apt clients see a valid, non-expired Release and can't detect the upstream staleness — the rollback is laundered.

## Fix

When signature verification is enabled, parse `Valid-Until` and apply the `on_invalid_signature` policy (`fail`/`warn`/`skip`) if it is in the past. Enforcement only engages when verification is on — an unverified Release isn't trusted regardless.

## Tests

fail vs warn policy, future/absent/unparseable dates, and the verification-disabled no-op.