### PR TITLE
fix(rpm): drop unpublishable zchunk/sqlite metadata variants

### DIFF
--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -178,6 +178,16 @@ class RpmPublisher(PublisherPlugin):
                 packages, repodata_path, published_metadata
             )
 
+        # Drop metadata variants we cannot republish correctly. zchunk (*_zck)
+        # needs de-chunking to recompute its open-checksum (no pure-Python
+        # support), so a regenerated repomd entry would be invalid in any mode;
+        # the sqlite (*_db) primary/filelists/other enumerate the full upstream
+        # package set, so they must not survive filtered mode (clients preferring
+        # them would see excluded packages). dnf/yum fall back to primary.xml(.gz).
+        published_metadata = self._drop_unpublishable_metadata(
+            published_metadata, repodata_path, mode
+        )
+
         # Produce exactly one primary.xml. Prefer regenerating it from the
         # upstream primary: that preserves the <format> block (provides /
         # requires / conflicts / obsoletes and the primary file list) that dnf
@@ -615,6 +625,33 @@ class RpmPublisher(PublisherPlugin):
             os.link(pool_file_path, target_file_path)
 
             print(f"  ✓ Published {repo_file.file_type}: {repo_file.original_path}")
+
+    def _drop_unpublishable_metadata(
+        self,
+        published_metadata: list[tuple[str, Path]],
+        repodata_path: Path,
+        mode: str,
+    ) -> list[tuple[str, Path]]:
+        """Drop metadata variants chantal cannot republish correctly.
+
+        - ``*_zck`` (zchunk): always dropped - chantal cannot recompute the
+          de-chunked open-checksum, so a repomd entry for it would be invalid.
+        - ``*_db`` (sqlite primary/filelists/other): dropped in filtered mode,
+          where they would otherwise enumerate the full upstream package set
+          including filtered-out packages.
+
+        The dropped files are also unlinked from the published repodata so the
+        repository does not carry metadata the repomd no longer references.
+        """
+        kept: list[tuple[str, Path]] = []
+        for file_type, file_path in published_metadata:
+            is_zck = file_type.endswith("_zck") or file_path.name.endswith(".zck")
+            is_db = file_type.endswith("_db")
+            if is_zck or (is_db and mode == RepositoryMode.FILTERED):
+                file_path.unlink(missing_ok=True)
+                continue
+            kept.append((file_type, file_path))
+        return kept
 
     def _generate_repomd_xml(
         self, repodata_path: Path, metadata_files: list[tuple[str, Path]]

--- a/tests/test_rpm_filtered_secondary.py
+++ b/tests/test_rpm_filtered_secondary.py
@@ -158,3 +158,45 @@ def test_filter_updateinfo_xz_stays_xz_compressed(publisher, tmp_path):
     # Must be genuinely xz-compressed; lzma raises on plaintext.
     data = lzma.open(out_path, "rb").read()
     assert b"TEST-1" in data  # the advisory survived the filter
+
+
+def _published(repodata):
+    """Create on-disk metadata files and the (file_type, path) tuples for them."""
+    files = {
+        "primary": "1111-primary.xml.gz",
+        "primary_zck": "2222-primary.xml.zck",
+        "primary_db": "3333-primary.sqlite.bz2",
+    }
+    out = []
+    for file_type, name in files.items():
+        p = repodata / name
+        p.write_bytes(b"x")
+        out.append((file_type, p))
+    return out
+
+
+def test_filtered_mode_drops_zck_and_db(publisher, tmp_path):
+    """Filtered mode must drop the package-enumerating *_zck and *_db variants."""
+    repodata = tmp_path / "repodata"
+    repodata.mkdir()
+    published = _published(repodata)
+
+    kept = publisher._drop_unpublishable_metadata(published, repodata, "filtered")
+
+    assert [ft for ft, _ in kept] == ["primary"]
+    assert not (repodata / "2222-primary.xml.zck").exists()
+    assert not (repodata / "3333-primary.sqlite.bz2").exists()
+
+
+def test_mirror_mode_drops_zck_but_keeps_db(publisher, tmp_path):
+    """Mirror mode keeps the valid *_db (correct open-checksum) but still drops
+    *_zck, which chantal cannot re-checksum without zchunk de-chunking."""
+    repodata = tmp_path / "repodata"
+    repodata.mkdir()
+    published = _published(repodata)
+
+    kept = publisher._drop_unpublishable_metadata(published, repodata, "mirror")
+
+    assert sorted(ft for ft, _ in kept) == ["primary", "primary_db"]
+    assert not (repodata / "2222-primary.xml.zck").exists()
+    assert (repodata / "3333-primary.sqlite.bz2").exists()


### PR DESCRIPTION
## Problem

In **filtered mode** chantal regenerates `primary`/`filelists`/`other`/`updateinfo`/`modules`, but passed **every other** metadata variant through unchanged. On EL9/Fedora that includes the **zchunk** (`*_zck`, the default dnf prefers) and **sqlite** (`*_db`) primary/filelists/other — which still enumerate the **full upstream package set** with upstream locations. A dnf client preferring zchunk/sqlite then sees (and tries to fetch) packages that were filtered out and are physically absent → 404s, defeating filtered mode and exposing metadata for excluded packages.

Separately, the regenerated repomd computed a **wrong `open-checksum`** for `.zck` (`decompress_bytes` returns zchunk bytes unchanged), so even mirror-mode zchunk entries were invalid.

## Fix

`_drop_unpublishable_metadata`:
- **`*_zck` — dropped in any mode.** chantal can't recompute the de-chunked open-checksum without zchunk support, so a regenerated repomd entry is invalid regardless. (dnf falls back to `primary.xml.gz`.)
- **`*_db` — dropped in filtered mode** (it enumerates the full set); **kept in mirror mode**, where it decompresses normally and its open-checksum is correct (still useful for EL7-era yum).

Dropped files are unlinked from the published repodata.

## Tests

- Filtered mode drops both `*_zck` and `*_db`.
- Mirror mode drops `*_zck` but keeps the valid `*_db`.

Note: full pure-Python zchunk support (to actually republish `.zck`) is out of scope; this makes the output correct by omitting what we can't faithfully reproduce.