### PR TITLE
fix(apk): bound APKINDEX extraction and fetch it only once

### DIFF
--- a/src/chantal/plugins/apk/sync.py
+++ b/src/chantal/plugins/apk/sync.py
@@ -24,6 +24,11 @@ from chantal.plugins.apk.models import ApkMetadata
 
 logger = logging.getLogger(__name__)
 
+# Even a very large Alpine repository's decompressed APKINDEX is well under this;
+# the cap stops a tiny but highly-compressible APKINDEX.tar.gz from exhausting
+# memory when extracted.
+_MAX_APKINDEX_BYTES = 256 * 1024 * 1024
+
 
 class ApkSyncer:
     """Syncer for Alpine APK repositories.
@@ -107,12 +112,12 @@ class ApkSyncer:
             f"{apk_config.branch}/{apk_config.repository}/{apk_config.architecture}/APKINDEX.tar.gz",
         )
 
-        # Fetch and parse APKINDEX
+        # Fetch and parse APKINDEX (single download, reused for storage)
         self.output.phase("Downloading APKINDEX.tar.gz", number=1)
-        index_data = self._fetch_apkindex(index_url, config)
+        index_data, raw_index = self._fetch_apkindex(index_url, config)
 
         # Store APKINDEX.tar.gz as RepositoryFile for mirror mode
-        self._store_apkindex_file(index_url, config, session, repository)
+        self._store_apkindex_file(raw_index, config, session, repository)
 
         # Parse packages from APKINDEX
         all_packages = self._parse_apkindex(index_data)
@@ -259,24 +264,27 @@ class ApkSyncer:
 
         return stats
 
-    def _fetch_apkindex(self, url: str, config: RepositoryConfig) -> str:
-        """Fetch and parse APKINDEX.tar.gz.
+    def _fetch_apkindex(self, url: str, config: RepositoryConfig) -> tuple[str, bytes]:
+        """Fetch APKINDEX.tar.gz once and extract its text content.
 
         Args:
             url: APKINDEX.tar.gz URL
             config: Repository configuration (for credentials)
 
         Returns:
-            str: Parsed APKINDEX text content
+            ``(apkindex_text, raw_tar_gz_bytes)`` - the raw bytes are reused to
+            store the file (mirror mode) without a second download, which also
+            closes the TOCTOU window between the parsed and stored index.
         """
         logger.info(f"Fetching APKINDEX from {url}")
 
         response = self.session.get(url, timeout=30)
         response.raise_for_status()
+        raw = response.content
 
         # Extract APKINDEX from tar.gz
         with tempfile.NamedTemporaryFile(delete=False, suffix=".tar.gz") as tmp:
-            tmp.write(response.content)
+            tmp.write(raw)
             tmp_path = tmp.name
 
         try:
@@ -284,10 +292,19 @@ class ApkSyncer:
                 # APKINDEX is the only file in the archive
                 for member in tar.getmembers():
                     if member.name == "APKINDEX" or member.name.endswith("/APKINDEX"):
+                        # Bound the decompressed size so a crafted tiny archive
+                        # cannot expand into a multi-GB buffer.
+                        if member.size > _MAX_APKINDEX_BYTES:
+                            raise ValueError(
+                                f"APKINDEX too large ({member.size} bytes; "
+                                f"limit {_MAX_APKINDEX_BYTES})"
+                            )
                         f = tar.extractfile(member)
                         if f:
-                            content = f.read().decode("utf-8")
-                            return content
+                            # Lenient decode: a stray non-UTF-8 byte in a third
+                            # party repo must not drop the whole index.
+                            content = f.read().decode("utf-8", "replace")
+                            return content, raw
 
             raise ValueError("APKINDEX file not found in archive")
         finally:
@@ -418,28 +435,25 @@ class ApkSyncer:
 
     def _store_apkindex_file(
         self,
-        index_url: str,
+        raw_index: bytes,
         config: RepositoryConfig,
         session: Session,
         repository: Repository,
     ) -> None:
-        """Download and store APKINDEX.tar.gz as RepositoryFile for mirror mode.
+        """Store the already-fetched APKINDEX.tar.gz as a RepositoryFile.
 
         Args:
-            index_url: URL to APKINDEX.tar.gz
+            raw_index: The APKINDEX.tar.gz bytes fetched by ``_fetch_apkindex``
+                (reused to avoid a second download / TOCTOU).
             config: Repository configuration
             session: Database session
             repository: Repository model instance
         """
         logger.info("Storing APKINDEX.tar.gz as RepositoryFile")
 
-        # Download APKINDEX.tar.gz
-        response = self.session.get(index_url, timeout=30)
-        response.raise_for_status()
-
-        # Write to temporary file
+        # Write the already-downloaded bytes to a temporary file for pooling.
         with tempfile.NamedTemporaryFile(delete=False, suffix=".tar.gz") as tmp:
-            tmp.write(response.content)
+            tmp.write(raw_index)
             tmp_path = Path(tmp.name)
 
         try:

--- a/tests/test_apk_index_fetch.py
+++ b/tests/test_apk_index_fetch.py
@@ -1,0 +1,73 @@
+"""APK: bounded APKINDEX extraction, lenient decode, and single-fetch reuse."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from unittest.mock import Mock
+
+import pytest
+
+import chantal.plugins.apk.sync as apk_sync
+from chantal.core.config import ApkConfig, RepositoryConfig
+from chantal.plugins.apk.sync import ApkSyncer
+
+
+def _apkindex_targz(body: bytes) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo("APKINDEX")
+        info.size = len(body)
+        tar.addfile(info, io.BytesIO(body))
+    return buf.getvalue()
+
+
+def _syncer():
+    config = RepositoryConfig(
+        id="alpine",
+        name="Alpine",
+        type="apk",
+        feed="http://example.com/alpine",
+        apk=ApkConfig(branch="v3.19", repository="main", architecture="x86_64"),
+    )
+    syncer = ApkSyncer(storage=None, config=config)
+    return syncer
+
+
+def _mock_get(syncer, raw: bytes):
+    resp = Mock()
+    resp.content = raw
+    resp.raise_for_status = Mock()
+    syncer.session.get = Mock(return_value=resp)
+
+
+def test_fetch_returns_text_and_raw_bytes():
+    raw = _apkindex_targz(b"C:Q1xxx\nP:demo\nV:1.0-r0\n")
+    syncer = _syncer()
+    _mock_get(syncer, raw)
+
+    text, returned_raw = syncer._fetch_apkindex("http://x/APKINDEX.tar.gz", syncer.config)
+
+    assert "P:demo" in text
+    assert returned_raw == raw  # raw reused for storage -> single download
+    syncer.session.get.assert_called_once()
+
+
+def test_fetch_decode_is_lenient():
+    raw = _apkindex_targz(b"P:demo\nm:Ma\xffntainer\n")  # invalid UTF-8 byte
+    syncer = _syncer()
+    _mock_get(syncer, raw)
+
+    text, _ = syncer._fetch_apkindex("http://x/APKINDEX.tar.gz", syncer.config)
+
+    assert "P:demo" in text  # the index is not dropped over one bad byte
+
+
+def test_fetch_rejects_oversized_apkindex(monkeypatch):
+    monkeypatch.setattr(apk_sync, "_MAX_APKINDEX_BYTES", 8)
+    raw = _apkindex_targz(b"P:demo\nV:1.0-r0\n")  # > 8 bytes uncompressed
+    syncer = _syncer()
+    _mock_get(syncer, raw)
+
+    with pytest.raises(ValueError, match="too large"):
+        syncer._fetch_apkindex("http://x/APKINDEX.tar.gz", syncer.config)

--- a/tests/test_apk_sync_dedup.py
+++ b/tests/test_apk_sync_dedup.py
@@ -49,7 +49,7 @@ def session(tmp_path):
 
 def _run(session, syncer, config, repo, parsed):
     with (
-        patch.object(syncer, "_fetch_apkindex", return_value=b""),
+        patch.object(syncer, "_fetch_apkindex", return_value=("", b"")),
         patch.object(syncer, "_store_apkindex_file"),
         patch.object(syncer, "_parse_apkindex", return_value=parsed),
         patch.object(


### PR DESCRIPTION
## Problems

1. **Decompression bomb.** `_fetch_apkindex` read the `APKINDEX` tar member with no size cap, so a tiny but highly-compressible `APKINDEX.tar.gz` could expand into a multi-GB buffer (OOM). (The `.apk` checksum path was already bomb-resistant; the index path that runs first was not.)
2. **Redundant second download / TOCTOU.** `_store_apkindex_file` did a **second** independent `GET` of the same archive — wasted bandwidth, and a TOCTOU window: if upstream changed between the two fetches, the stored mirror index could reference packages that were never parsed/downloaded → mirror publish serving an APKINDEX pointing at missing `.apk` files.
3. **Strict decode.** `.decode("utf-8")` (uncaught) crashed the whole sync on a single non-UTF-8 byte (latin-1 maintainer fields appear in some third-party repos).

## Fix

Cap the decompressed APKINDEX at **256 MiB** (far above any real repo), decode **leniently** (`errors="replace"`), and return the raw bytes from the **single** fetch so `_store_apkindex_file` reuses them instead of downloading again.

## Tests

Oversized APKINDEX rejected; lenient decode keeps the index; the single fetch returns the raw bytes (one `GET`).