### PR TITLE
fix(helm): order chart versions with SemVer, not PEP 440

### DIFF
--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -445,24 +445,27 @@ class HelmSyncer:
         # Post-processing: only_latest_version
         if config.filters and config.filters.post_processing:
             if config.filters.post_processing.only_latest_version:
-                # Group by chart name and keep only latest version
-                from packaging import version as pkg_version
+                # Keep the newest version of each chart using SemVer ordering
+                # (Helm versions are SemVer 2.0.0, not PEP 440).
+                from chantal.plugins.helm.version import semver_compare
 
-                by_name = {}
+                by_name: dict[str, dict] = {}
                 for chart in filtered:
                     name = chart["name"]
-                    ver = chart["version"]
-
-                    if name not in by_name:
+                    current = by_name.get(name)
+                    if current is None:
                         by_name[name] = chart
-                    else:
-                        # Compare versions
-                        try:
-                            if pkg_version.parse(ver) > pkg_version.parse(by_name[name]["version"]):
-                                by_name[name] = chart
-                        except Exception:
-                            # Version parsing failed - keep first one
-                            pass
+                        continue
+                    try:
+                        if semver_compare(chart["version"], current["version"]) > 0:
+                            by_name[name] = chart
+                    except ValueError as e:
+                        # Unparseable version: keep the already-stored chart so
+                        # the result is deterministic rather than arbitrary.
+                        logger.warning(
+                            f"Helm version comparison failed for {name} "
+                            f"({chart['version']} vs {current['version']}): {e}"
+                        )
 
                 filtered = list(by_name.values())
 

--- a/src/chantal/plugins/helm/version.py
+++ b/src/chantal/plugins/helm/version.py
@@ -1,0 +1,84 @@
+"""Helm chart version comparison (SemVer 2.0.0).
+
+Helm chart versions are SemVer 2.0.0, *not* PEP 440. The differences that matter
+for picking the "latest" version:
+
+* a version with a pre-release is lower than the same without
+  (``1.2.3-alpha < 1.2.3``);
+* pre-release identifiers are compared dot-separated, numeric ones numerically,
+  alphanumeric ones lexically, with numeric < alphanumeric;
+* build metadata (``+...``) is ignored for precedence.
+
+PEP 440 disagrees on all of these (and rejects many valid SemVer strings), so the
+``only_latest_version`` filter uses this module instead.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+
+# Optional leading "v" (Helm tolerates it), then MAJOR.MINOR.PATCH, optional
+# -prerelease and +build.
+_SEMVER_RE = re.compile(
+    r"^v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+(?P<build>[0-9A-Za-z.-]+))?$"
+)
+
+
+def _parse(version: str) -> tuple[int, int, int, list[str]]:
+    """Parse a SemVer string into ``(major, minor, patch, prerelease_ids)``.
+
+    Build metadata is discarded. Raises ValueError on a non-SemVer string.
+    """
+    m = _SEMVER_RE.match(version.strip())
+    if not m:
+        raise ValueError(f"not a SemVer version: {version!r}")
+    pre = m.group("prerelease")
+    pre_ids = pre.split(".") if pre else []
+    return int(m.group("major")), int(m.group("minor")), int(m.group("patch")), pre_ids
+
+
+def _cmp_prerelease_id(a: str, b: str) -> int:
+    """Compare two pre-release identifiers per SemVer rules."""
+    a_num, b_num = a.isdigit(), b.isdigit()
+    if a_num and b_num:
+        ai, bi = int(a), int(b)
+        return (ai > bi) - (ai < bi)
+    if a_num != b_num:
+        # Numeric identifiers always have lower precedence than alphanumeric.
+        return -1 if a_num else 1
+    return (a > b) - (a < b)
+
+
+def semver_compare(a: str, b: str) -> int:
+    """Compare two SemVer versions. Returns -1, 0 or 1 (a<b, a==b, a>b).
+
+    Raises ValueError if either version is not valid SemVer.
+    """
+    pa = _parse(a)
+    pb = _parse(b)
+
+    for x, y in zip(pa[:3], pb[:3], strict=True):
+        if x != y:
+            return (x > y) - (x < y)
+
+    pre_a, pre_b = pa[3], pb[3]
+    # A version with a pre-release is lower than one without.
+    if not pre_a and pre_b:
+        return 1
+    if pre_a and not pre_b:
+        return -1
+    if not pre_a and not pre_b:
+        return 0
+
+    for ida, idb in zip(pre_a, pre_b, strict=False):
+        c = _cmp_prerelease_id(ida, idb)
+        if c:
+            return c
+    # All shared identifiers equal: the longer pre-release wins.
+    return (len(pre_a) > len(pre_b)) - (len(pre_a) < len(pre_b))
+
+
+semver_key = functools.cmp_to_key(semver_compare)

--- a/tests/test_helm_version.py
+++ b/tests/test_helm_version.py
@@ -1,0 +1,68 @@
+"""Tests for Helm SemVer comparison and the only_latest_version filter."""
+
+from __future__ import annotations
+
+import pytest
+
+from chantal.plugins.helm.version import semver_compare, semver_key
+
+
+@pytest.mark.parametrize(
+    "a, b, expected",
+    [
+        ("2.0.0", "1.9.9", 1),
+        ("1.10.0", "1.9.0", 1),  # numeric, not lexical
+        ("1.2.3", "1.2.3", 0),
+        ("1.2.3-alpha", "1.2.3", -1),  # pre-release < release
+        ("1.2.3-alpha", "1.2.3-alpha.1", -1),
+        ("1.2.3-alpha.1", "1.2.3-alpha.beta", -1),  # numeric < alphanumeric
+        ("1.2.3-beta.2", "1.2.3-beta.11", -1),  # numeric identifiers numeric
+        ("1.2.3-rc.1", "1.2.3", -1),
+        ("1.2.3+build1", "1.2.3+build2", 0),  # build metadata ignored
+        ("v1.2.3", "1.2.3", 0),  # leading v tolerated
+    ],
+)
+def test_semver_compare(a, b, expected):
+    assert semver_compare(a, b) == expected
+    assert semver_compare(b, a) == -expected
+
+
+def test_semver_key_sorts():
+    versions = ["1.2.3", "1.2.3-rc.1", "1.10.0", "1.2.3-alpha", "2.0.0"]
+    assert sorted(versions, key=semver_key) == [
+        "1.2.3-alpha",
+        "1.2.3-rc.1",
+        "1.2.3",
+        "1.10.0",
+        "2.0.0",
+    ]
+
+
+def test_semver_compare_rejects_non_semver():
+    with pytest.raises(ValueError):
+        semver_compare("1.2", "1.2.3")  # not 3-part
+    with pytest.raises(ValueError):
+        semver_compare("notaversion", "1.2.3")
+
+
+def test_only_latest_version_filter_uses_semver():
+    from chantal.core.config import FilterConfig, PostProcessingConfig, RepositoryConfig
+    from chantal.plugins.helm.sync import HelmSyncer
+
+    config = RepositoryConfig(
+        id="demo",
+        name="Demo",
+        type="helm",
+        feed="http://example.com/charts",
+        filters=FilterConfig(post_processing=PostProcessingConfig(only_latest_version=True)),
+    )
+    syncer = HelmSyncer(storage=None, config=config)
+
+    charts = [
+        {"name": "demo", "version": "1.2.3-rc.1"},  # pre-release: must NOT win
+        {"name": "demo", "version": "1.2.3"},
+        {"name": "demo", "version": "1.10.0"},  # newest (PEP 440 string-confusion aside)
+        {"name": "demo", "version": "1.9.0"},
+    ]
+    result = syncer._apply_filters(charts, config)
+    assert [c["version"] for c in result] == ["1.10.0"]


### PR DESCRIPTION
## Problem

`only_latest_version` compared Helm chart versions with `packaging.version` (**PEP 440**), but Helm versions are **SemVer 2.0.0**. PEP 440 mis-orders pre-releases/build metadata and **rejects** many valid SemVer strings (e.g. `1.2.3-alpha.1+build.5`) — and the parse error was swallowed, keeping whichever chart was seen first. So the "latest" version kept could be wrong.

## Fix

New `src/chantal/plugins/helm/version.py` — a SemVer 2.0.0 comparator: `major.minor.patch` numeric, pre-release precedence (dot-separated identifiers, **numeric < alphanumeric**, a pre-release is lower than the release), **build metadata ignored**, optional leading `v`. The filter uses it and falls back deterministically (keeps the stored chart) on an unparseable version.

## Tests

The canonical semver.org precedence chain (`1.0.0-alpha < … < 1.0.0-rc.1 < 1.0.0`), build-metadata/leading-v/numeric cases, and the filter picking the SemVer-newest of a multi-version set.