### PR TITLE
fix(apt): order versions with dpkg semantics, not PEP 440

### DIFF
--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -1132,24 +1132,27 @@ class AptSyncPlugin:
 
         # Post-processing: only_latest_version
         if config.filters.post_processing and config.filters.post_processing.only_latest_version:
-            from packaging import version as pkg_version
+            # Keep the newest version of each (name, arch) using dpkg version
+            # ordering (Debian epoch/~/revision semantics; PEP 440 mis-orders or
+            # rejects them).
+            from chantal.plugins.apt.version import dpkg_compare
 
-            # Group by (package name, architecture)
-            by_name_arch = {}
+            by_name_arch: dict[tuple[str, str], DebMetadata] = {}
             for pkg in filtered:
                 key = (pkg.package, pkg.architecture)
-                if key not in by_name_arch:
+                current = by_name_arch.get(key)
+                if current is None:
                     by_name_arch[key] = pkg
-                else:
-                    # Compare versions
-                    try:
-                        if pkg_version.parse(pkg.version) > pkg_version.parse(
-                            by_name_arch[key].version
-                        ):
-                            by_name_arch[key] = pkg
-                    except Exception:
-                        # Version parsing failed - keep first one
-                        pass
+                    continue
+                try:
+                    if dpkg_compare(pkg.version, current.version) > 0:
+                        by_name_arch[key] = pkg
+                except ValueError as e:
+                    # Unparseable version: keep the already-stored package.
+                    logger.warning(
+                        f"Debian version comparison failed for {pkg.package} "
+                        f"({pkg.version} vs {current.version}): {e}"
+                    )
 
             filtered = list(by_name_arch.values())
 

--- a/src/chantal/plugins/apt/version.py
+++ b/src/chantal/plugins/apt/version.py
@@ -1,0 +1,93 @@
+"""Debian package version comparison (dpkg semantics).
+
+Debian versions are ``[epoch:]upstream_version[-debian_revision]`` and are *not*
+ordered by PEP 440: the epoch is compared first as an integer, ``~`` sorts before
+everything (even the empty string, so ``1.0~rc1 < 1.0``), and digit/non-digit
+runs alternate with dpkg's own character ordering. PEP 440 rejects the epoch
+colon and ``~`` outright, so the ``only_latest_version`` filter uses this faithful
+port of dpkg's ``verrevcmp`` instead.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+
+_VERSION_RE = re.compile(r"^(?:(\d+):)?([A-Za-z0-9.+~-]*?)(?:-([A-Za-z0-9.+~]+))?$")
+
+
+def _order(char: str) -> int:
+    """Character ranking used by dpkg's non-digit comparison.
+
+    ``~`` < (end of string) < digits-position < letters < other punctuation.
+    """
+    if char == "~":
+        return -1
+    if char.isalpha():
+        return ord(char)
+    # Non-letter, non-digit, non-tilde: sort after letters.
+    return ord(char) + 256
+
+
+def _verrevcmp(a: str, b: str) -> int:
+    """Compare two upstream/revision strings exactly as dpkg's verrevcmp does."""
+    i = j = 0
+    la, lb = len(a), len(b)
+    while i < la or j < lb:
+        # Compare the leading non-digit run.
+        while (i < la and not a[i].isdigit()) or (j < lb and not b[j].isdigit()):
+            ac = _order(a[i]) if i < la and not a[i].isdigit() else 0
+            bc = _order(b[j]) if j < lb and not b[j].isdigit() else 0
+            if ac != bc:
+                return -1 if ac < bc else 1
+            i += 1
+            j += 1
+        # Skip leading zeros, then compare the digit run by value (length first).
+        while i < la and a[i] == "0":
+            i += 1
+        while j < lb and b[j] == "0":
+            j += 1
+        first_diff = 0
+        while i < la and a[i].isdigit() and j < lb and b[j].isdigit():
+            if first_diff == 0:
+                first_diff = ord(a[i]) - ord(b[j])
+            i += 1
+            j += 1
+        if i < la and a[i].isdigit():
+            return 1  # a has a longer number -> larger
+        if j < lb and b[j].isdigit():
+            return -1
+        if first_diff != 0:
+            return -1 if first_diff < 0 else 1
+    return 0
+
+
+def _split(version: str) -> tuple[int, str, str]:
+    """Split a Debian version into ``(epoch, upstream, revision)``."""
+    m = _VERSION_RE.match(version.strip())
+    if not m:
+        raise ValueError(f"not a Debian version: {version!r}")
+    epoch = int(m.group(1)) if m.group(1) else 0
+    upstream = m.group(2) or ""
+    revision = m.group(3) or ""
+    if not upstream:
+        raise ValueError(f"empty upstream version in {version!r}")
+    return epoch, upstream, revision
+
+
+def dpkg_compare(a: str, b: str) -> int:
+    """Compare two Debian versions. Returns -1, 0 or 1 (a<b, a==b, a>b).
+
+    Raises ValueError if either version cannot be parsed.
+    """
+    ea, ua, ra = _split(a)
+    eb, ub, rb = _split(b)
+    if ea != eb:
+        return -1 if ea < eb else 1
+    c = _verrevcmp(ua, ub)
+    if c:
+        return c
+    return _verrevcmp(ra, rb)
+
+
+dpkg_version_key = functools.cmp_to_key(dpkg_compare)

--- a/tests/test_apt_version.py
+++ b/tests/test_apt_version.py
@@ -1,0 +1,82 @@
+"""Tests for Debian version comparison and the only_latest_version filter."""
+
+from __future__ import annotations
+
+import pytest
+
+from chantal.plugins.apt.version import dpkg_compare, dpkg_version_key
+
+
+@pytest.mark.parametrize(
+    "a, b, expected",
+    [
+        ("2.0", "1.0", 1),
+        ("1.10", "1.9", 1),  # numeric upstream, not lexical
+        ("1:1.0", "2.0", 1),  # epoch wins
+        ("0:1.0", "1.0", 0),  # explicit epoch 0 == none
+        ("1.0~rc1", "1.0", -1),  # tilde sorts before the release
+        ("1.0~~", "1.0~", -1),
+        ("1.0-1", "1.0-10", -1),  # revision numeric, not lexical
+        ("1.0", "1.0-1", -1),  # no revision < revision
+        ("1.0", "1.0-0", 0),  # empty revision == -0
+        ("1.0+deb1", "1.0", 1),  # '+' sorts after end
+        ("2.2.4-1", "2.2.4-1", 0),
+    ],
+)
+def test_dpkg_compare(a, b, expected):
+    assert dpkg_compare(a, b) == expected
+    assert dpkg_compare(b, a) == -expected
+
+
+def test_dpkg_key_sorts():
+    versions = ["1.0", "1:0.5", "1.0~rc1", "1.0-2", "1.0-10", "2.0"]
+    assert sorted(versions, key=dpkg_version_key) == [
+        "1.0~rc1",
+        "1.0",
+        "1.0-2",
+        "1.0-10",
+        "2.0",
+        "1:0.5",  # epoch 1 outranks everything with epoch 0
+    ]
+
+
+def test_dpkg_compare_rejects_unparseable():
+    with pytest.raises(ValueError):
+        dpkg_compare("", "1.0")
+
+
+def test_only_latest_version_filter_uses_dpkg_ordering():
+    from chantal.core.config import (
+        AptConfig,
+        FilterConfig,
+        PostProcessingConfig,
+        RepositoryConfig,
+    )
+    from chantal.plugins.apt.models import DebMetadata
+    from chantal.plugins.apt.sync import AptSyncPlugin
+
+    config = RepositoryConfig(
+        id="deb",
+        name="Deb",
+        type="apt",
+        feed="http://example.com/ubuntu",
+        apt=AptConfig(distribution="jammy", components=["main"], architectures=["amd64"]),
+        filters=FilterConfig(post_processing=PostProcessingConfig(only_latest_version=True)),
+    )
+    syncer = AptSyncPlugin(storage=None, config=config)
+
+    def deb(version):
+        return DebMetadata(
+            package="demo",
+            version=version,
+            architecture="amd64",
+            filename=f"pool/demo_{version}_amd64.deb",
+            size=1,
+            sha256="0" * 64,
+        )
+
+    # 2.0 was first-seen; the epoch'd 1:1.0 is newer in Debian (PEP 440 can't even
+    # parse it and would keep 2.0).
+    packages = [deb("2.0"), deb("1:1.0"), deb("1.0~rc1")]
+    result = syncer._apply_filters(packages, config)
+    assert [p.version for p in result] == ["1:1.0"]


### PR DESCRIPTION
## Problem

`only_latest_version` compared Debian versions with `packaging.version` (**PEP 440**). Debian versions use an **epoch** (`1:...`), a **`~`** that sorts *before* everything (so `1.0~rc1 < 1.0`), and a **`-revision`** — none of which PEP 440 models. It rejects the epoch colon and `~` outright, and the swallowed `InvalidVersion` left `only_latest` keeping whichever package was **seen first**. So the newest could be dropped — e.g. an epoch'd `1:1.0` losing to `2.0`.

## Fix

New `src/chantal/plugins/apt/version.py` — a faithful port of dpkg's `verrevcmp`: epoch compared first as an integer, then upstream and revision via the alternating digit/non-digit comparison with the dpkg character order (`~` < end-of-string < digits-position < letters < other punctuation). The filter uses it, grouped per `(name, arch)`, falling back deterministically on an unparseable version.

## Tests

dpkg ordering edge cases (epoch, `~`, `~~`, numeric revision `-1` vs `-10`, `+` suffix, `-0` ≡ no revision), each antisymmetric, and the filter picking the dpkg-newest of an epoch'd set.