### PR TITLE
fix(helm): dedup repackaged charts at publish and pass OCI credentials

### DIFF
--- a/src/chantal/plugins/helm/publisher.py
+++ b/src/chantal/plugins/helm/publisher.py
@@ -115,6 +115,14 @@ class HelmPublisher(PublisherPlugin):
         """
         target_path.mkdir(parents=True, exist_ok=True)
 
+        # A repackaged chart (same name+version, hence same filename, but new
+        # bytes) leaves two ContentItems linked. Publishing both hardlinks the
+        # same filename twice (last wins on disk) and emits two index entries with
+        # conflicting digests pointing at the one file - a client resolving the
+        # wrong digest then fails verification. Keep one chart per filename (the
+        # most recently synced, i.e. highest id) so disk and index agree.
+        charts = self._dedup_charts_by_filename(charts)
+
         # Hardlink chart files to target directory
         for chart in charts:
             pool_path = self.storage.get_absolute_pool_path(chart.sha256, chart.filename)
@@ -131,6 +139,22 @@ class HelmPublisher(PublisherPlugin):
         )
 
         logger.info(f"Published {len(charts)} charts to {target_path}")
+
+    @staticmethod
+    def _dedup_charts_by_filename(charts: list[ContentItem]) -> list[ContentItem]:
+        """Keep a single chart per published filename (the highest-id one).
+
+        Two ContentItems can share a filename when upstream repackages a chart
+        (same name+version, new bytes). They map to one tarball on disk, so the
+        published index must reference exactly one of them; keep the most recently
+        synced (highest id) so the index digest matches the file that wins on disk.
+        """
+        by_filename: dict[str, ContentItem] = {}
+        for chart in charts:
+            existing = by_filename.get(chart.filename)
+            if existing is None or (chart.id or 0) > (existing.id or 0):
+                by_filename[chart.filename] = chart
+        return list(by_filename.values())
 
     def _publish_metadata_files(
         self,

--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -547,11 +547,16 @@ class HelmSyncer:
             # Build helm command
             cmd = ["helm", "pull", url, "--destination", str(tmpdir_path)]
 
-            # Add registry credentials if available
+            # Pass registry credentials directly so private OCI registries work
+            # without relying on a prior `helm registry login` (which would make
+            # the mirror depend on ambient host state).
             if config.auth and config.auth.username and config.auth.password:
-                # helm pull will use credentials from helm registry login
-                # For inline credentials, we'd need to run helm registry login first
-                logger.debug("Registry credentials available but helm pull uses stored credentials")
+                cmd += [
+                    "--username",
+                    config.auth.username,
+                    "--password",
+                    config.auth.password,
+                ]
 
             try:
                 # Execute helm pull

--- a/tests/test_helm_publish_dedup.py
+++ b/tests/test_helm_publish_dedup.py
@@ -1,0 +1,68 @@
+"""Helm: dedup repackaged charts at publish, and pass OCI registry credentials."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from chantal.core.config import AuthConfig, RepositoryConfig
+from chantal.db.models import ContentItem
+from chantal.plugins.helm.publisher import HelmPublisher
+from chantal.plugins.helm.sync import HelmSyncer
+
+
+def _chart(item_id: int, sha: str, filename="demo-1.0.0.tgz") -> ContentItem:
+    c = ContentItem(
+        content_type="helm",
+        name="demo",
+        version="1.0.0",
+        sha256=sha,
+        size_bytes=1,
+        pool_path=f"{sha[:2]}/{sha[2:4]}/{filename}",
+        filename=filename,
+        content_metadata={},
+    )
+    c.id = item_id
+    return c
+
+
+def test_dedup_keeps_highest_id_per_filename():
+    """A repackaged chart (same filename, new bytes) must collapse to one entry —
+    the most recently synced (highest id), matching the file that wins on disk."""
+    older = _chart(1, "a" * 64)
+    newer = _chart(2, "b" * 64)
+    result = HelmPublisher._dedup_charts_by_filename([older, newer])
+    assert len(result) == 1
+    assert result[0].sha256 == "b" * 64
+
+    # Distinct filenames are all kept.
+    other = _chart(3, "c" * 64, filename="other-2.0.0.tgz")
+    result2 = HelmPublisher._dedup_charts_by_filename([older, newer, other])
+    assert {c.filename for c in result2} == {"demo-1.0.0.tgz", "other-2.0.0.tgz"}
+
+
+def test_oci_pull_passes_credentials():
+    config = RepositoryConfig(
+        id="demo",
+        name="Demo",
+        type="helm",
+        feed="oci://reg.example.com/charts",
+        auth=AuthConfig(type="basic", username="user", password="secret"),
+    )
+    syncer = HelmSyncer(storage=None, config=config)
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        raise subprocess.CalledProcessError(1, cmd, stderr="stop here")
+
+    with patch("chantal.plugins.helm.sync.subprocess.run", side_effect=fake_run):
+        try:
+            syncer._download_oci_chart("oci://reg.example.com/charts/demo:1.0.0", config)
+        except RuntimeError:
+            pass  # we only care about the command that was built
+
+    cmd = captured["cmd"]
+    assert "--username" in cmd and "user" in cmd
+    assert "--password" in cmd and "secret" in cmd


### PR DESCRIPTION
## Problems

1. **Conflicting index entries from a repackaged chart.** When upstream repackages a chart (same name+version → same filename, new bytes), two `ContentItem`s stay linked. Publishing both hardlinked the one filename twice (last wins on disk) and emitted **two `index.yaml` entries with conflicting digests** pointing at that single file — a Helm client resolving the entry whose digest ≠ the on-disk bytes then fails verification.
2. **OCI credentials ignored.** For `oci://` charts the credentials were only *logged*; `helm pull` was invoked without them, so private OCI registries failed or silently depended on a prior `helm registry login` on the host (non-reproducible in an automated mirror).

## Fix

1. `_dedup_charts_by_filename` keeps one chart per published filename (the most recently synced — highest id), so the index and the on-disk file agree.
2. Pass `--username`/`--password` to `helm pull`.

## Tests

- Dedup keeps the highest-id chart per filename; distinct filenames coexist.
- The OCI pull command carries the configured credentials.

Note: pruning the superseded `ContentItem` at sync time is a broader content-lifecycle change (left as-is); this fixes the published-output symptom.