### PR TITLE
fix(apt): bound index decompression and decode indices leniently

### DIFF
--- a/src/chantal/plugins/apt/parsers.py
+++ b/src/chantal/plugins/apt/parsers.py
@@ -491,10 +491,10 @@ def parse_packages_from_bytes(data: bytes, compressed: bool = False) -> list[Deb
         List of DebMetadata objects
     """
     if compressed:
-        with gzip.open(BytesIO(data), "rt", encoding="utf-8") as f:
+        with gzip.open(BytesIO(data), "rt", encoding="utf-8", errors="replace") as f:
             content = f.read()
     else:
-        content = data.decode("utf-8")
+        content = data.decode("utf-8", "replace")
     return parse_packages_file(content)
 
 
@@ -525,8 +525,8 @@ def parse_sources_from_bytes(data: bytes, compressed: bool = False) -> list[Sour
         List of SourcesMetadata objects
     """
     if compressed:
-        with gzip.open(BytesIO(data), "rt", encoding="utf-8") as f:
+        with gzip.open(BytesIO(data), "rt", encoding="utf-8", errors="replace") as f:
             content = f.read()
     else:
-        content = data.decode("utf-8")
+        content = data.decode("utf-8", "replace")
     return parse_sources_file(content)

--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -37,6 +37,11 @@ logger = logging.getLogger(__name__)
 _INDEX_VARIANTS = (".gz", ".xz", ".bz2", ".zst", "")
 _COMPRESSED_SUFFIXES = (".gz", ".xz", ".bz2", ".zst")
 
+# Upper bound on a decompressed index. The largest real indices (Debian main
+# Contents-*) are a few hundred MB; this cap is far above that but stops a tiny,
+# highly-compressible Packages/Sources/Contents from expanding into many GB.
+_MAX_INDEX_BYTES = 2 * 1024 * 1024 * 1024
+
 
 def _pick_index_variant(base: str, checksums: dict) -> str | None:
     """Return the first present compression variant of ``base`` in ``checksums``.
@@ -52,9 +57,17 @@ def _pick_index_variant(base: str, checksums: dict) -> str | None:
 
 
 def _decompress_index(data: bytes, relative_path: str) -> bytes:
-    """Decompress an index file by its path suffix (gz/xz/bz2/zst or raw)."""
+    """Decompress an index file by its path suffix (gz/xz/bz2/zst or raw).
+
+    Bounded so a malicious (or, with verification disabled, simply untrusted)
+    upstream cannot ship a tiny index that inflates to many GB and OOMs the sync.
+    """
     suffix = PurePosixPath(relative_path).suffix
-    return decompress_bytes(data, suffix if suffix in _COMPRESSED_SUFFIXES else "")
+    return decompress_bytes(
+        data,
+        suffix if suffix in _COMPRESSED_SUFFIXES else "",
+        max_output_bytes=_MAX_INDEX_BYTES,
+    )
 
 
 @dataclass

--- a/tests/test_apt_index_decode.py
+++ b/tests/test_apt_index_decode.py
@@ -1,0 +1,43 @@
+"""APT: bounded index decompression and lenient index decoding."""
+
+from __future__ import annotations
+
+import gzip
+
+import pytest
+
+import chantal.plugins.apt.sync as apt_sync
+from chantal.plugins.apt.parsers import parse_packages_from_bytes
+from chantal.plugins.apt.sync import _decompress_index
+from chantal.plugins.rpm.modules import DecompressionLimitError
+
+
+def test_decompress_index_rejects_bomb(monkeypatch):
+    monkeypatch.setattr(apt_sync, "_MAX_INDEX_BYTES", 64)
+    bomb = gzip.compress(b"\0" * (1024 * 1024))  # 1 MiB -> tiny gz, over the 64 B cap
+    with pytest.raises(DecompressionLimitError):
+        _decompress_index(bomb, "main/binary-amd64/Packages.gz")
+
+
+def test_decompress_index_under_cap_round_trips():
+    payload = b"Package: demo\n\n"
+    assert _decompress_index(gzip.compress(payload), "main/binary-amd64/Packages.gz") == payload
+    # Uncompressed (no known suffix) is returned as-is.
+    assert _decompress_index(payload, "main/binary-amd64/Packages") == payload
+
+
+def test_parse_packages_is_lenient_on_bad_utf8():
+    """A stray non-UTF-8 byte must not drop the whole index."""
+    stanza = (
+        b"Package: demo\n"
+        b"Version: 1.0\n"
+        b"Architecture: amd64\n"
+        b"Maintainer: Ma\xffntainer\n"  # invalid UTF-8 byte
+        b"Filename: pool/demo_1.0_amd64.deb\n"
+        b"Size: 10\n"
+        b"SHA256: " + b"a" * 64 + b"\n"
+        b"Description: a demo\n"
+        b"\n"
+    )
+    packages = parse_packages_from_bytes(stanza, compressed=False)
+    assert [p.package for p in packages] == ["demo"]


### PR DESCRIPTION
## Problems

1. **Decompression bomb.** `_decompress_index` decompressed `Packages`/`Sources`/`Contents` with **no size cap** — the same protection added for `control.tar` (#106) and `Chart.yaml` (#110) was never extended to the much larger index path. A malicious upstream (or any upstream when signature verification is disabled — the default) could ship a tiny index that inflates to many GB and OOMs the sync.
2. **Strict decode drops a whole index.** The parsers did `data.decode("utf-8")`, so a single non-UTF-8 byte (latin-1 maintainer/description fields appear in some third-party repos) raised, and the caller silently dropped the **entire component/arch**.

## Fix

- Cap `_decompress_index` output at **2 GiB** (far above the largest real `Contents-*`) via `decompress_bytes(..., max_output_bytes=...)`.
- Decode indices with `errors="replace"` (both the raw and gzip paths), matching the `.deb` control parser.

## Tests

An over-cap gz index is rejected; an under-cap one round-trips; a `Packages` stanza with a bad byte still parses.