### PR TITLE
fix(rpm): order versions with rpm EVR semantics, not PEP 440

### DIFF
--- a/src/chantal/plugins/rpm/filters.py
+++ b/src/chantal/plugins/rpm/filters.py
@@ -10,8 +10,6 @@ import re
 from collections import defaultdict
 from datetime import datetime, timedelta
 
-from packaging import version
-
 from chantal.core.config import (
     FilterConfig,
     GenericMetadataFilterConfig,
@@ -20,6 +18,7 @@ from chantal.core.config import (
     PostProcessingConfig,
     RpmFilterConfig,
 )
+from chantal.plugins.rpm.version import evr_pkg_key
 
 
 def apply_filters(packages: list[dict], filters: FilterConfig) -> list[dict]:
@@ -253,35 +252,12 @@ def keep_only_latest_versions(packages: list[dict], n: int = 1) -> list[dict]:
         key = (name, arch)
         grouped[key].append(pkg)
 
-    # For each group, keep only latest N versions
+    # For each group, keep only the latest N versions (newest first) using RPM's
+    # own EVR ordering (rpmvercmp). PEP 440 mis-orders releases like 10.el9 vs
+    # 9.el9 and rejects/mishandles RPM '~'/'^' versions.
     result = []
-    for (name, arch), pkg_list in grouped.items():
-        # Sort by version (newest first)
-        # Use tuple comparison: (epoch, version, release) for RPM version semantics
-        try:
-            sorted_pkgs = sorted(
-                pkg_list,
-                key=lambda p: (
-                    int(p.get("epoch", 0) or 0),  # Epoch as int
-                    version.parse(p.get("version", "")),  # Parse version
-                    p.get("release", ""),  # Release as string
-                ),
-                reverse=True,
-            )
-        except Exception as e:
-            # If version parsing fails, fall back to simple tuple comparison
-            print(f"Warning: Version parsing failed for {name}.{arch}: {e}")
-            sorted_pkgs = sorted(
-                pkg_list,
-                key=lambda p: (
-                    int(p.get("epoch", 0) or 0),
-                    p.get("version", ""),
-                    p.get("release", ""),
-                ),
-                reverse=True,
-            )
-
-        # Keep only latest N versions
+    for pkg_list in grouped.values():
+        sorted_pkgs = sorted(pkg_list, key=evr_pkg_key, reverse=True)
         result.extend(sorted_pkgs[:n])
 
     return result

--- a/src/chantal/plugins/rpm/version.py
+++ b/src/chantal/plugins/rpm/version.py
@@ -1,0 +1,134 @@
+"""RPM EVR (epoch:version-release) comparison.
+
+RPM versions are *not* ordered by PEP 440. ``rpm`` compares the epoch as an
+integer, then the version and release each with ``rpmvercmp``: a segment-wise
+comparison where ``~`` sorts before everything (pre-release), ``^`` sorts after
+the end of a version but before a following segment (post-release snapshot),
+numeric segments outrank alphabetic ones, and a longer numeric segment is
+greater (so ``10.el9`` > ``9.el9``, which lexical/PEP 440 ordering gets wrong).
+
+This is a faithful port of rpm's ``rpmvercmp`` (lib/rpmvercmp.c), used by the
+``only_latest_version`` filter.
+"""
+
+from __future__ import annotations
+
+import functools
+
+
+def rpmvercmp(a: str, b: str) -> int:
+    """Compare two RPM version (or release) strings. Returns -1, 0 or 1."""
+    if a == b:
+        return 0
+
+    i, j = 0, 0
+    la, lb = len(a), len(b)
+
+    def _sep(c: str) -> bool:
+        return not (c.isalnum() or c in "~^")
+
+    while i < la or j < lb:
+        # Skip separators (anything that isn't alphanumeric, '~' or '^').
+        while i < la and _sep(a[i]):
+            i += 1
+        while j < lb and _sep(b[j]):
+            j += 1
+
+        # Tilde: sorts before everything, even the empty string.
+        a_t = i < la and a[i] == "~"
+        b_t = j < lb and b[j] == "~"
+        if a_t or b_t:
+            if not a_t:
+                return 1
+            if not b_t:
+                return -1
+            i += 1
+            j += 1
+            continue
+
+        # Caret: greater than the end of string, less than a following segment.
+        a_c = i < la and a[i] == "^"
+        b_c = j < lb and b[j] == "^"
+        if a_c or b_c:
+            if i >= la:
+                return -1
+            if j >= lb:
+                return 1
+            if not a_c:
+                return 1
+            if not b_c:
+                return -1
+            i += 1
+            j += 1
+            continue
+
+        # One side ran out (after skipping separators).
+        if not (i < la and j < lb):
+            break
+
+        # Grab the next segment (a run of digits or a run of letters).
+        start_i, start_j = i, j
+        if a[i].isdigit():
+            while i < la and a[i].isdigit():
+                i += 1
+            while j < lb and b[j].isdigit():
+                j += 1
+            isnum = True
+        else:
+            while i < la and a[i].isalpha():
+                i += 1
+            while j < lb and b[j].isalpha():
+                j += 1
+            isnum = False
+
+        seg_a = a[start_i:i]
+        seg_b = b[start_j:j]
+
+        if seg_b == "":
+            # b has no segment of this type here: a numeric segment outranks it,
+            # an alphabetic one is outranked.
+            return 1 if isnum else -1
+
+        if isnum:
+            # Numeric: ignore leading zeros, then the longer number is greater.
+            seg_a = seg_a.lstrip("0")
+            seg_b = seg_b.lstrip("0")
+            if len(seg_a) > len(seg_b):
+                return 1
+            if len(seg_b) > len(seg_a):
+                return -1
+
+        if seg_a < seg_b:
+            return -1
+        if seg_a > seg_b:
+            return 1
+
+    if i >= la and j >= lb:
+        return 0
+    return -1 if i >= la else 1
+
+
+def evr_compare(epoch_a: int, ver_a: str, rel_a: str, epoch_b: int, ver_b: str, rel_b: str) -> int:
+    """Compare two RPM EVRs. Returns -1, 0 or 1."""
+    if epoch_a != epoch_b:
+        return -1 if epoch_a < epoch_b else 1
+    c = rpmvercmp(ver_a, ver_b)
+    if c:
+        return c
+    return rpmvercmp(rel_a, rel_b)
+
+
+def _evr_pkg_compare(p1: dict, p2: dict) -> int:
+    """Compare two package dicts (name/version/release/epoch fields) by EVR."""
+    return evr_compare(
+        int(p1.get("epoch", 0) or 0),
+        p1.get("version", "") or "",
+        p1.get("release", "") or "",
+        int(p2.get("epoch", 0) or 0),
+        p2.get("version", "") or "",
+        p2.get("release", "") or "",
+    )
+
+
+# ``sorted(packages, key=evr_pkg_key)`` orders package dicts oldest-to-newest.
+evr_pkg_key = functools.cmp_to_key(_evr_pkg_compare)

--- a/tests/test_rpm_version.py
+++ b/tests/test_rpm_version.py
@@ -1,0 +1,70 @@
+"""Tests for RPM EVR comparison and the only_latest_version filter."""
+
+from __future__ import annotations
+
+import pytest
+
+from chantal.plugins.rpm.filters import keep_only_latest_versions
+from chantal.plugins.rpm.version import evr_compare, rpmvercmp
+
+
+@pytest.mark.parametrize(
+    "a, b, expected",
+    [
+        ("1.0", "1.0", 0),
+        ("9.el9", "10.el9", -1),  # the headline bug: numeric segment length
+        ("1.0", "1.0.1", -1),
+        ("2.0", "2.0~rc1", 1),  # tilde sorts before the release
+        ("2.0~rc1", "2.0~rc2", -1),
+        ("1.0^20230101", "1.0", 1),  # caret sorts after the end
+        ("1.0", "1.0^x", -1),
+        ("1.a", "1.1", -1),  # numeric segment outranks alphabetic
+        ("1.0", "1.00", 0),  # leading zeros ignored
+        ("fc36", "fc37", -1),
+    ],
+)
+def test_rpmvercmp(a, b, expected):
+    assert rpmvercmp(a, b) == expected
+    assert rpmvercmp(b, a) == -expected
+
+
+def test_evr_compare_epoch_and_release():
+    # Epoch dominates everything.
+    assert evr_compare(1, "1.0", "1", 0, "9.0", "9") == 1
+    # Same epoch+version: release compared with rpmvercmp (10 > 9).
+    assert evr_compare(0, "1.0", "9.el9", 0, "1.0", "10.el9") == -1
+
+
+def test_only_latest_version_filter_uses_evr():
+    def pkg(version, release, epoch="0"):
+        return {
+            "name": "demo",
+            "arch": "x86_64",
+            "version": version,
+            "release": release,
+            "epoch": epoch,
+        }
+
+    packages = [
+        pkg("1.0", "9.el9"),
+        pkg("1.0", "10.el9"),  # newest by EVR (PEP 440/lexical would pick 9.el9)
+        pkg("1.0", "1.el9"),
+    ]
+    result = keep_only_latest_versions(packages, n=1)
+    assert len(result) == 1
+    assert result[0]["release"] == "10.el9"
+
+
+def test_only_latest_version_epoch_wins():
+    def pkg(version, epoch):
+        return {
+            "name": "demo",
+            "arch": "x86_64",
+            "version": version,
+            "release": "1",
+            "epoch": epoch,
+        }
+
+    # 2.0 looks newer, but epoch 1 on the 1.0 build wins.
+    result = keep_only_latest_versions([pkg("2.0", "0"), pkg("1.0", "1")], n=1)
+    assert result[0]["version"] == "1.0"


### PR DESCRIPTION
## Problem

`keep_only_latest_versions` (`rpm/filters.py`) sorted by `(epoch, packaging.version.parse(version), release_as_string)` — **PEP 440** for the version and a **plain lexical string** for the release. So release `9.el9` sorted **above** `10.el9`, and RPM `~`/`^` versions were mis-parsed. `only_latest_version` could therefore publish an **older** build as the latest. (apt/helm/apk version ordering was fixed earlier; RPM's filter is a separate path that was missed.)

## Fix

New `src/chantal/plugins/rpm/version.py` — a faithful port of rpm's `rpmvercmp` (segment-wise: `~` sorts before everything, `^` after the end, numeric segments outrank alphabetic, a longer numeric segment is greater) plus EVR comparison (epoch as int → version → release). The filter uses it.

## Tests

`rpmvercmp` edge cases (`10.el9 > 9.el9`, tilde, caret, numeric-vs-alpha, leading zeros), and the filter picking the EVR-newest / epoch winner — the headline case fails under the old PEP 440 + lexical-release code.