### PR TITLE
fix(publish): resolve charts/packages via stored pool_path; fix OCI/query filenames

### DIFF
--- a/src/chantal/plugins/apk/publisher.py
+++ b/src/chantal/plugins/apk/publisher.py
@@ -128,8 +128,11 @@ class ApkPublisher(PublisherPlugin):
 
         # Hardlink package files to target directory
         for pkg in packages:
-            pool_path = self.storage.get_absolute_pool_path(pkg.sha256, pkg.filename)
-            target_file = arch_path / pkg.filename
+            # Use the authoritative stored pool_path rather than reconstructing
+            # it from sha256+filename, and confine the published name to a bare
+            # basename so a crafted name/version can't escape the arch dir.
+            pool_path = self.storage.pool_path / pkg.pool_path
+            target_file = arch_path / Path(pkg.filename).name
 
             # Create hardlink
             if target_file.exists():

--- a/src/chantal/plugins/helm/publisher.py
+++ b/src/chantal/plugins/helm/publisher.py
@@ -125,7 +125,10 @@ class HelmPublisher(PublisherPlugin):
 
         # Hardlink chart files to target directory
         for chart in charts:
-            pool_path = self.storage.get_absolute_pool_path(chart.sha256, chart.filename)
+            # Use the authoritative stored pool_path, not a path reconstructed
+            # from sha256+filename (which diverges for oci:// / query-string
+            # filenames).
+            pool_path = self.storage.pool_path / chart.pool_path
             target_file = target_path / chart.filename
 
             # Create hardlink

--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -178,7 +178,7 @@ class HelmSyncer:
                 chart_name = f"{chart_entry['name']}-{chart_entry['version']}"
                 self.output.downloading(chart_name, 0, i, len(filtered_charts))
 
-                pool_path, sha256, size = self._download_chart(chart_url, config)
+                pool_path, sha256, size, filename = self._download_chart(chart_url, config)
 
                 # Verify the downloaded bytes against the digest advertised in
                 # index.yaml. A mismatch means the tarball was tampered with or
@@ -186,11 +186,11 @@ class HelmSyncer:
                 # stored or published).
                 if expected_digest and sha256 != expected_digest:
                     # The download already content-addressed the bytes into the
-                    # pool; remove the orphan if nothing else references it.
+                    # pool; remove the orphan if nothing else references it. Use
+                    # the actual pool path (the chart url basename is unreliable
+                    # for oci:// and signed/query URLs).
                     if not session.query(ContentItem).filter_by(sha256=sha256).first():
-                        self.storage.get_absolute_pool_path(sha256, Path(chart_url).name).unlink(
-                            missing_ok=True
-                        )
+                        (self.storage.pool_path / pool_path).unlink(missing_ok=True)
                     raise ValueError(
                         f"digest mismatch for {chart_name}: index.yaml advertises "
                         f"{expected_digest}, downloaded content is {sha256} (possible tampering)"
@@ -221,7 +221,7 @@ class HelmSyncer:
                     name=metadata.name,
                     version=metadata.version,
                     sha256=sha256,
-                    filename=Path(chart_url).name,
+                    filename=filename,
                     size_bytes=size,
                     pool_path=str(pool_path),
                     content_type="helm",
@@ -471,7 +471,7 @@ class HelmSyncer:
 
         return filtered
 
-    def _download_chart(self, url: str, config: RepositoryConfig) -> tuple[Path, str, int]:
+    def _download_chart(self, url: str, config: RepositoryConfig) -> tuple[Path, str, int, str]:
         """Download chart .tgz file to pool.
 
         Supports both HTTP/HTTPS and OCI registry URLs.
@@ -481,7 +481,9 @@ class HelmSyncer:
             config: Repository configuration (for credentials)
 
         Returns:
-            tuple: (pool_path, sha256, size_bytes)
+            tuple: (pool_path, sha256, size_bytes, filename) - filename is the
+            name the chart was actually pooled/published under (NOT the raw URL
+            basename, which is wrong for oci:// and signed/query URLs).
         """
         logger.debug(f"Downloading chart from {url}")
 
@@ -492,7 +494,9 @@ class HelmSyncer:
         else:
             return self._download_http_chart(url, config)
 
-    def _download_http_chart(self, url: str, config: RepositoryConfig) -> tuple[Path, str, int]:
+    def _download_http_chart(
+        self, url: str, config: RepositoryConfig
+    ) -> tuple[Path, str, int, str]:
         """Download chart from HTTP/HTTPS URL.
 
         Args:
@@ -500,7 +504,7 @@ class HelmSyncer:
             config: Repository configuration
 
         Returns:
-            tuple: (pool_path, sha256, size_bytes)
+            tuple: (pool_path, sha256, size_bytes, filename)
         """
         response = self.session.get(url, timeout=300, stream=True)
         response.raise_for_status()
@@ -511,7 +515,10 @@ class HelmSyncer:
                 tmp.write(chunk)
             tmp_path = Path(tmp.name)
 
-        filename = Path(url).name
+        # Strip any query string/fragment from the URL before taking the
+        # basename, so a signed/parameterized URL doesn't bake `?token=...` into
+        # the pooled and published filename (and the served index.yaml).
+        filename = Path(urlparse(url).path).name
 
         # Add to pool (this calculates SHA256, deduplicates, and moves file)
         sha256, pool_path, size = self.storage.add_package(tmp_path, filename)
@@ -521,9 +528,9 @@ class HelmSyncer:
 
         logger.debug(f"Stored chart in pool: {pool_path}")
 
-        return Path(pool_path), sha256, size
+        return Path(pool_path), sha256, size, filename
 
-    def _download_oci_chart(self, url: str, config: RepositoryConfig) -> tuple[Path, str, int]:
+    def _download_oci_chart(self, url: str, config: RepositoryConfig) -> tuple[Path, str, int, str]:
         """Download chart from OCI registry.
 
         Uses helm CLI to pull charts from OCI registries.
@@ -533,7 +540,8 @@ class HelmSyncer:
             config: Repository configuration (may contain registry credentials)
 
         Returns:
-            tuple: (pool_path, sha256, size_bytes)
+            tuple: (pool_path, sha256, size_bytes, filename) - filename is the
+            real ``<chart>-<version>.tgz`` helm produced, not the oci:// basename.
 
         Raises:
             RuntimeError: If helm binary not found or pull fails
@@ -602,4 +610,4 @@ class HelmSyncer:
 
             logger.debug(f"Stored OCI chart in pool: {pool_path}")
 
-            return Path(pool_path), sha256, size
+            return Path(pool_path), sha256, size, filename

--- a/tests/test_helm_pool_path.py
+++ b/tests/test_helm_pool_path.py
@@ -1,0 +1,84 @@
+"""Helm: publish resolves charts via the stored pool_path, and HTTP downloads
+strip query strings from the pooled/published filename.
+
+Regression for OCI charts: their ContentItem.filename (e.g. "chart:1.2.3", from
+the oci:// basename) does not match the name they were pooled under
+("chart-1.2.3.tgz"), so a publisher that rebuilds the pool path from
+sha256+filename can't find the file.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from chantal.core.config import RepositoryConfig, StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.models import Base, ContentItem, Repository
+from chantal.plugins.helm.publisher import HelmPublisher
+from chantal.plugins.helm.sync import HelmSyncer
+
+
+def _storage(tmp_path):
+    (tmp_path / "pool").mkdir()
+    return StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(tmp_path / "pool"),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+
+
+def test_publish_resolves_via_stored_pool_path(tmp_path):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    storage = _storage(tmp_path)
+    # Pool a chart under its real tarball name.
+    src = tmp_path / "src.tgz"
+    src.write_bytes(b"chart-bytes")
+    sha256, pool_rel, size = storage.add_package(src, "mychart-1.2.3.tgz")
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    repo = Repository(repo_id="oci", name="OCI", type="helm", feed="oci://x", mode="FILTERED")
+    session.add(repo)
+    session.commit()
+
+    # The ContentItem.filename is the (wrong) oci:// basename, but pool_path is
+    # authoritative.
+    chart = ContentItem(
+        content_type="helm",
+        name="mychart",
+        version="1.2.3",
+        sha256=sha256,
+        size_bytes=size,
+        pool_path=pool_rel,
+        filename="mychart:1.2.3",
+        content_metadata={"name": "mychart", "version": "1.2.3"},
+    )
+
+    config = RepositoryConfig(id="oci", name="OCI", type="helm", feed="oci://x")
+    target = tmp_path / "published"
+    publisher = HelmPublisher(storage=storage)
+
+    # Must not raise FileNotFoundError (the bug); the chart is published.
+    publisher._publish_charts([chart], target, config, session, repo)
+    assert (target / "mychart:1.2.3").read_bytes() == b"chart-bytes"
+
+
+def test_http_download_strips_query_string(tmp_path):
+    storage = _storage(tmp_path)
+    config = RepositoryConfig(id="h", name="H", type="helm", feed="http://x")
+    syncer = HelmSyncer(storage=storage, config=config)
+
+    resp = Mock()
+    resp.iter_content = lambda chunk_size=8192: [b"data"]
+    resp.raise_for_status = Mock()
+    syncer.session.get = Mock(return_value=resp)
+
+    _, _, _, filename = syncer._download_http_chart(
+        "https://charts.example.com/demo-1.0.0.tgz?token=abc&x=1", config
+    )
+    assert filename == "demo-1.0.0.tgz"  # no query string baked in

--- a/tests/test_helm_sync.py
+++ b/tests/test_helm_sync.py
@@ -480,7 +480,12 @@ class TestHelmIntegration:
             "apiVersion": "v1",
             "entries": {"demo": [{"name": "demo", "version": "0.1.0", "urls": ["demo-0.1.0.tgz"]}]},
         }
-        mock_download.return_value = (Path("ab/cd/demo-0.1.0.tgz"), "ab" * 32, 123, "demo-0.1.0.tgz")
+        mock_download.return_value = (
+            Path("ab/cd/demo-0.1.0.tgz"),
+            "ab" * 32,
+            123,
+            "demo-0.1.0.tgz",
+        )
 
         repo_config = RepositoryConfig(
             id="test-helm", name="Test", type="helm", feed="https://charts.example.com"

--- a/tests/test_helm_sync.py
+++ b/tests/test_helm_sync.py
@@ -480,7 +480,7 @@ class TestHelmIntegration:
             "apiVersion": "v1",
             "entries": {"demo": [{"name": "demo", "version": "0.1.0", "urls": ["demo-0.1.0.tgz"]}]},
         }
-        mock_download.return_value = (Path("ab/cd/demo-0.1.0.tgz"), "ab" * 32, 123)
+        mock_download.return_value = (Path("ab/cd/demo-0.1.0.tgz"), "ab" * 32, 123, "demo-0.1.0.tgz")
 
         repo_config = RepositoryConfig(
             id="test-helm", name="Test", type="helm", feed="https://charts.example.com"
@@ -516,7 +516,7 @@ class TestHelmIntegration:
             },
         }
         # Both "downloads" yield the same content (same sha256).
-        mock_download.return_value = (Path("ab/cd/demo.tgz"), "cd" * 32, 123)
+        mock_download.return_value = (Path("ab/cd/demo.tgz"), "cd" * 32, 123, "demo.tgz")
 
         repo_config = RepositoryConfig(
             id="test-helm", name="Test", type="helm", feed="https://charts.example.com"

--- a/tests/test_helm_sync_dedup.py
+++ b/tests/test_helm_sync_dedup.py
@@ -83,7 +83,9 @@ def test_digestless_duplicate_in_one_sync_dedup_autoflush_off(session):
     with (
         patch.object(syncer, "_fetch_index", return_value=index),
         patch.object(syncer, "_store_index_file", return_value="e" * 64),
-        patch.object(syncer, "_download_chart", return_value=("ab/cd/demo.tgz", "cd" * 32, 123)),
+        patch.object(
+            syncer, "_download_chart", return_value=("ab/cd/demo.tgz", "cd" * 32, 123, "demo.tgz")
+        ),
     ):
         stats = syncer.sync_repository(session, repo, config)
 

--- a/tests/test_helm_sync_verify.py
+++ b/tests/test_helm_sync_verify.py
@@ -78,7 +78,7 @@ def _syncer(storage, repo_config, *, downloaded_sha: str):
     # Avoid real HTTP for the index-store side effect.
     syncer._store_index_file = lambda *a, **k: None  # type: ignore[method-assign]
     # _download_chart returns (pool_path, sha256, size).
-    syncer._download_chart = lambda *a, **k: (Path("/pool/demo-0.1.0.tgz"), downloaded_sha, 123)  # type: ignore[method-assign]
+    syncer._download_chart = lambda *a, **k: (Path("/pool/demo-0.1.0.tgz"), downloaded_sha, 123, "demo-0.1.0.tgz")  # type: ignore[method-assign]
     return syncer
 
 


### PR DESCRIPTION
## Problem

The Helm and APK publishers reconstructed the pool path with `get_absolute_pool_path(sha256, filename)` instead of using the authoritative **stored `pool_path`** column. This breaks whenever `filename` differs from the basename the file was actually pooled under:

- **OCI charts (HIGH):** `ContentItem.filename` is set from the `oci://` URL basename — `Path('oci://reg/chart:1.2.3').name` = `'chart:1.2.3'` (no `.tgz`) — but the file was pooled as `chart-1.2.3.tgz`. The reconstructed path doesn't exist → publish aborts with `FileNotFoundError`. OCI mirroring was effectively broken.
- **Signed/query HTTP URLs:** `Path(url).name` baked `?token=...` into the pooled filename, the published filename, and the served `index.yaml`.

## Fix

- Publishers hardlink from the **stored `pool_path`** (`storage.pool_path / item.pool_path`).
- Helm `_download_chart` now returns the **real pooled filename** (helm's `chart-version.tgz` for OCI; the **query-stripped** basename for HTTP); sync stores that as `filename` and uses `pool_path` for the digest-mismatch orphan cleanup.
- APK publisher confines the published name to a bare basename.

## Tests

- Publishing a chart whose `filename` ≠ pooled basename (the OCI case) succeeds — `FileNotFoundError` without the fix.
- HTTP download strips the query string from the filename.