### PR TITLE
fix(db): widen size/byte columns to BigInteger

### DIFF
--- a/alembic/versions/20260627_2330_b1c2d3e4f5a6_bigint_size_columns.py
+++ b/alembic/versions/20260627_2330_b1c2d3e4f5a6_bigint_size_columns.py
@@ -1,0 +1,44 @@
+"""widen size/bytes columns to BigInteger
+
+Integer (int4) overflows on PostgreSQL for files larger than 2 GiB and for the
+multi-GiB aggregate counters of any real mirror. Widen them to BigInteger.
+
+Revision ID: b1c2d3e4f5a6
+Revises: e190d159daac
+Create Date: 2026-06-27 23:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | None = "e190d159daac"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (table, column) pairs that hold byte sizes/aggregates.
+_COLUMNS = [
+    ("content_items", "size_bytes"),
+    ("repository_files", "size_bytes"),
+    ("snapshots", "total_size_bytes"),
+    ("sync_history", "bytes_downloaded"),
+    ("view_snapshots", "total_size_bytes"),
+]
+
+
+def upgrade() -> None:
+    # batch mode so this also works on SQLite (which recreates the table).
+    for table, column in _COLUMNS:
+        with op.batch_alter_table(table) as batch:
+            batch.alter_column(column, type_=sa.BigInteger(), existing_nullable=False)
+
+
+def downgrade() -> None:
+    for table, column in _COLUMNS:
+        with op.batch_alter_table(table) as batch:
+            batch.alter_column(column, type_=sa.Integer(), existing_nullable=False)

--- a/src/chantal/db/models.py
+++ b/src/chantal/db/models.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     Column,
     DateTime,
@@ -167,7 +168,7 @@ class ContentItem(Base):
 
     # Content addressing (pool storage)
     sha256: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
-    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
     pool_path: Mapped[str] = mapped_column(
         Text, nullable=False
     )  # Relative path in pool (e.g., "ab/cd/abc123...rpm")
@@ -269,7 +270,7 @@ class Snapshot(Base):
 
     # Statistics (cached for performance)
     package_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
-    total_size_bytes: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_size_bytes: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
 
     # Relationships
     repository: Mapped[Repository] = relationship("Repository", back_populates="snapshots")
@@ -309,7 +310,7 @@ class SyncHistory(Base):
     packages_added: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     packages_removed: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     packages_updated: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
-    bytes_downloaded: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    bytes_downloaded: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
 
     # Snapshot created during this sync
     snapshot_id: Mapped[int | None] = mapped_column(
@@ -434,7 +435,7 @@ class ViewSnapshot(Base):
 
     # Statistics (cached for performance)
     package_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
-    total_size_bytes: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_size_bytes: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
 
     # Relationships
     view: Mapped[View] = relationship("View", back_populates="view_snapshots")
@@ -477,7 +478,7 @@ class RepositoryFile(Base):
     sha256: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     pool_path: Mapped[str] = mapped_column(Text, nullable=False)
     # Format: "files/ab/cd/abc123_updateinfo.xml.gz"
-    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
 
     # Publishing path (preserve exact upstream structure)
     original_path: Mapped[str] = mapped_column(Text, nullable=False)

--- a/tests/test_db_bigint.py
+++ b/tests/test_db_bigint.py
@@ -1,0 +1,56 @@
+"""Size/byte columns must be BigInteger so PostgreSQL doesn't overflow int4
+for >2 GiB files or multi-GiB aggregate counters."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import BigInteger, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from chantal.db.models import (
+    Base,
+    ContentItem,
+    Repository,
+    RepositoryFile,
+    Snapshot,
+    SyncHistory,
+    ViewSnapshot,
+)
+
+_OVER_INT4 = 5_000_000_000  # > 2_147_483_647 (int4 max)
+
+
+@pytest.mark.parametrize(
+    "model, column",
+    [
+        (ContentItem, "size_bytes"),
+        (RepositoryFile, "size_bytes"),
+        (Snapshot, "total_size_bytes"),
+        (SyncHistory, "bytes_downloaded"),
+        (ViewSnapshot, "total_size_bytes"),
+    ],
+)
+def test_size_columns_are_bigint(model, column):
+    assert isinstance(model.__table__.c[column].type, BigInteger)
+
+
+def test_large_size_round_trips():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    repo = Repository(repo_id="r", name="R", type="rpm", feed="http://x", mode="MIRROR")
+    item = ContentItem(
+        content_type="rpm",
+        name="huge",
+        version="1.0",
+        sha256="a" * 64,
+        size_bytes=_OVER_INT4,
+        pool_path="ab/cd/huge.rpm",
+        filename="huge.rpm",
+        content_metadata={},
+    )
+    session.add_all([repo, item])
+    session.commit()
+
+    assert session.query(ContentItem).one().size_bytes == _OVER_INT4


### PR DESCRIPTION
## Problem

`ContentItem.size_bytes`, `RepositoryFile.size_bytes`, `Snapshot`/`ViewSnapshot.total_size_bytes` and `SyncHistory.bytes_downloaded` were `Integer`, which maps to PostgreSQL **int4** (max ~2.1 GiB). A single **>2 GiB file** (install media, large container/Helm layers) overflows `size_bytes`, and the **aggregate counters** exceed 2 GiB for essentially every real mirror → `NumericValueOutOfRange`, aborting the sync/snapshot transaction. SQLite hides this (dynamic typing), so it only bit production Postgres (the shipped example config uses Postgres).

## Fix

Change the five columns to `BigInteger` and add a **batch-mode** alembic migration (works on both SQLite and PostgreSQL).

## Tests

Assert the column types are `BigInteger` and round-trip a >int4 value. The migration applies and downgrades cleanly (verified: columns become `BIGINT`).