### PR TITLE
fix(storage): atomic pool writes and cross-filesystem link fallback

### DIFF
--- a/src/chantal/core/storage.py
+++ b/src/chantal/core/storage.py
@@ -7,9 +7,11 @@ This module provides SHA256-based deduplication storage that works
 for all package types (RPM, DEB, etc.).
 """
 
+import errno
 import hashlib
 import os
 import shutil
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -160,22 +162,10 @@ class StorageManager:
                 raise ValueError(f"Pool file exists but checksum mismatch: {pool_path_abs}")
             return sha256, pool_path_rel, size_bytes
 
-        # Create directory structure
-        pool_path_abs.parent.mkdir(parents=True, exist_ok=True)
-
-        # Copy file to pool
-        shutil.copy2(source_path, pool_path_abs)
-
-        # Verify checksum if requested
-        if verify_checksum:
-            copied_sha256 = self.calculate_sha256(pool_path_abs)
-            if copied_sha256 != sha256:
-                # Checksum mismatch, remove bad file
-                pool_path_abs.unlink()
-                raise ValueError(
-                    f"Checksum verification failed after copy: "
-                    f"expected {sha256}, got {copied_sha256}"
-                )
+        # Copy into the pool atomically (temp file + rename), so a crash never
+        # leaves a truncated blob at the canonical path that would then fail the
+        # checksum on every later run.
+        self._atomic_store(source_path, pool_path_abs, sha256, verify_checksum)
 
         return sha256, pool_path_rel, size_bytes
 
@@ -221,29 +211,61 @@ class StorageManager:
                 raise ValueError(f"Pool file exists but checksum mismatch: {pool_path_abs}")
             return sha256, pool_path_rel, size_bytes
 
-        # Create directory structure
-        pool_path_abs.parent.mkdir(parents=True, exist_ok=True)
-
-        # Copy file to pool
-        shutil.copy2(source_path, pool_path_abs)
-
-        # Verify checksum if requested
-        if verify_checksum:
-            copied_sha256 = self.calculate_sha256(pool_path_abs)
-            if copied_sha256 != sha256:
-                # Checksum mismatch, remove bad file
-                pool_path_abs.unlink()
-                raise ValueError(
-                    f"Checksum verification failed after copy: "
-                    f"expected {sha256}, got {copied_sha256}"
-                )
+        # Copy into the pool atomically (temp file + rename) - see add_package.
+        self._atomic_store(source_path, pool_path_abs, sha256, verify_checksum)
 
         return sha256, pool_path_rel, size_bytes
+
+    def _atomic_store(
+        self, source_path: Path, pool_path_abs: Path, sha256: str, verify_checksum: bool
+    ) -> None:
+        """Copy ``source_path`` into the pool atomically.
+
+        Writes to a temp file in the destination directory, verifies it, then
+        ``os.replace``s it onto the canonical path. A crash or checksum failure
+        therefore never leaves a partial/corrupt blob at the final path.
+        """
+        pool_path_abs.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(dir=pool_path_abs.parent, suffix=".tmp")
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        try:
+            shutil.copy2(source_path, tmp_path)
+            if verify_checksum:
+                copied_sha256 = self.calculate_sha256(tmp_path)
+                if copied_sha256 != sha256:
+                    raise ValueError(
+                        f"Checksum verification failed after copy: "
+                        f"expected {sha256}, got {copied_sha256}"
+                    )
+            os.replace(tmp_path, pool_path_abs)
+        finally:
+            # No-op once the file has been renamed into place.
+            tmp_path.unlink(missing_ok=True)
+
+    def link_or_copy(self, source_path: Path, target_path: Path) -> None:
+        """Hardlink ``source_path`` to ``target_path``, copying across filesystems.
+
+        Publishing uses hardlinks (zero-copy) into the published tree, but the
+        pool and the published tree are often on different filesystems, where
+        ``os.link`` raises ``EXDEV``. Fall back to a copy in that case.
+        """
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if target_path.exists():
+            target_path.unlink()
+        try:
+            os.link(source_path, target_path)
+        except OSError as e:
+            if e.errno != errno.EXDEV:
+                raise
+            # Pool and target are on different filesystems: copy instead.
+            shutil.copy2(source_path, target_path)
 
     def create_hardlink(self, sha256: str, filename: str, target_path: Path) -> None:
         """Create hardlink from pool to target location.
 
-        This is used for publishing - creates zero-copy references to pool files.
+        This is used for publishing - creates zero-copy references to pool files
+        (falling back to a copy across filesystems).
 
         Args:
             sha256: SHA256 hash of package
@@ -258,15 +280,7 @@ class StorageManager:
         if not source_path.exists():
             raise FileNotFoundError(f"Source file not in pool: {source_path}")
 
-        # Create target directory if needed
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Remove target if already exists
-        if target_path.exists():
-            target_path.unlink()
-
-        # Create hardlink (use os.link for Python 3.9 compatibility)
-        os.link(source_path, target_path)
+        self.link_or_copy(source_path, target_path)
 
     def get_orphaned_files(self, session: Session) -> list[Path]:
         """Find files in pool that are not referenced in database.

--- a/src/chantal/plugins/apk/publisher.py
+++ b/src/chantal/plugins/apk/publisher.py
@@ -7,7 +7,6 @@ This module implements publishing for Alpine APK repositories.
 """
 
 import logging
-import os
 import shutil
 import tarfile
 import tempfile
@@ -137,7 +136,7 @@ class ApkPublisher(PublisherPlugin):
             # Create hardlink
             if target_file.exists():
                 target_file.unlink()
-            os.link(pool_path, target_file)
+            self.storage.link_or_copy(pool_path, target_file)
 
         # Publish metadata files (APKINDEX.tar.gz) from RepositoryFile or generate
         self._publish_metadata_files(
@@ -226,7 +225,7 @@ class ApkPublisher(PublisherPlugin):
             if target_file.exists():
                 target_file.unlink()
 
-            os.link(pool_path, target_file)
+            self.storage.link_or_copy(pool_path, target_file)
             logger.info(
                 f"Published APKINDEX.tar.gz from pool (mirror mode): {apkindex_file.sha256[:16]}..."
             )

--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -306,7 +306,6 @@ class AptPublisher(PublisherPlugin):
         ``Architecture: all`` package linked from several arch indices resolves
         to one pool file.
         """
-        import os
 
         for package in packages:
             pool_file_path = self.storage.pool_path / package.pool_path
@@ -324,7 +323,7 @@ class AptPublisher(PublisherPlugin):
             target_file_path.parent.mkdir(parents=True, exist_ok=True)
             if target_file_path.exists():
                 target_file_path.unlink()
-            os.link(pool_file_path, target_file_path)
+            self.storage.link_or_copy(pool_file_path, target_file_path)
 
     def _upstream_rel_path(self, package: ContentItem) -> str | None:
         """Repo-root-relative path a package occupied upstream (for verbatim mirror).
@@ -340,15 +339,9 @@ class AptPublisher(PublisherPlugin):
         upstream = meta.get("filename")
         return str(upstream) if upstream else None
 
-    @staticmethod
-    def _link_verbatim(src: Path, dest: Path) -> None:
-        """Hardlink ``src`` to ``dest`` (replacing any existing file)."""
-        import os
-
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        if dest.exists():
-            dest.unlink()
-        os.link(src, dest)
+    def _link_verbatim(self, src: Path, dest: Path) -> None:
+        """Hardlink ``src`` to ``dest`` (copying across filesystems)."""
+        self.storage.link_or_copy(src, dest)
 
     def _publish_verbatim(
         self,
@@ -655,14 +648,13 @@ class AptPublisher(PublisherPlugin):
         stays consistent while it is being updated. The emitted sha is recorded
         in ``emitted`` so stale entries can be pruned afterwards.
         """
-        import os
 
         by_hash_dir = file_path.parent / "by-hash" / "SHA256"
         by_hash_dir.mkdir(parents=True, exist_ok=True)
         target = by_hash_dir / sha256_hex
         if target.exists():
             target.unlink()
-        os.link(file_path, target)
+        self.storage.link_or_copy(file_path, target)
         emitted.setdefault(by_hash_dir, set()).add(sha256_hex)
 
     def _prune_by_hash(self, emitted: dict[Path, set[str]]) -> None:

--- a/src/chantal/plugins/helm/publisher.py
+++ b/src/chantal/plugins/helm/publisher.py
@@ -7,7 +7,6 @@ This module implements publishing for Helm chart repositories.
 """
 
 import logging
-import os
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
@@ -134,7 +133,7 @@ class HelmPublisher(PublisherPlugin):
             # Create hardlink
             if target_file.exists():
                 target_file.unlink()
-            os.link(pool_path, target_file)
+            self.storage.link_or_copy(pool_path, target_file)
 
         # Publish metadata files (index.yaml) from RepositoryFile or generate
         self._publish_metadata_files(

--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -570,9 +570,7 @@ class RpmPublisher(PublisherPlugin):
             if target_path.exists():
                 target_path.unlink()
 
-            import os
-
-            os.link(pool_file_path, target_path)
+            self.storage.link_or_copy(pool_file_path, target_path)
 
             # Add to published list
             published.append((repo_file.file_type, target_path))
@@ -588,7 +586,6 @@ class RpmPublisher(PublisherPlugin):
             kickstart_files: List of RepositoryFile with file_category="kickstart"
             target_path: Target directory for publishing
         """
-        import os
 
         for repo_file in kickstart_files:
             pool_file_path = self.storage.pool_path / repo_file.pool_path
@@ -622,7 +619,7 @@ class RpmPublisher(PublisherPlugin):
             if target_file_path.exists():
                 target_file_path.unlink()
 
-            os.link(pool_file_path, target_file_path)
+            self.storage.link_or_copy(pool_file_path, target_file_path)
 
             print(f"  ✓ Published {repo_file.file_type}: {repo_file.original_path}")
 

--- a/tests/test_storage_atomic.py
+++ b/tests/test_storage_atomic.py
@@ -1,0 +1,90 @@
+"""Storage: atomic pool writes and cross-filesystem link fallback."""
+
+from __future__ import annotations
+
+import errno
+import os
+
+import pytest
+
+import chantal.core.storage as storage_mod
+from chantal.core.config import StorageConfig
+from chantal.core.storage import StorageManager
+
+
+@pytest.fixture
+def storage(tmp_path):
+    (tmp_path / "pool").mkdir()
+    return StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path),
+            pool_path=str(tmp_path / "pool"),
+            published_path=str(tmp_path / "published"),
+        )
+    )
+
+
+def test_atomic_store_failure_leaves_no_partial(storage, tmp_path):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    dest = storage.pool_path / "ab" / "cd" / "ab_demo.rpm"
+
+    # A wrong expected sha makes the post-copy verification fail.
+    with pytest.raises(ValueError, match="Checksum verification failed"):
+        storage._atomic_store(src, dest, "0" * 64, verify_checksum=True)
+
+    assert not dest.exists()  # nothing left at the canonical path
+    # And no .tmp leftover in the destination dir.
+    assert not any(p.suffix == ".tmp" for p in dest.parent.iterdir())
+
+
+def test_atomic_store_success(storage, tmp_path):
+    import hashlib
+
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    dest = storage.pool_path / "ab" / "cd" / "ab_demo.rpm"
+
+    storage._atomic_store(src, dest, hashlib.sha256(b"payload").hexdigest(), verify_checksum=True)
+
+    assert dest.read_bytes() == b"payload"
+    assert not any(p.suffix == ".tmp" for p in dest.parent.iterdir())
+
+
+def test_link_or_copy_same_filesystem_hardlinks(storage, tmp_path):
+    src = storage.pool_path / "src.bin"
+    src.write_bytes(b"data")
+    target = tmp_path / "out" / "linked.bin"
+
+    storage.link_or_copy(src, target)
+
+    assert target.read_bytes() == b"data"
+    assert os.stat(src).st_ino == os.stat(target).st_ino  # a real hardlink
+
+
+def test_link_or_copy_falls_back_to_copy_on_exdev(storage, tmp_path, monkeypatch):
+    src = storage.pool_path / "src.bin"
+    src.write_bytes(b"data")
+    target = tmp_path / "out" / "copied.bin"
+
+    def fake_link(a, b):
+        raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+    monkeypatch.setattr(storage_mod.os, "link", fake_link)
+    storage.link_or_copy(src, target)
+
+    assert target.read_bytes() == b"data"
+    assert os.stat(src).st_ino != os.stat(target).st_ino  # a copy, not a link
+
+
+def test_link_or_copy_reraises_other_oserror(storage, tmp_path, monkeypatch):
+    src = storage.pool_path / "src.bin"
+    src.write_bytes(b"data")
+    target = tmp_path / "out" / "x.bin"
+
+    def fake_link(a, b):
+        raise OSError(errno.EACCES, "permission denied")
+
+    monkeypatch.setattr(storage_mod.os, "link", fake_link)
+    with pytest.raises(OSError, match="permission denied"):
+        storage.link_or_copy(src, target)


### PR DESCRIPTION
## Problems

1. **Non-atomic pool writes.** `add_package`/`add_repository_file` copied straight to the canonical pool path with `shutil.copy2`. A crash mid-copy leaves a **truncated blob** at `{sha}_{filename}`; on the next run the path exists, so the checksum is recomputed, mismatches, and raises `ValueError` — **permanently** blocking that file (orphan cleanup won't remove it either, since its sha is still referenced).
2. **`os.link` has no cross-filesystem fallback.** Publishing hardlinks pool blobs into the published tree with `os.link`, which raises `EXDEV` when the pool (e.g. `/var/lib/chantal`) and the published tree (e.g. `/var/www`) are on **different filesystems** — a common layout — so publishing failed entirely.

## Fix

- `_atomic_store`: copy into a temp file in the destination dir, verify the checksum, then `os.replace` it into place. A failure never leaves a partial at the final path.
- `link_or_copy`: hardlink, falling back to `shutil.copy2` on `EXDEV`; `create_hardlink` and all four publishers route through it.

## Tests

Atomic store leaves no partial/`.tmp` on a verification failure and succeeds cleanly; `link_or_copy` hardlinks on the same FS, copies on `EXDEV`, and re-raises other `OSError`s. Publish e2e (rpm/apt/helm/apk) still green.