### PR TITLE
fix(core): harden pool cleanup, redirect headers, cache key, gpg trust

### DIFF
--- a/src/chantal/cli/pool_commands.py
+++ b/src/chantal/cli/pool_commands.py
@@ -198,14 +198,33 @@ def create_pool_group(cli: click.Group) -> click.Group:
                 else:
                     click.echo("Removing database entries with missing files...")
 
-                # Find packages with missing files
-                packages = session.query(ContentItem).all()
-                missing_packages = []
-
-                for package in packages:
-                    pool_file = storage.pool_path / package.pool_path
-                    if not pool_file.exists():
+                # A wholly-absent pool usually means the storage volume is not
+                # mounted, not that every package was deleted - refuse rather than
+                # wipe the whole catalog (and corrupt every snapshot).
+                protected_count = 0
+                missing_packages: list[ContentItem] = []
+                if not storage.pool_path.exists():
+                    click.echo(
+                        "  Pool directory not found - is the storage volume "
+                        "mounted? Skipping missing-entry cleanup."
+                    )
+                else:
+                    # Find packages with missing files.
+                    packages = session.query(ContentItem).all()
+                    for package in packages:
+                        pool_file = storage.pool_path / package.pool_path
+                        if pool_file.exists():
+                            continue
+                        # Never delete a content item an immutable snapshot still
+                        # references - a missing pool file there is far more likely
+                        # a transiently-unavailable pool than a real deletion.
+                        if package.snapshots:
+                            protected_count += 1
+                            continue
                         missing_packages.append(package)
+
+                if protected_count:
+                    click.echo(f"  Kept {protected_count:,} entries still referenced by snapshots")
 
                 if not dry_run:
                     for package in missing_packages:

--- a/src/chantal/core/cache.py
+++ b/src/chantal/core/cache.py
@@ -9,12 +9,22 @@ to avoid repeated downloads of large metadata files.
 
 import hashlib
 import logging
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# A cache key is an upstream-supplied checksum (sha1/sha256/sha512 hex). Validate
+# it before interpolating it into a path so a crafted value like "../../x" cannot
+# traverse out of the cache dir (and feed an arbitrary file to pickle.loads).
+_HEX_KEY_RE = re.compile(r"^[0-9a-fA-F]{32,128}$")
+
+
+def _is_safe_key(checksum: str) -> bool:
+    return bool(checksum) and _HEX_KEY_RE.match(checksum) is not None
 
 
 @dataclass
@@ -68,7 +78,7 @@ class MetadataCache:
         Returns:
             Path to cached file, or None if not found/invalid
         """
-        if not self.enabled or not self.cache_path:
+        if not self.enabled or not self.cache_path or not _is_safe_key(checksum):
             return None
 
         # Build cache file path
@@ -170,7 +180,7 @@ class MetadataCache:
         Returns:
             Parsed data (list[dict] for packages), or None if not found/invalid
         """
-        if not self.enabled or not self.cache_path:
+        if not self.enabled or not self.cache_path or not _is_safe_key(checksum):
             return None
 
         # Build cache file path for parsed data

--- a/src/chantal/core/downloader.py
+++ b/src/chantal/core/downloader.py
@@ -12,7 +12,8 @@ import hashlib
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import quote, urlsplit, urlunsplit
+from typing import Any
+from urllib.parse import quote, urlparse, urlsplit, urlunsplit
 
 import requests
 
@@ -220,7 +221,29 @@ class RequestsBackend(DownloadBackend):
             # Custom HTTP headers
             if auth.headers:
                 session.headers.update(auth.headers)
-                print("Using custom HTTP headers")
+                # requests strips Authorization on a cross-host redirect but not
+                # arbitrary headers, so a custom secret header (e.g. X-API-Key)
+                # would be forwarded to whatever host an upstream redirects to.
+                # Strip our custom headers too when the redirect target's host
+                # differs from the original.
+                self._strip_custom_headers_on_redirect(session, set(auth.headers))
+
+    @staticmethod
+    def _strip_custom_headers_on_redirect(
+        session: requests.Session, custom_header_names: set[str]
+    ) -> None:
+        """Drop custom auth headers when a redirect crosses to a different host."""
+        original_rebuild_auth = session.rebuild_auth
+
+        def rebuild_auth(prepared_request: Any, response: Any) -> None:
+            original_rebuild_auth(prepared_request, response)
+            new_host = urlparse(prepared_request.url).hostname
+            old_host = urlparse(response.request.url).hostname
+            if new_host != old_host:
+                for name in custom_header_names:
+                    prepared_request.headers.pop(name, None)
+
+        session.rebuild_auth = rebuild_auth  # type: ignore[method-assign]
 
     def download_file(self, url: str, dest: Path, expected_sha256: str | None = None) -> Path:
         """Download a single file with retry and checksum verification.

--- a/src/chantal/core/gpg_verify.py
+++ b/src/chantal/core/gpg_verify.py
@@ -12,6 +12,7 @@ package header signatures).
 Wraps the ``gpg`` binary via ``python-gnupg`` (already a dependency).
 """
 
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -20,6 +21,8 @@ from types import TracebackType
 import gnupg
 
 from chantal.core.config import SignatureVerificationConfig
+
+logger = logging.getLogger(__name__)
 
 
 class GpgVerificationError(Exception):
@@ -53,6 +56,19 @@ class GpgVerifier:
         os.chmod(self._gnupg_home, 0o700)
         self.gpg = gnupg.GPG(gnupghome=str(self._gnupg_home))
         self.gpg.encoding = "utf-8"
+
+        # A signature is accepted if it's valid AND made by any key in the
+        # keyring. With the default temp keyring that's only the configured trust
+        # anchors. But a configured (possibly pre-existing/shared) gnupg_home may
+        # already contain other keys, so without fingerprint pinning any of them
+        # would be trusted. Warn so the operator pins via trusted_fingerprints.
+        if config.gnupg_home and not config.trusted_fingerprints:
+            logger.warning(
+                "Signature verification uses a configured gnupg_home (%s) without "
+                "trusted_fingerprints: any key already in that keyring will be "
+                "trusted. Set verify.trusted_fingerprints to pin the upstream key.",
+                config.gnupg_home,
+            )
 
     def __enter__(self) -> GpgVerifier:
         return self

--- a/tests/test_core_hardening.py
+++ b/tests/test_core_hardening.py
@@ -1,0 +1,125 @@
+"""Core hardening: cache key validation, redirect header stripping, gpg warning."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock
+
+from chantal.core.cache import MetadataCache
+from chantal.core.config import SignatureVerificationConfig
+from chantal.core.downloader import RequestsBackend
+from chantal.core.gpg_verify import GpgVerifier
+
+
+# --- cache: a non-hex key must not be used to read/deserialize a file ---------
+def test_cache_rejects_traversal_key(tmp_path):
+    cache = MetadataCache(cache_path=tmp_path / "cache", enabled=True)
+    # Plant a file the traversal would point at, to prove it is NOT read.
+    (tmp_path / "evil.xml.gz").write_bytes(b"x")
+    assert cache.get("../../evil") is None
+    assert cache.get_parsed("../../evil") is None
+    # A legit hex key simply misses (nothing cached) without raising.
+    assert cache.get("a" * 64) is None
+
+
+# --- downloader: custom auth headers stripped on a cross-host redirect ---------
+def test_custom_headers_stripped_on_cross_host_redirect():
+    import requests
+
+    session = requests.Session()
+    session.headers.update({"X-API-Key": "secret"})
+    RequestsBackend._strip_custom_headers_on_redirect(session, {"X-API-Key"})
+
+    def _req(url, headers):
+        r = Mock()
+        r.url = url
+        r.headers = headers
+        return r
+
+    # Cross-host redirect: header dropped.
+    prepared = _req("https://evil.example/x", {"X-API-Key": "secret"})
+    resp = Mock(request=_req("https://upstream.example/x", {}))
+    session.rebuild_auth(prepared, resp)
+    assert "X-API-Key" not in prepared.headers
+
+    # Same-host redirect: header kept.
+    prepared2 = _req("https://upstream.example/y", {"X-API-Key": "secret"})
+    resp2 = Mock(request=_req("https://upstream.example/x", {}))
+    session.rebuild_auth(prepared2, resp2)
+    assert prepared2.headers.get("X-API-Key") == "secret"
+
+
+# --- gpg: warn when a shared gnupg_home is used without fingerprint pinning ----
+def test_gpg_warns_on_shared_home_without_pinning(tmp_path, caplog):
+    home = tmp_path / "gpghome"
+    config = SignatureVerificationConfig(enabled=True, keys=["x"], gnupg_home=str(home))
+    with caplog.at_level(logging.WARNING):
+        GpgVerifier(config)
+    assert any("trusted_fingerprints" in r.message for r in caplog.records)
+
+
+def test_gpg_no_warning_with_default_keyring(tmp_path, caplog):
+    config = SignatureVerificationConfig(enabled=True, keys=["x"])  # temp keyring
+    with caplog.at_level(logging.WARNING):
+        GpgVerifier(config)
+    assert not any("trusted_fingerprints" in r.message for r in caplog.records)
+
+
+# --- pool cleanup: must not delete a snapshot-referenced item with missing file
+def test_pool_cleanup_keeps_snapshot_referenced_missing_file(tmp_path):
+    import yaml
+    from click.testing import CliRunner
+
+    from chantal.cli.main import cli
+    from chantal.db.connection import DatabaseManager
+    from chantal.db.models import Base, ContentItem, Repository, Snapshot
+
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    dbm = DatabaseManager(db_url)
+    Base.metadata.create_all(dbm.engine)
+    session = dbm.get_session()
+    repo = Repository(repo_id="r", name="R", type="rpm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+    # A content item whose pool file does NOT exist, referenced by a snapshot.
+    item = ContentItem(
+        content_type="rpm",
+        name="demo",
+        version="1.0",
+        sha256="a" * 64,
+        size_bytes=1,
+        pool_path="ab/cd/missing.rpm",
+        filename="missing.rpm",
+        content_metadata={},
+    )
+    snap = Snapshot(repository_id=repo.id, name="snap-1")
+    snap.content_items.append(item)
+    session.add(snap)
+    session.commit()
+    session.close()
+
+    pool = tmp_path / "data" / "pool"
+    pool.mkdir(parents=True)  # pool dir exists, but the file inside does not
+    config = {
+        "database": {"url": db_url},
+        "storage": {
+            "base_path": str(tmp_path / "data"),
+            "pool_path": str(pool),
+            "published_path": str(tmp_path / "published"),
+        },
+        "repositories": [],
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli, ["--config", str(config_path), "pool", "cleanup", "--missing", "--force"]
+    )
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+
+    session = dbm.get_session()
+    try:
+        # The snapshot-referenced item must survive (immutable snapshot intact).
+        assert session.query(ContentItem).count() == 1
+    finally:
+        session.close()


### PR DESCRIPTION
Four shared-layer hardening fixes the per-plugin re-review surfaced:

- **`pool cleanup --missing` corrupted snapshots.** It deleted every `ContentItem` whose pool file was absent — *including snapshot-referenced ones*. A transiently-unmounted pool volume (plus `--force` in cron) would wipe the catalog and silently mutate immutable snapshots. Now it **skips snapshot-referenced items** and **refuses entirely** when the pool directory itself is missing.
- **Custom auth headers leaked across cross-host redirects.** requests strips `Authorization` on a cross-host redirect but not arbitrary headers, so a configured custom secret (e.g. `X-API-Key`) was forwarded to whatever host an upstream 302'd to. Now stripped on a host change.
- **Cache key path traversal / pickle.** The metadata cache interpolated the upstream-supplied checksum into a path and fed the file to `pickle.loads` with no validation; a crafted key (`../../x`) could traverse out of the cache dir. `get()`/`get_parsed()` now reject non-hex keys.
- **GPG shared-keyring trust.** Warn when verification uses a configured (possibly shared/pre-existing) `gnupg_home` without `trusted_fingerprints` — there, any key already in the keyring would be trusted.

## Tests

Cache rejects a traversal key; custom header dropped on cross-host (kept same-host); gpg warns only with a shared home and no pinning; `pool cleanup --missing --force` keeps a snapshot-referenced item with a missing file (deletes it without the fix).