### PR TITLE
fix(rpm): drop sqlite _db metadata in mirror mode too

### DIFF
--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -631,20 +631,27 @@ class RpmPublisher(PublisherPlugin):
     ) -> list[tuple[str, Path]]:
         """Drop metadata variants chantal cannot republish correctly.
 
-        - ``*_zck`` (zchunk): always dropped - chantal cannot recompute the
-          de-chunked open-checksum, so a repomd entry for it would be invalid.
-        - ``*_db`` (sqlite primary/filelists/other): dropped in filtered mode,
-          where they would otherwise enumerate the full upstream package set
-          including filtered-out packages.
+        Both are dropped in *every* mode, because chantal regenerates primary.xml
+        with each package ``<location>`` rewritten to the republished ``Packages/``
+        layout in mirror mode too:
 
-        The dropped files are also unlinked from the published repodata so the
-        repository does not carry metadata the repomd no longer references.
+        - ``*_zck`` (zchunk): chantal cannot recompute the de-chunked
+          open-checksum, so a repomd entry for it would be invalid.
+        - ``*_db`` (sqlite primary/filelists/other): the sqlite still carries the
+          upstream package locations (and, in filtered mode, the full upstream
+          package set), so a sqlite-consuming client would resolve wrong/removed
+          download URLs. chantal cannot rewrite sqlite, so drop it.
+
+        dnf/yum fall back to ``primary.xml(.gz)``. The dropped files are unlinked
+        from the published repodata so the repository does not carry metadata the
+        repomd no longer references. (``mode`` is retained for signature parity
+        with the other filter helpers.)
         """
         kept: list[tuple[str, Path]] = []
         for file_type, file_path in published_metadata:
             is_zck = file_type.endswith("_zck") or file_path.name.endswith(".zck")
             is_db = file_type.endswith("_db")
-            if is_zck or (is_db and mode == RepositoryMode.FILTERED):
+            if is_zck or is_db:
                 file_path.unlink(missing_ok=True)
                 continue
             kept.append((file_type, file_path))

--- a/tests/test_rpm_filtered_secondary.py
+++ b/tests/test_rpm_filtered_secondary.py
@@ -188,15 +188,16 @@ def test_filtered_mode_drops_zck_and_db(publisher, tmp_path):
     assert not (repodata / "3333-primary.sqlite.bz2").exists()
 
 
-def test_mirror_mode_drops_zck_but_keeps_db(publisher, tmp_path):
-    """Mirror mode keeps the valid *_db (correct open-checksum) but still drops
-    *_zck, which chantal cannot re-checksum without zchunk de-chunking."""
+def test_mirror_mode_drops_zck_and_db(publisher, tmp_path):
+    """Mirror mode also drops *_zck and *_db: chantal regenerates primary.xml
+    with rewritten Packages/ locations even in mirror mode, so the kept sqlite
+    would point sqlite-consuming clients at stale upstream paths."""
     repodata = tmp_path / "repodata"
     repodata.mkdir()
     published = _published(repodata)
 
     kept = publisher._drop_unpublishable_metadata(published, repodata, "mirror")
 
-    assert sorted(ft for ft, _ in kept) == ["primary", "primary_db"]
+    assert [ft for ft, _ in kept] == ["primary"]
     assert not (repodata / "2222-primary.xml.zck").exists()
-    assert (repodata / "3333-primary.sqlite.bz2").exists()
+    assert not (repodata / "3333-primary.sqlite.bz2").exists()


### PR DESCRIPTION
## Problem

PR #118 dropped `*_db` (sqlite `primary`/`filelists`/`other`) only in **filtered** mode, keeping it in **mirror** mode on the assumption its open-checksum was correct. But chantal regenerates `primary.xml` with each package `<location>` rewritten to the republished `Packages/` layout in **mirror mode as well** (`_regenerate_primary` runs unconditionally), while the kept sqlite still carries the **upstream** package locations — so a sqlite-consuming client (yum / older dnf) resolves wrong download URLs and 404s.

## Fix

chantal cannot rewrite sqlite, so drop `*_db` in **every** mode (alongside `*_zck`); clients fall back to the regenerated `primary.xml(.gz)`.

## Tests

The mirror test now asserts `*_db` (and `*_zck`) are dropped.