### PR TITLE
fix(helm): drop a mirror index entry whose digest we don't have

### DIFF
--- a/src/chantal/plugins/helm/publisher.py
+++ b/src/chantal/plugins/helm/publisher.py
@@ -272,12 +272,19 @@ class HelmPublisher(PublisherPlugin):
                 if not isinstance(urls, list) or not urls:
                     continue
                 basename = Path(str(urls[0])).name
-                published_name = by_digest.get(normalize_digest(entry.get("digest")))
-                if published_name is None and basename in by_name:
+                entry_digest = normalize_digest(entry.get("digest"))
+                published_name = by_digest.get(entry_digest) if entry_digest else None
+                # The basename fallback is only safe for a digest-LESS entry. If
+                # the entry advertises a digest we don't have (e.g. upstream
+                # repackaged this version and only the old tarball is pooled),
+                # serving the same-named old file under the new digest would fail
+                # the client's digest verification - drop it instead.
+                if published_name is None and not entry_digest and basename in by_name:
                     published_name = basename
                 if published_name is None:
-                    # Not mirrored (filtered out / download failed) -> drop it so
-                    # the index never references a missing tarball.
+                    # Not mirrored (filtered out / download failed / a digest we
+                    # don't have) -> drop it so the index never references a
+                    # missing or digest-mismatched tarball.
                     continue
                 entry["urls"] = [published_name]
                 kept.append(entry)

--- a/tests/test_helm_sync.py
+++ b/tests/test_helm_sync.py
@@ -580,3 +580,79 @@ class TestHelmIntegration:
         # Matched by digest despite the differing basename -> rewritten to the
         # actually-published filename, not dropped.
         assert published["entries"]["demo"][0]["urls"] == ["demo-pooled-1.0.0.tgz"]
+
+    def test_mirror_index_drops_entry_whose_digest_is_not_published(self, temp_storage):
+        """An entry advertising a digest we don't have (upstream repackaged the
+        version; only the old tarball is pooled) must be dropped, not rewritten to
+        the old file under the new digest - that would fail client verification."""
+        index = {
+            "apiVersion": "v1",
+            "entries": {
+                "demo": [
+                    {
+                        "name": "demo",
+                        "version": "1.0.0",
+                        "digest": "sha256:" + "cd" * 32,  # the repackaged (new) digest
+                        "urls": ["https://up.example.com/demo-1.0.0.tgz"],
+                    }
+                ]
+            },
+            "generated": "2026-01-01T00:00:00Z",
+        }
+        index_path = temp_storage.pool_path / "index.yaml"
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(yaml.safe_dump(index), encoding="utf-8")
+
+        # We only have the OLD tarball (same name+version+basename, old digest).
+        old_chart = ContentItem(
+            content_type="helm",
+            name="demo",
+            version="1.0.0",
+            sha256="ab" * 32,  # != the index's "cd"*32
+            size_bytes=1,
+            pool_path="ab/ab/demo-1.0.0.tgz",
+            filename="demo-1.0.0.tgz",
+            content_metadata={},
+        )
+
+        publisher = HelmPublisher(storage=temp_storage)
+        target = temp_storage.published_path
+        target.mkdir(parents=True, exist_ok=True)
+        repo_config = RepositoryConfig(id="x", name="x", type="helm", feed="https://up.example.com")
+
+        publisher._publish_mirror_index(index_path, target, [old_chart], repo_config)
+
+        published = yaml.safe_load((target / "index.yaml").read_text())
+        # The version had no matching-digest tarball -> dropped entirely.
+        assert "demo" not in published.get("entries", {})
+
+    def test_mirror_index_keeps_digestless_entry_by_basename(self, temp_storage):
+        """A digest-LESS entry may still fall back to the basename match."""
+        index = {
+            "apiVersion": "v1",
+            "entries": {"demo": [{"name": "demo", "version": "1.0.0", "urls": ["demo-1.0.0.tgz"]}]},
+        }
+        index_path = temp_storage.pool_path / "index.yaml"
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(yaml.safe_dump(index), encoding="utf-8")
+
+        chart = ContentItem(
+            content_type="helm",
+            name="demo",
+            version="1.0.0",
+            sha256="ab" * 32,
+            size_bytes=1,
+            pool_path="ab/ab/demo-1.0.0.tgz",
+            filename="demo-1.0.0.tgz",
+            content_metadata={},
+        )
+
+        publisher = HelmPublisher(storage=temp_storage)
+        target = temp_storage.published_path
+        target.mkdir(parents=True, exist_ok=True)
+        repo_config = RepositoryConfig(id="x", name="x", type="helm", feed="https://up.example.com")
+
+        publisher._publish_mirror_index(index_path, target, [chart], repo_config)
+
+        published = yaml.safe_load((target / "index.yaml").read_text())
+        assert published["entries"]["demo"][0]["urls"] == ["demo-1.0.0.tgz"]


### PR DESCRIPTION
## Problem

`_publish_mirror_index` resolves each version by content digest, then falls back to the tarball **basename**. That fallback is wrong when the entry advertises a digest we did **not** publish — e.g. upstream repackaged the version (new digest) but only the **old** tarball is pooled. The basename matches the old file, so it rewrote the url to the old file while leaving the **new** digest untouched → the served `index.yaml` advertised the new digest over old bytes, and a client using `helm --verify` / digest pinning fails.

## Fix

Use the basename fallback **only for a digest-less entry**. An entry that carries a digest we don't have is **dropped**, so the index never advertises a digest/file mismatch. (Digest-matched and digest-less cases are unchanged.)

## Tests

An entry whose digest isn't published is dropped (it was served as the old file under the new digest without the fix); a digest-less entry still falls back to the basename match.