### PR TITLE
ci: select e2e by marker, real toolchain preflight, scoped mypy, coverage gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,12 +59,15 @@ jobs:
       - name: Run mypy (type checking)
         run: |
           echo "Running mypy type checker..."
-          mypy src/chantal/ --ignore-missing-imports
+          # Missing-import handling is scoped per-module in pyproject (only
+          # gnupg.* is ignored); don't blanket-suppress it on the CLI.
+          mypy src/chantal/
 
       - name: Run pytest (unit tests)
         run: |
           echo "Running pytest..."
-          pytest tests/ -v --tb=short -m "not e2e"
+          pytest tests/ -v --tb=short -m "not e2e" \
+            --cov=chantal --cov-report=term-missing --cov-fail-under=50
 
   e2e:
     name: E2E (${{ matrix.plugin }})
@@ -94,9 +97,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y rpm
 
       - name: Verify e2e toolchain is present
+        # Bare commands (not an echo wrapper) so a missing tool actually fails
+        # the step instead of echo swallowing the non-zero exit.
         run: |
-          echo "docker: $(docker --version)"
-          echo "gpg: $(gpg --version | head -1)"
+          docker --version
+          gpg --version | head -1
 
       - name: Run end-to-end sync->publish test
         env:
@@ -106,6 +111,8 @@ jobs:
           # toolchain regression can't turn the real-client e2e tests green.
           CHANTAL_REQUIRE_DOCKER: '1'
           CHANTAL_REQUIRE_GPG: '1'
+        # Select by marker, not -k: a substring match (e.g. -k apt matching
+        # test_deb_..._real_apt by coincidence) silently over/under-selects.
         run: |
           echo "Running E2E sync->publish for ${{ matrix.plugin }}..."
-          pytest tests/e2e -v -s -m e2e -k ${{ matrix.plugin }}
+          pytest tests/e2e -v -s -m "e2e and ${{ matrix.plugin }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,10 @@ python_classes = "Test*"
 python_functions = "test_*"
 markers = [
     "e2e: end-to-end sync->publish tests (build a fixture repo, sync, publish)",
+    "rpm: RPM-plugin e2e tests (selected by the rpm CI leg)",
+    "apt: APT/DEB-plugin e2e tests (selected by the apt CI leg)",
+    "helm: Helm-plugin e2e tests (selected by the helm CI leg)",
+    "apk: Alpine APK-plugin e2e tests (selected by the apk CI leg)",
 ]
 
 # Coverage configuration

--- a/tests/e2e/test_apk_e2e.py
+++ b/tests/e2e/test_apk_e2e.py
@@ -11,7 +11,7 @@ import pytest
 
 from chantal.plugins.apk.checksum import compute_apk_control_checksum
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apk]
 
 BRANCH = "v3.19"
 REPO = "main"

--- a/tests/e2e/test_apk_real_client_e2e.py
+++ b/tests/e2e/test_apk_real_client_e2e.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apk]
 
 _HAVE_DOCKER = shutil.which("docker") is not None
 _IMAGE = "alpine:3.20"

--- a/tests/e2e/test_apt_arch_all_e2e.py
+++ b/tests/e2e/test_apt_arch_all_e2e.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_byhash_e2e.py
+++ b/tests/e2e/test_apt_byhash_e2e.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_contents_e2e.py
+++ b/tests/e2e/test_apt_contents_e2e.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_e2e.py
+++ b/tests/e2e/test_apt_e2e.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_features_real_client_e2e.py
+++ b/tests/e2e/test_apt_features_real_client_e2e.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 _HAVE_DOCKER = shutil.which("docker") is not None
 _HAVE_GPG = shutil.which("gpg") is not None

--- a/tests/e2e/test_apt_mirror_verbatim_e2e.py
+++ b/tests/e2e/test_apt_mirror_verbatim_e2e.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_pool_layout_e2e.py
+++ b/tests/e2e/test_apt_pool_layout_e2e.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_real_client_e2e.py
+++ b/tests/e2e/test_apt_real_client_e2e.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 _HAVE_DOCKER = shutil.which("docker") is not None
 _IMAGE = "debian:bookworm"

--- a/tests/e2e/test_apt_release_fields_e2e.py
+++ b/tests/e2e/test_apt_release_fields_e2e.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_sources_e2e.py
+++ b/tests/e2e/test_apt_sources_e2e.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_translation_e2e.py
+++ b/tests/e2e/test_apt_translation_e2e.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 DIST = "jammy"
 COMP = "main"

--- a/tests/e2e/test_apt_verify_e2e.py
+++ b/tests/e2e/test_apt_verify_e2e.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 _HAVE_GPG = shutil.which("gpg") is not None or shutil.which("gpg2") is not None
 

--- a/tests/e2e/test_deb_real_client_e2e.py
+++ b/tests/e2e/test_deb_real_client_e2e.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.apt]
 
 _HAVE_DOCKER = shutil.which("docker") is not None
 _IMAGE = "debian:bookworm"

--- a/tests/e2e/test_helm_e2e.py
+++ b/tests/e2e/test_helm_e2e.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.helm]
 
 
 def _build_helm_upstream(root: Path) -> None:

--- a/tests/e2e/test_helm_features_real_client_e2e.py
+++ b/tests/e2e/test_helm_features_real_client_e2e.py
@@ -30,7 +30,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.helm]
 
 _HAVE_DOCKER = shutil.which("docker") is not None
 _IMAGE = "alpine/helm"

--- a/tests/e2e/test_helm_real_client_e2e.py
+++ b/tests/e2e/test_helm_real_client_e2e.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.helm]
 
 _HAVE_DOCKER = shutil.which("docker") is not None
 _IMAGE = "alpine/helm"

--- a/tests/e2e/test_rpm_client_key_e2e.py
+++ b/tests/e2e/test_rpm_client_key_e2e.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.rpm]
 
 _UPSTREAM_KEY = (
     "-----BEGIN PGP PUBLIC KEY BLOCK-----\n"

--- a/tests/e2e/test_rpm_e2e.py
+++ b/tests/e2e/test_rpm_e2e.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.rpm]
 
 
 def _build_rpm_upstream(root: Path, revision: int = 1) -> None:

--- a/tests/e2e/test_rpm_features_real_client_e2e.py
+++ b/tests/e2e/test_rpm_features_real_client_e2e.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.rpm]
 
 _HAVE_DOCKER = shutil.which("docker") is not None
 _HAVE_GPG = shutil.which("gpg") is not None or shutil.which("gpg2") is not None

--- a/tests/e2e/test_rpm_modules_e2e.py
+++ b/tests/e2e/test_rpm_modules_e2e.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.rpm]
 
 
 def _build_rpm_upstream_with_modules(root: Path) -> None:

--- a/tests/e2e/test_rpm_real_client_e2e.py
+++ b/tests/e2e/test_rpm_real_client_e2e.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.rpm]
 
 _HAVE_DOCKER = shutil.which("docker") is not None
 _IMAGE = "almalinux:9"

--- a/tests/e2e/test_rpm_sha512_e2e.py
+++ b/tests/e2e/test_rpm_sha512_e2e.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.rpm]
 
 
 def _build_sha512_rpm_upstream(root: Path, *, corrupt_package_checksum: bool = False) -> None:

--- a/tests/e2e/test_rpm_verify_e2e.py
+++ b/tests/e2e/test_rpm_verify_e2e.py
@@ -17,7 +17,7 @@ import subprocess
 
 import pytest
 
-pytestmark = pytest.mark.e2e
+pytestmark = [pytest.mark.e2e, pytest.mark.rpm]
 
 _HAVE_RPM = bool(
     shutil.which("rpmbuild")


### PR DESCRIPTION
Test/CI gaps the re-review surfaced:

- **e2e selected by `-k <plugin>` (substring match).** The deb real-client test (`test_deb_real_client_e2e.py`) was selected by the `apt` leg **only** because `apt` is a substring of its function name `..._real_apt` — renaming it would silently drop it from CI with the leg still green. Every e2e module now carries a per-plugin marker (`rpm`/`apt`/`helm`/`apk`) and the matrix selects with `-m "e2e and <plugin>"`. Verified: total e2e (57) == sum of the four legs (16+31+6+4).
- **Toolchain preflight was an `echo`.** `echo "$(docker --version)"` exits 0 even if docker is absent, so the 'preflight' never failed. Now bare commands.
- **`mypy --ignore-missing-imports` overrode pyproject.** Dropped, so the per-module config (only `gnupg.*` ignored) governs. (Passes clean without the flag.)
- **No coverage measurement.** Added `--cov-fail-under=50` to the unit step (current unit coverage ~56%).

This PR's own CI exercises all four changes.