### PR TITLE
docs: correct inaccuracies surfaced by the documentation review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, thank you for considering contributing to Chantal!
 
 ## Project Status
 
-**✅ Chantal is an actively maintained, released project (v1.4.0, available on [PyPI](https://pypi.org/project/chantal/)).**
+**✅ Chantal is an actively maintained, released project (available on [PyPI](https://pypi.org/project/chantal/)).**
 
 Contributions are welcome - bug reports, feature requests, documentation improvements, and pull requests.
 
@@ -100,11 +100,20 @@ ruff check --fix src/  # Auto-fix issues
 #### 4. Testing (pytest)
 
 ```bash
-pytest tests/ -v
+# Unit tests (fast, no external tools)
+pytest tests/ -v -m "not e2e"
+
+# End-to-end tests (build a fixture repo, sync, publish, and consume with a
+# real client). These require docker and gpg; without them the docker/gpg-gated
+# tests skip. Select a single plugin's e2e with its marker:
+pytest tests/e2e -v -m "e2e and rpm"   # or apt / helm / apk
 ```
 
 - Write tests for new features
 - All tests must pass
+- CI sets `CHANTAL_REQUIRE_DOCKER=1` / `CHANTAL_REQUIRE_GPG=1` so a missing tool
+  **fails** (rather than silently skips) the e2e suite — install docker and gpg
+  to run the real-client tests locally.
 
 ### Common Type Patterns
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -345,16 +345,24 @@ See [Plugin System](plugin-system.md) for details.
 ## Security Considerations
 
 1. **Certificate validation:** Always verify SSL certificates
-2. **Checksum verification:** All packages verified via SHA256
-3. **Database injection:** SQLAlchemy prevents SQL injection
-4. **Path traversal:** All paths validated and normalized
-5. **Permissions:** Follow principle of least privilege
+2. **Checksum verification:** All packages verified via SHA256 (integrity)
+3. **Signature verification (authenticity):** GPG/OpenPGP verification of upstream
+   metadata (RPM `repomd.xml.asc`, APT `InRelease`/`Release.gpg`, RPM package
+   header signatures) is implemented but **OFF by default** — enable it under the
+   repository's `verify:` block. Until enabled, a mirror is authenticated only by
+   checksum, so a compromised or MITM'd upstream that serves a self-consistent
+   metadata set is trusted. APT additionally rejects an expired (`Valid-Until` in
+   the past) Release when verification is enabled.
+4. **Database injection:** SQLAlchemy prevents SQL injection
+5. **Path traversal:** All paths validated and normalized
+6. **Permissions:** Follow principle of least privilege
 
 ## Future Enhancements
 
 1. **Parallel downloads:** Download multiple packages concurrently
-2. **Delta syncs:** Only download package deltas
-3. **Signature verification:** GPG signature checking
-4. **Compression:** Compress pool storage
-5. **Web UI:** Read-only web interface
-6. **REST API:** HTTP API for automation
+2. **Compression:** Compress pool storage
+3. **Web UI:** Read-only web interface
+4. **REST API:** HTTP API for automation
+
+> Delta RPMs (drpm/prestodelta) are **not planned** — see the RPM plugin
+> limitations.

--- a/docs/configuration/filters.md
+++ b/docs/configuration/filters.md
@@ -444,8 +444,7 @@ chantal repo sync --repo-id epel9-webservers --dry-run
 See which packages are filtered and why:
 
 ```bash
-# Future feature
-chantal repo sync --repo-id epel9-webservers --verbose
+chantal repo sync --repo-id epel9-webservers -v   # --verbose
 ```
 
 ## Best Practices

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -312,17 +312,22 @@ Error: Configuration validation failed:
 
 ## Environment Variables
 
-Chantal supports environment variable interpolation:
+The config file is parsed as plain YAML — Chantal does **not** expand `${VAR}`
+references inside it, so a value like `url: ${DATABASE_URL}` is stored literally.
+Supply secrets through the values directly (e.g. from a templating step in your
+deployment), or point Chantal at a different config file per environment with
+`--config` / `CHANTAL_CONFIG`.
 
-```yaml
-database:
-  url: ${DATABASE_URL:-sqlite:///chantal.db}
+## Strict configuration validation
 
-storage:
-  base_path: ${CHANTAL_STORAGE_PATH:-/var/lib/chantal}
+Unknown keys are **rejected**, including in nested sections, so a typo fails the
+load loudly instead of being silently ignored:
+
+```text
+Error: Configuration validation error:
+repositories.0.schedule.enabledd
+  Extra inputs are not permitted
 ```
-
-**Note:** This feature may be added in a future version.
 
 ## Best Practices
 

--- a/docs/plugins/apt-plugin.md
+++ b/docs/plugins/apt-plugin.md
@@ -4,7 +4,7 @@ The APT plugin provides support for Debian/Ubuntu APT repositories.
 
 ## Overview
 
-**Status:** ✅ Available (v0.2.0)
+**Status:** ✅ Available
 
 The APT plugin consists of:
 - **AptSyncPlugin** - Syncs packages from upstream APT repositories
@@ -396,7 +396,7 @@ repositories:
 
 ### FILTERED Mode
 
-**Status:** ✅ Available (v0.2.0) - without GPG signing
+**Status:** ✅ Available (regenerated metadata is GPG-signed when a key is configured)
 
 Regenerates metadata for filtered package sets based on configured filters.
 
@@ -631,6 +631,10 @@ without their own). Notes specific to APT:
 - A failed check under `on_invalid_signature: fail` (or a missing signature
   under `on_missing_signature: fail`) aborts the sync before any metadata is
   trusted or any package is downloaded.
+- **Freshness (`Valid-Until`):** when verification is enabled, an otherwise-valid
+  Release whose `Valid-Until` is in the past is rejected (applying the
+  `on_invalid_signature` policy) — a valid signature proves authenticity, not
+  freshness, so this blocks a replayed/rolled-back Release.
 
 > **Note:** this verifies the *upstream* signature on sync. Re-signing the
 > regenerated metadata for *your* clients (filtered mode) is the separate `gpg`

--- a/docs/plugins/rpm-plugin.md
+++ b/docs/plugins/rpm-plugin.md
@@ -43,8 +43,8 @@ The RPM plugin consists of:
 - ✅ Compression level tests
 - ✅ Large data handling tests
 
-**Planned:**
-- 🚧 Delta RPMs
+**Not supported:**
+- ❌ Delta RPMs (drpm / prestodelta) — see [Limitations](#limitations)
 
 **Note:** RPM packages are served unmodified and keep their upstream signatures
 (verified client-side with `gpgcheck=1`). Chantal signs only the repository
@@ -146,10 +146,13 @@ repositories:
 ```
 
 **Behavior:**
-- ✅ All metadata files downloaded: updateinfo, filelists, other, comps, modules, etc.
-- ✅ Metadata published unchanged (no filtering)
-- ✅ Perfect 1:1 mirror of upstream repository
-- ✅ Ideal for: Complete repository mirrors, compliance requirements
+- ✅ All package files mirrored; `primary`/`filelists`/`other`/`updateinfo`/`comps`/`modules` published
+- ⚠️ `primary.xml` and `repomd.xml` are **regenerated** (package `<location>`s are
+  rewritten to the republished `Packages/` layout), so the published repo is not
+  byte-for-byte identical to upstream
+- ⚠️ zchunk (`*_zck`) and sqlite (`*_db`) metadata variants are **dropped** — see
+  [Limitations](#limitations); clients fall back to `primary.xml.gz`
+- ✅ Ideal for: complete repository mirrors, compliance requirements
 
 **Metadata types mirrored:**
 - `primary` - Package metadata (name, version, arch, dependencies)
@@ -471,10 +474,9 @@ Zero-copy publishing using hardlinks.
 #### 4. Publish Metadata
 
 **Mirror Mode:**
-- Copy ALL metadata files from pool to `repodata/`
-- Hardlinks: `pool/files/{sha256}.xml.gz` → `repodata/{type}.xml.gz`
-- Copy `repomd.xml` unchanged
-- Perfect 1:1 mirror
+- Hardlink metadata files from pool to `repodata/` (zchunk/sqlite variants dropped)
+- Regenerate `primary.xml` and `repomd.xml` (locations rewritten, repomd re-signed
+  when a GPG key is configured)
 
 **Filtered Mode:**
 - Generate `primary.xml` with filtered package list
@@ -869,9 +871,19 @@ Warning: Filtered out all packages, 0 remaining
 - Verify architecture filter includes needed architectures
 - Review `only_latest_version` setting
 
-## Future Enhancements
+## Limitations
 
-- **Delta RPMs** - Download only package deltas (drpm)
+- **No Delta RPMs (drpm / prestodelta).** Not supported and not planned: for an
+  offline mirror the bandwidth saving (client↔mirror) is marginal, and chantal
+  downloads full RPMs anyway. The `prestodelta` metadata and `.drpm` files are not
+  mirrored.
+- **zchunk (`*_zck`) is dropped in every mode.** chantal cannot recompute a
+  zchunk's de-chunked open-checksum without a zchunk library, so it cannot emit a
+  valid repomd entry for it. dnf falls back to `primary.xml.gz`.
+- **sqlite (`*_db`) is dropped in every mode.** chantal regenerates `primary.xml`
+  with rewritten package locations but cannot rewrite the sqlite databases, whose
+  embedded locations would then be stale. Old yum clients fall back to
+  `primary.xml.gz`.
 
 (Modular repositories, GPG package-signature verification, comps, updateinfo, and
 filelists are already implemented — see the sections above.)


### PR DESCRIPTION
Documentation fixes where the docs contradicted the actual behavior:

- **Config:** removed the **false `${VAR}` interpolation** example (the loader does plain YAML — no env expansion; a user copying it would store the literal), and documented **strict validation** (unknown keys, including nested, are now rejected).
- **Architecture:** moved **signature verification** out of "future enhancements" into Security, with an explicit note it is **OFF by default** (mirrors authenticated only by checksum until enabled) + APT **Valid-Until** enforcement; dropped delta syncs from the roadmap.
- **RPM plugin:** corrected the **"perfect 1:1 mirror"** claims (`primary`/`repomd` are regenerated; **zchunk `*_zck` and sqlite `*_db` are dropped**), marked **Delta RPMs** as not supported, and added a **Limitations** section.
- **APT plugin:** documented the **Valid-Until** freshness check; removed stale `v0.2.0` status tags and the "without GPG signing" note.
- **CONTRIBUTING:** dropped the hardcoded `v1.4.0`; documented the e2e **docker/gpg** requirement (`CHANTAL_REQUIRE_DOCKER/GPG`) and per-plugin marker selection.
- **filters:** `--verbose` is implemented, not a future feature.

(Note: the RPM `only_latest_version` doc that claimed RPM EVR semantics is now accurate after the EVR comparator fix — no doc change needed there.)