### PR TITLE
test: Re-sync idempotency e2e + fix APT duplicate Packages stanza

### DIFF
--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -259,7 +259,30 @@ class AptPublisher(PublisherPlugin):
             for arch in targets:
                 grouped.setdefault((component, arch), []).append(package)
 
-        return grouped
+        return {key: self._dedup_by_filename(pkgs) for key, pkgs in grouped.items()}
+
+    @staticmethod
+    def _dedup_by_filename(packages: list[ContentItem]) -> list[ContentItem]:
+        """Keep one package per published filename (the highest-id one).
+
+        Two ContentItems can share a published ``.deb`` filename when upstream
+        repackages a package (same name+version+arch, new bytes). They hardlink
+        to a single file on disk (last link wins), so emitting a stanza for each
+        yields a Packages index whose extra stanza's SHA256 cannot match the
+        published file. Keep the most recently synced (highest id) so the index
+        matches the file that wins on disk.
+        """
+        by_filename: dict[object, ContentItem] = {}
+        for pkg in packages:
+            # A package without a filename has no on-disk collision to resolve;
+            # key it by identity so distinct ones are never merged together.
+            key: object = Path(pkg.filename).name if pkg.filename else id(pkg)
+            existing = by_filename.get(key)
+            if existing is None or (pkg.id or 0) > (existing.id or 0):
+                by_filename[key] = pkg
+        # Preserve input order for stable, diff-friendly index output.
+        kept = {id(p) for p in by_filename.values()}
+        return [p for p in packages if id(p) in kept]
 
     @staticmethod
     def _safe_name(name: str) -> str:

--- a/tests/e2e/test_apk_e2e.py
+++ b/tests/e2e/test_apk_e2e.py
@@ -31,19 +31,23 @@ def _gz_tar(name: str, content: bytes) -> bytes:
     return out.getvalue()
 
 
-def _build_minimal_apk() -> bytes:
-    """A valid APKv2 archive: concatenated control + data gzip streams."""
+def _build_minimal_apk(revision: int = 1) -> bytes:
+    """A valid APKv2 archive: concatenated control + data gzip streams.
+
+    ``revision`` is woven into the data segment so the archive bytes (and thus
+    the control checksum) differ between revisions, modelling a repackaged .apk.
+    """
     control = _gz_tar(".PKGINFO", b"pkgname = demo\npkgver = 1.0-r0\n")
-    data = _gz_tar("usr/share/demo/README", b"hello-from-demo\n")
+    data = _gz_tar("usr/share/demo/README", f"hello-from-demo rev{revision}\n".encode())
     return control + data
 
 
-def _build_apk_upstream(root: Path) -> None:
+def _build_apk_upstream(root: Path, revision: int = 1) -> None:
     """Create a minimal Alpine repo (APKINDEX.tar.gz + one .apk)."""
     arch_dir = root / BRANCH / REPO / ARCH
     arch_dir.mkdir(parents=True, exist_ok=True)
 
-    apk = _build_minimal_apk()
+    apk = _build_minimal_apk(revision)
     (arch_dir / "demo-1.0-r0.apk").write_bytes(apk)
     # APK checksum field: Q1 + base64(SHA1 of the control segment).
     q1 = compute_apk_control_checksum(apk)
@@ -98,3 +102,83 @@ def test_apk_sync_and_publish(tmp_path, serve, chantal_env):
     # APKINDEX.tar.gz was regenerated and the .apk was published.
     assert list(target.rglob("APKINDEX.tar.gz")), "published APKINDEX not found"
     assert list(target.rglob("demo-1.0-r0.apk")), "published .apk not found"
+
+
+def _apkindex_demo_count(apkindex_path: Path) -> int:
+    """Return how many demo package stanzas the published APKINDEX contains."""
+    buf = io.BytesIO(apkindex_path.read_bytes())
+    with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+        member = tar.extractfile("APKINDEX")
+        assert member is not None
+        text = member.read().decode()
+    return sum(1 for line in text.splitlines() if line == "P:demo")
+
+
+def test_apk_mirror_sync_and_publish(tmp_path, serve, chantal_env):
+    """Mirror mode must publish the upstream .apk and a usable APKINDEX."""
+    upstream = tmp_path / "upstream"
+    _build_apk_upstream(upstream)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apk",
+            "name": "Demo APK",
+            "type": "apk",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "mirror",
+            "apk": {
+                "branch": BRANCH,
+                "repository": REPO,
+                "architecture": ARCH,
+            },
+        }
+    )
+
+    target = chantal_env.sync_and_publish("demo-apk")
+
+    indexes = list(target.rglob("APKINDEX.tar.gz"))
+    assert indexes, "published APKINDEX not found"
+    assert list(target.rglob("demo-1.0-r0.apk")), "published .apk not found"
+    assert _apkindex_demo_count(indexes[0]) == 1
+
+
+def test_apk_resync_does_not_duplicate_package(tmp_path, serve, chantal_env):
+    """Re-syncing a repackaged demo 1.0-r0 must leave exactly one index entry.
+
+    When upstream repackages the .apk (same version, new control checksum), the
+    stale ContentItem must not stay associated and get republished: the
+    regenerated APKINDEX would list demo twice and the pool would grow unbounded.
+    """
+    upstream = tmp_path / "upstream"
+    _build_apk_upstream(upstream, revision=1)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apk",
+            "name": "Demo APK",
+            "type": "apk",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apk": {
+                "branch": BRANCH,
+                "repository": REPO,
+                "architecture": ARCH,
+            },
+        }
+    )
+
+    chantal_env.sync_and_publish("demo-apk")
+
+    # Upstream repackages demo 1.0-r0 with new bytes (fresh control checksum).
+    _build_apk_upstream(upstream, revision=2)
+    target = chantal_env.sync_and_publish("demo-apk")
+
+    indexes = list(target.rglob("APKINDEX.tar.gz"))
+    assert indexes, "published APKINDEX not found"
+    assert _apkindex_demo_count(indexes[0]) == 1, "re-sync left duplicate demo stanzas in APKINDEX"
+    apks = list(target.rglob("demo-1.0-r0.apk"))
+    assert len(apks) == 1, f"re-sync published duplicate .apk files: {apks}"

--- a/tests/e2e/test_apt_e2e.py
+++ b/tests/e2e/test_apt_e2e.py
@@ -15,12 +15,17 @@ COMP = "main"
 ARCH = "amd64"
 
 
-def _build_apt_upstream(root: Path) -> None:
-    """Create a minimal APT repo (Release + Packages(.gz) + one .deb)."""
+def _build_apt_upstream(root: Path, revision: int = 1) -> None:
+    """Create a minimal APT repo (Release + Packages(.gz) + one .deb).
+
+    ``revision`` is woven into the .deb payload (and thus its SHA256) so calling
+    this twice with different revisions models an upstream that repackaged demo
+    1.0 with new bytes — a fresh ContentItem with the same published filename.
+    """
     deb_rel = f"pool/{COMP}/d/demo/demo_1.0_{ARCH}.deb"
     deb_path = root / deb_rel
     deb_path.parent.mkdir(parents=True, exist_ok=True)
-    deb = b"dummy deb payload" * 16
+    deb = b"dummy deb payload" * 16 + f" rev{revision}".encode()
     deb_path.write_bytes(deb)
 
     packages = (
@@ -85,3 +90,45 @@ def test_apt_sync_and_publish(tmp_path, serve, chantal_env):
     assert (target / "dists" / DIST / "Release").exists()
     assert list(target.rglob("Packages")), "published Packages index not found"
     assert list(target.rglob("demo_1.0_amd64.deb")), "published .deb not found"
+
+
+def test_apt_resync_does_not_duplicate_package(tmp_path, serve, chantal_env):
+    """Re-syncing a repackaged demo 1.0 must leave exactly one published .deb.
+
+    When upstream regenerates Packages with new bytes for the same version, the
+    previous ContentItem must not stay associated and get republished alongside
+    the new one: the Packages index would then carry two ``Package: demo``
+    stanzas and the pool would grow unbounded.
+    """
+    upstream = tmp_path / "upstream"
+    _build_apt_upstream(upstream, revision=1)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-apt",
+            "name": "Demo APT",
+            "type": "apt",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+            "apt": {
+                "distribution": DIST,
+                "components": [COMP],
+                "architectures": [ARCH],
+            },
+        }
+    )
+
+    chantal_env.sync_and_publish("demo-apt")
+
+    # Upstream repackages demo 1.0 with new bytes (fresh SHA256).
+    _build_apt_upstream(upstream, revision=2)
+    target = chantal_env.sync_and_publish("demo-apt")
+
+    packages = next(iter(target.rglob("Packages"))).read_text(encoding="utf-8")
+    assert (
+        packages.count("Package: demo") == 1
+    ), f"re-sync left duplicate demo stanzas in Packages:\n{packages}"
+    debs = list(target.rglob("demo_1.0_amd64.deb"))
+    assert len(debs) == 1, f"re-sync published duplicate .deb files: {debs}"

--- a/tests/e2e/test_helm_e2e.py
+++ b/tests/e2e/test_helm_e2e.py
@@ -11,10 +11,15 @@ import yaml
 pytestmark = [pytest.mark.e2e, pytest.mark.helm]
 
 
-def _build_helm_upstream(root: Path) -> None:
-    """Create a minimal Helm chart repository (index.yaml + one chart)."""
+def _build_helm_upstream(root: Path, revision: int = 1) -> None:
+    """Create a minimal Helm chart repository (index.yaml + one chart).
+
+    ``revision`` is woven into the chart payload (and thus its digest) so calling
+    this twice models an upstream that repackaged demo 0.1.0 with new bytes — a
+    fresh ContentItem sharing the published ``demo-0.1.0.tgz`` filename.
+    """
     root.mkdir(parents=True, exist_ok=True)
-    chart = b"dummy helm chart tgz payload" * 8
+    chart = b"dummy helm chart tgz payload" * 8 + f" rev{revision}".encode()
     (root / "demo-0.1.0.tgz").write_bytes(chart)
     index = {
         "apiVersion": "v1",
@@ -59,3 +64,38 @@ def test_helm_sync_and_publish(tmp_path, serve, chantal_env):
     assert indexes, "published index.yaml not found"
     index = yaml.safe_load(indexes[0].read_text())
     assert "demo" in index.get("entries", {})
+
+
+def test_helm_resync_does_not_duplicate_chart(tmp_path, serve, chantal_env):
+    """Re-syncing a repackaged demo 0.1.0 must leave exactly one index entry.
+
+    When upstream repackages a chart (same name+version, new digest), the stale
+    ContentItem must not stay associated and get republished: the regenerated
+    index.yaml would then list demo 0.1.0 twice and the pool would grow unbounded.
+    """
+    upstream = tmp_path / "upstream"
+    _build_helm_upstream(upstream, revision=1)
+    base_url = serve(upstream)
+
+    chantal_env.write_config(
+        {
+            "id": "demo-helm",
+            "name": "Demo Helm",
+            "type": "helm",
+            "feed": base_url,
+            "enabled": True,
+            "mode": "filtered",
+        }
+    )
+
+    chantal_env.sync_and_publish("demo-helm")
+
+    # Upstream repackages demo 0.1.0 with new bytes (fresh digest).
+    _build_helm_upstream(upstream, revision=2)
+    target = chantal_env.sync_and_publish("demo-helm")
+
+    index = yaml.safe_load(next(iter(target.rglob("index.yaml"))).read_text())
+    demo_entries = index.get("entries", {}).get("demo", [])
+    assert len(demo_entries) == 1, f"re-sync left duplicate demo entries: {demo_entries}"
+    charts = list(target.rglob("demo-0.1.0.tgz"))
+    assert len(charts) == 1, f"re-sync published duplicate chart files: {charts}"

--- a/tests/test_apt_valid_until.py
+++ b/tests/test_apt_valid_until.py
@@ -7,6 +7,8 @@ repository at a vulnerable state.
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 
 from chantal.core.config import AptConfig, RepositoryConfig, SignatureVerificationConfig
@@ -38,8 +40,12 @@ def test_expired_release_fails_under_fail_policy():
 
 
 def test_expired_release_warns_under_warn_policy():
-    # warn policy logs but does not raise.
-    _syncer(policy="warn")._enforce_release_freshness(_PAST)
+    # warn policy must surface a warning (not silently accept) without raising.
+    syncer = _syncer(policy="warn")
+    syncer.output.warning = Mock()
+    syncer._enforce_release_freshness(_PAST)
+    assert syncer.output.warning.call_count == 1
+    assert "expired" in syncer.output.warning.call_args.args[0]
 
 
 def test_future_release_is_accepted():
@@ -50,8 +56,14 @@ def test_no_valid_until_is_accepted():
     _syncer(policy="fail")._enforce_release_freshness(None)
 
 
-def test_unparseable_valid_until_does_not_raise():
-    _syncer(policy="fail")._enforce_release_freshness("not a date")
+def test_unparseable_valid_until_warns_and_does_not_raise():
+    # An unparseable Valid-Until must not be silently treated as fresh: warn,
+    # but do not raise (we cannot prove staleness from a date we can't read).
+    syncer = _syncer(policy="fail")
+    syncer.output.warning = Mock()
+    syncer._enforce_release_freshness("not a date")
+    assert syncer.output.warning.call_count == 1
+    assert "Valid-Until" in syncer.output.warning.call_args.args[0]
 
 
 def test_verification_disabled_skips_enforcement():

--- a/tests/test_helm_publish_dedup.py
+++ b/tests/test_helm_publish_dedup.py
@@ -35,6 +35,12 @@ def test_dedup_keeps_highest_id_per_filename():
     assert len(result) == 1
     assert result[0].sha256 == "b" * 64
 
+    # Highest id wins regardless of input order (not "last seen"): feeding the
+    # newer chart first must still keep the newer one.
+    result_desc = HelmPublisher._dedup_charts_by_filename([newer, older])
+    assert len(result_desc) == 1
+    assert result_desc[0].sha256 == "b" * 64
+
     # Distinct filenames are all kept.
     other = _chart(3, "c" * 64, filename="other-2.0.0.tgz")
     result2 = HelmPublisher._dedup_charts_by_filename([older, newer, other])


### PR DESCRIPTION
## Summary

Adds re-sync idempotency end-to-end coverage and fixes a real defect it uncovered in the APT publisher.

### New e2e tests
- **apt / helm / apk re-sync idempotency**: sync → publish → upstream repackages the same version with new bytes → re-sync → publish, asserting the regenerated index lists the package exactly once and only one artifact is published (modelled on the existing rpm re-sync test).
- **apk mirror-mode** sync→publish (apk previously only exercised filtered mode).

### Bug fix (found by the new apt test)
When upstream repackages a package with the same `name+version+arch` but new bytes, sync pools a second `ContentItem` sharing the published `.deb` filename. The filtered/hosted publisher emitted one `Packages` stanza per item, so the index carried **two stanzas for a single on-disk file** (the last hardlink wins) and the extra stanza's SHA256 could never match — a corrupt index.

The publisher now deduplicates each component/arch group by published filename, keeping the highest-id item so the index matches the file that wins on disk. This mirrors the existing Helm publisher behaviour.

### Test strengthening
- APT `Valid-Until` warn / unparseable cases now assert a warning is actually emitted, not merely that no exception is raised.
- Helm publish-dedup test adds a descending-id case so it is no longer order-confounded.

## Test plan
- `mypy src/chantal/` — clean
- `black --check` / `ruff check` — clean
- Full unit suite — green
- Full e2e suite — 60 passed, 1 skipped