### PR TITLE
fix(apt): fold regenerated index fields to prevent stanza injection

### DIFF
--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -417,6 +417,25 @@ class AptPublisher(PublisherPlugin):
 
         print(f"  ✓ Published verbatim mirror ({len(packages)} packages)")
 
+    @staticmethod
+    def _fold_field_line(line: str) -> str:
+        """Fold a stanza field's value into safe RFC822 continuation lines.
+
+        An upstream field value can contain embedded newlines (the parser
+        un-folds continuation lines into ``\\n``-joined values). Re-emitting it
+        verbatim would let a crafted value inject a forged field or a stanza
+        break (blank line) into the index chantal then GPG-signs. Prefix every
+        continuation line with a space so the value stays a single field, using
+        Debian's ``" ."`` marker for an otherwise-empty continuation line.
+        """
+        parts = line.split("\n")
+        if len(parts) == 1:
+            return line
+        folded = [parts[0]]
+        for cont in parts[1:]:
+            folded.append(" ." if cont.strip() == "" else " " + cont)
+        return "\n".join(folded)
+
     def _generate_packages_file(
         self,
         packages: list[ContentItem],
@@ -545,8 +564,9 @@ class AptPublisher(PublisherPlugin):
             if sha512:
                 stanza.append(f"SHA512: {sha512}")
 
-            # Join stanza lines
-            packages_content.append("\n".join(stanza))
+            # Join stanza lines (folding each field so an upstream value with an
+            # embedded newline cannot inject a forged field or stanza break).
+            packages_content.append("\n".join(self._fold_field_line(s) for s in stanza))
 
         # Join all stanzas with blank lines
         full_content = "\n\n".join(packages_content)
@@ -640,7 +660,7 @@ class AptPublisher(PublisherPlugin):
                 lines.append("Checksums-Sha256:")
                 lines.extend(sha256_lines)
 
-            stanzas.append("\n".join(lines))
+            stanzas.append("\n".join(self._fold_field_line(s) for s in lines))
 
         full_content = "\n\n".join(stanzas)
         if full_content:

--- a/tests/test_apt_publisher.py
+++ b/tests/test_apt_publisher.py
@@ -209,6 +209,50 @@ class TestPackagesFileGeneration:
         # Should contain a pool-relative filename (so it resolves for real apt)
         assert "Filename: pool/main/t/test-package/test-package_1.0-1_amd64.deb" in content
 
+    def test_generate_packages_rejects_field_injection(
+        self, db_session, temp_storage, apt_config, test_deb_file
+    ):
+        """A crafted upstream field with embedded newlines must not inject a
+        forged stanza into the (chantal-signed) regenerated Packages index."""
+        from chantal.plugins.apt.parsers import parse_packages_from_bytes
+
+        sha256, pool_path, size_bytes = temp_storage.add_package(
+            test_deb_file, "victim_1.0_amd64.deb"
+        )
+        injected = (
+            "realdep\n"
+            "\n"
+            "Package: evil\n"
+            "Version: 6.6.6\n"
+            "Architecture: amd64\n"
+            "Filename: pool/evil.deb\n"
+            "Size: 1\n"
+            "SHA256: " + "e" * 64
+        )
+        pkg = ContentItem(
+            content_type="deb",
+            name="victim",
+            version="1.0",
+            sha256=sha256,
+            size_bytes=size_bytes,
+            pool_path=pool_path,
+            filename="victim_1.0_amd64.deb",
+            content_metadata={"architecture": "amd64", "depends": injected},
+        )
+
+        publisher = AptPublisher(storage=temp_storage, config=apt_config)
+        out = Path(temp_storage.config.published_path) / "ca"
+        out.mkdir(parents=True, exist_ok=True)
+        publisher._generate_packages_file([pkg], out, "main", "amd64")
+
+        parsed = parse_packages_from_bytes((out / "Packages").read_bytes(), compressed=False)
+        names = [p.package for p in parsed]
+        assert names == ["victim"], f"forged stanza injected: {names}"
+        # No line may break out of the Depends value as a real field/stanza.
+        text = (out / "Packages").read_text()
+        assert "\n\nPackage: evil" not in text
+        assert "\nSHA256: " + "e" * 64 + "\n" not in text  # not a standalone field
+
     def test_generate_packages_file_multiple_packages(
         self, db_session, temp_storage, apt_config, test_repository
     ):


### PR DESCRIPTION
## Problem (security — index/metadata injection of a chantal-signed repo)

The RFC822 parser **un-folds** continuation lines into newline-joined field values (`parsers.py`), and the filtered/hosted-mode `Packages`/`Sources` regenerator re-emitted those values **verbatim**. A crafted upstream field — e.g. a `Depends` folded so its value contains a blank line followed by `Package: evil … SHA256: <attacker hash>` — therefore **injected a fully forged stanza** into the regenerated index. In filtered/hosted mode chantal then **GPG-signs** that index, so it signs attacker-controlled package metadata (package spoofing).

## Fix

`_fold_field_line` folds every emitted stanza line: each embedded newline becomes an RFC822 **continuation** (leading space; Debian's `" ."` for an otherwise-empty line), so a field value can never break out into a new field or a stanza break. Single-line elements (including the Sources `Files:`/`Checksums-*` continuation lines, which are already one line each) pass through unchanged. Applied at both the `Packages` and `Sources` join points.

## Test

Injects a forged stanza via `Depends` and asserts only the real package survives the round-trip (fails without the fold).