### PR TITLE
fix(helm): don't delete a pool blob an in-run chart still references

### DIFF
--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -188,8 +188,14 @@ class HelmSyncer:
                     # The download already content-addressed the bytes into the
                     # pool; remove the orphan if nothing else references it. Use
                     # the actual pool path (the chart url basename is unreliable
-                    # for oci:// and signed/query URLs).
-                    if not session.query(ContentItem).filter_by(sha256=sha256).first():
+                    # for oci:// and signed/query URLs). Consult the in-run dict
+                    # too: with autoflush=False a query can't see a chart added
+                    # earlier this run that legitimately shares these bytes, so
+                    # without it we could delete a blob a committed chart needs.
+                    if (
+                        sha256 not in inserted_by_sha
+                        and not session.query(ContentItem).filter_by(sha256=sha256).first()
+                    ):
                         (self.storage.pool_path / pool_path).unlink(missing_ok=True)
                     raise ValueError(
                         f"digest mismatch for {chart_name}: index.yaml advertises "

--- a/tests/test_helm_sync_dedup.py
+++ b/tests/test_helm_sync_dedup.py
@@ -91,3 +91,55 @@ def test_digestless_duplicate_in_one_sync_dedup_autoflush_off(session):
 
     assert stats["charts_added"] == 1  # second deduped, no IntegrityError
     assert session.query(ContentItem).filter_by(content_type="helm").count() == 1
+
+
+def test_digest_mismatch_keeps_blob_referenced_by_in_run_chart(session, tmp_path):
+    """A duplicate same-bytes entry with a bad digest must not delete the pool
+    blob the first (uncommitted, autoflush=False) chart already references."""
+    from chantal.core.config import StorageConfig
+    from chantal.core.storage import StorageManager
+
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    storage = StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path), pool_path=str(pool), published_path=str(tmp_path / "pub")
+        )
+    )
+    blob = pool / "ab" / "cd" / "demo.tgz"
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(b"chart-bytes")
+
+    repo = Repository(repo_id="demo", name="Demo", type="helm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.commit()
+
+    sha = "cd" * 32
+    config = _config()
+    syncer = HelmSyncer(storage=storage, config=config)
+    index = {
+        "apiVersion": "v1",
+        "entries": {
+            "demo": [
+                {"name": "demo", "version": "0.1.0", "urls": ["demo-0.1.0.tgz"], "digest": sha},
+                # identical bytes, but a wrong advertised digest -> mismatch branch
+                {
+                    "name": "demo",
+                    "version": "0.1.1",
+                    "urls": ["demo-0.1.1.tgz"],
+                    "digest": "e" * 64,
+                },
+            ]
+        },
+    }
+    with (
+        patch.object(syncer, "_fetch_index", return_value=index),
+        patch.object(syncer, "_store_index_file", return_value="f" * 64),
+        patch.object(
+            syncer, "_download_chart", return_value=("ab/cd/demo.tgz", sha, 11, "demo.tgz")
+        ),
+    ):
+        syncer.sync_repository(session, repo, config)
+
+    assert blob.exists(), "the shared pool blob was wrongly deleted"
+    assert session.query(ContentItem).filter_by(content_type="helm").count() == 1


### PR DESCRIPTION
## Problem (silent pool corruption / data loss)

On a digest mismatch the orphan-cleanup unlinked the just-downloaded pool blob *unless* a `ContentItem` referenced it — but the query saw only **committed** rows, and the session is `autoflush=False`. A duplicate index stanza with **identical bytes** (entry 1 with the correct digest → stored but uncommitted; entry 2 with a wrong digest → mismatch branch) made the cleanup **delete the shared blob** that the first chart references.

At `session.commit()` the first chart persists pointing at a now-deleted pool file → the next publish fails with `FileNotFoundError`, and a re-sync (digest cache-hit) never re-downloads it — permanent breakage until manual pool repair. Triggerable by untrusted upstream index content.

## Fix

Consult the in-run `inserted_by_sha` dict before unlinking, mirroring the insert-dedup guard a few lines below.

## Test

Two same-bytes entries in one sync, the second with a bad digest; the shared pool blob must survive (it's deleted without the fix).