### PR TITLE
fix(apk): prune stale APKINDEX files on re-sync

### DIFF
--- a/src/chantal/plugins/apk/sync.py
+++ b/src/chantal/plugins/apk/sync.py
@@ -503,9 +503,38 @@ class ApkSyncer:
                     f"Stored APKINDEX.tar.gz in pool: {sha256[:16]}... ({size_bytes} bytes)"
                 )
 
+            # Prune the previous sync's APKINDEX so mirror publishing doesn't pick
+            # up a stale one (Alpine regenerates the gz on nearly every fetch).
+            self._prune_stale_apkindex(session, repository, sha256)
+
         finally:
             # Clean up temp file
             tmp_path.unlink(missing_ok=True)
+
+    def _prune_stale_apkindex(
+        self, session: Session, repository: Repository, current_sha: str
+    ) -> None:
+        """Unlink APKINDEX RepositoryFiles from previous syncs.
+
+        Without this, every changed re-sync leaves another ``apkindex``
+        RepositoryFile linked, and the publisher (which picks the first match)
+        would republish a stale APKINDEX inconsistent with the published .apk
+        set, while old pool blobs stay referenced forever. Delete the row when no
+        other repository or snapshot still references it.
+        """
+        removed = 0
+        for repo_file in list(repository.repository_files):
+            if repo_file.file_category != "metadata" or repo_file.file_type != "apkindex":
+                continue
+            if repo_file.sha256 == current_sha:
+                continue
+            repository.repository_files.remove(repo_file)
+            removed += 1
+            if not repo_file.repositories and not repo_file.snapshots:
+                session.delete(repo_file)
+        if removed:
+            session.commit()
+            logger.info(f"Pruned {removed} stale APKINDEX file(s) from a previous sync")
 
     def _download_package(
         self,

--- a/tests/test_apk_prune_apkindex.py
+++ b/tests/test_apk_prune_apkindex.py
@@ -1,0 +1,64 @@
+"""APK: stale APKINDEX RepositoryFiles must be pruned on re-sync."""
+
+from __future__ import annotations
+
+import pytest
+
+from chantal.core.config import ApkConfig, RepositoryConfig
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import Base, Repository, RepositoryFile, Snapshot
+from chantal.plugins.apk.sync import ApkSyncer
+
+
+@pytest.fixture
+def session(tmp_path):
+    dbm = DatabaseManager(f"sqlite:///{tmp_path / 'chantal.db'}")
+    Base.metadata.create_all(dbm.engine)
+    return dbm.get_session()
+
+
+def _apkindex(sha: str) -> RepositoryFile:
+    return RepositoryFile(
+        file_category="metadata",
+        file_type="apkindex",
+        sha256=sha,
+        size_bytes=1,
+        pool_path=f"{sha[:2]}/{sha[2:4]}/APKINDEX.tar.gz",
+        original_path="v3.19/main/x86_64/APKINDEX.tar.gz",
+        file_metadata={},
+    )
+
+
+def _syncer():
+    config = RepositoryConfig(
+        id="alpine",
+        name="Alpine",
+        type="apk",
+        feed="http://example.com/alpine",
+        apk=ApkConfig(branch="v3.19", repository="main", architecture="x86_64"),
+    )
+    return ApkSyncer(storage=None, config=config)
+
+
+def test_prune_unlinks_old_apkindex_keeps_current(session):
+    repo = Repository(repo_id="alpine", name="Alpine", type="apk", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+
+    current = _apkindex("c" * 64)
+    stale_orphan = _apkindex("a" * 64)
+    stale_snapshot = _apkindex("b" * 64)
+    for rf in (current, stale_orphan, stale_snapshot):
+        repo.repository_files.append(rf)
+    snap = Snapshot(repository_id=repo.id, name="snap-1")
+    snap.repository_files.append(stale_snapshot)
+    session.add(snap)
+    session.commit()
+
+    _syncer()._prune_stale_apkindex(session, repo, "c" * 64)
+
+    session.refresh(repo)
+    assert {rf.sha256 for rf in repo.repository_files} == {"c" * 64}
+    remaining = {rf.sha256 for rf in session.query(RepositoryFile).all()}
+    assert "a" * 64 not in remaining  # orphan deleted
+    assert "b" * 64 in remaining  # snapshot-referenced kept


### PR DESCRIPTION
## Problem

Unlike the rpm/apt/helm syncers (which all prune stale metadata on re-sync), the apk syncer **never unlinked** the previous sync's `APKINDEX` `RepositoryFile`. Alpine regenerates `APKINDEX.tar.gz` on nearly every fetch (gzip mtime / any package change), so every changed re-sync left another `apkindex` row linked to the repository. The publisher picks the **first** match (the `repository_files` relationship has no ordering → association-table insertion order → the **oldest**), so:

- **mirror-mode publishing served a stale APKINDEX** inconsistent with the actually-published `.apk` set (missing newly-synced packages, referencing pruned ones), and
- old index pool blobs stayed referenced forever → never reclaimable by `pool cleanup` (unbounded growth).

## Fix

`_prune_stale_apkindex` (mirroring rpm/apt/helm): unlink `apkindex` files whose sha differs from the just-stored one, deleting the row when no other repository/snapshot references it.

## Test

Orphan deletion, snapshot-referenced preservation, and current retention.