### PR TITLE
fix(rpm): check_updates uses EVR ordering, not PEP 440

### DIFF
--- a/src/chantal/plugins/rpm/sync.py
+++ b/src/chantal/plugins/rpm/sync.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from urllib.parse import urljoin
 
 import requests
-from packaging import version
 from sqlalchemy.orm import Session
 
 from chantal.core.cache import MetadataCache
@@ -27,6 +26,7 @@ from chantal.core.storage import StorageManager
 from chantal.db.models import ContentItem, Repository, RepositoryFile
 from chantal.plugins.rpm import filters, parsers
 from chantal.plugins.rpm.models import RpmMetadata
+from chantal.plugins.rpm.version import evr_compare
 
 
 @dataclass
@@ -556,41 +556,24 @@ class RpmSyncPlugin:
                     updates.append(update)
                     total_update_size += pkg_meta["size_bytes"]
                 else:
-                    # Package exists - check if remote version is newer
+                    # Package exists - check if remote is newer using rpm EVR
+                    # semantics (epoch, then version, then release via rpmvercmp).
+                    # PEP 440 mis-orders these (e.g. 10.el9 < 9.el9, 1.0~rc1 newer
+                    # than 1.0) and rejects many valid rpm versions.
                     remote_epoch = int(pkg_meta.get("epoch") or "0")
                     local_epoch = int(existing_pkg.content_metadata.get("epoch") or "0")
 
-                    # EPOCH-style version comparison: compare epoch, then version, then release
-                    is_newer = False
-
-                    if remote_epoch > local_epoch:
-                        is_newer = True
-                    elif remote_epoch == local_epoch:
-                        # Compare version (use packaging library for proper version comparison)
-                        try:
-                            remote_ver = version.parse(pkg_meta["version"])
-                            local_ver = version.parse(existing_pkg.version)
-
-                            if remote_ver > local_ver:
-                                is_newer = True
-                            elif remote_ver == local_ver:
-                                # Compare release
-                                remote_rel = version.parse(pkg_meta["release"])
-                                local_rel = version.parse(
-                                    existing_pkg.content_metadata.get("release", "")
-                                )
-
-                                if remote_rel > local_rel:
-                                    is_newer = True
-                        except Exception:
-                            # Fallback to string comparison if packaging fails
-                            if pkg_meta["version"] > existing_pkg.version:
-                                is_newer = True
-                            elif pkg_meta["version"] == existing_pkg.version:
-                                if pkg_meta["release"] > existing_pkg.content_metadata.get(
-                                    "release", ""
-                                ):
-                                    is_newer = True
+                    is_newer = (
+                        evr_compare(
+                            remote_epoch,
+                            pkg_meta["version"],
+                            pkg_meta["release"],
+                            local_epoch,
+                            existing_pkg.version,
+                            existing_pkg.content_metadata.get("release", ""),
+                        )
+                        > 0
+                    )
 
                     if is_newer:
                         # Update available

--- a/tests/test_rpm_check_updates.py
+++ b/tests/test_rpm_check_updates.py
@@ -1,0 +1,81 @@
+"""check_updates must use rpm EVR ordering, not PEP 440.
+
+A release bump 9.el9 -> 10.el9 is a real update, but PEP 440 / lexical string
+comparison ('10.el9' > '9.el9' is False) reported "no update available".
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from unittest.mock import patch
+
+import pytest
+
+from chantal.core.config import RepositoryConfig
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import Base, ContentItem, Repository
+from chantal.plugins.rpm.sync import RpmSyncPlugin
+
+
+@pytest.fixture
+def session(tmp_path):
+    dbm = DatabaseManager(f"sqlite:///{tmp_path / 'chantal.db'}")
+    Base.metadata.create_all(dbm.engine)
+    return dbm.get_session()
+
+
+def _remote_pkg(release: str) -> dict:
+    return {
+        "name": "demo",
+        "arch": "x86_64",
+        "version": "1.0",
+        "release": release,
+        "epoch": "0",
+        "size_bytes": 1,
+        "sha256": "a" * 64,
+        "location": "Packages/demo.rpm",
+    }
+
+
+def test_check_updates_uses_evr_ordering(session):
+    repo = Repository(repo_id="demo", name="Demo", type="rpm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+    # Locally have 1.0-9.el9; upstream offers 1.0-10.el9 (a real update).
+    local = ContentItem(
+        content_type="rpm",
+        name="demo",
+        version="1.0",
+        sha256="b" * 64,
+        size_bytes=1,
+        pool_path="bb/bb/demo.rpm",
+        filename="demo-1.0-9.el9.x86_64.rpm",
+        content_metadata={"arch": "x86_64", "release": "9.el9", "epoch": "0"},
+    )
+    local.repositories.append(repo)
+    session.add(local)
+    session.commit()
+
+    config = RepositoryConfig(id="demo", name="Demo", type="rpm", feed="http://example.com/repo")
+    plugin = RpmSyncPlugin(storage=None, config=config)
+
+    with (
+        patch("chantal.plugins.rpm.sync.parsers.fetch_repomd_xml", return_value=ET.Element("r")),
+        patch(
+            "chantal.plugins.rpm.sync.parsers.extract_all_metadata",
+            return_value=[{"file_type": "primary", "location": "p", "checksum": "c"}],
+        ),
+        patch(
+            "chantal.plugins.rpm.sync.parsers.fetch_metadata_with_cache",
+            return_value=(b"<metadata/>", False),
+        ),
+        patch(
+            "chantal.plugins.rpm.sync.parsers.parse_primary_xml",
+            return_value=[_remote_pkg("10.el9")],
+        ),
+    ):
+        result = plugin.check_updates(session, repo)
+
+    assert result.success
+    versions = [(u.name, u.remote_release) for u in result.updates_available]
+    assert versions == [("demo", "10.el9")], f"10.el9 update not detected: {versions}"


### PR DESCRIPTION
## Problem

The rpm **EVR** comparator (`rpmvercmp`, #124) was wired into the `only_latest` filter but **not** into `check_updates`, which still used `packaging.version.parse` with a lexical string fallback. So:
- a release bump `1.0-9.el9` → `1.0-10.el9` was reported as **"no update available"** (`'10.el9' > '9.el9'` is `False`), and
- a `~rc` pre-release was treated as **newer** than its release.

## Fix

Route the epoch/version/release comparison through `evr_compare`.

## Test

A `1.0-9.el9` → `1.0-10.el9` update is now detected by `check_updates` (it returned 0 updates without the fix).