### PR TITLE
fix(apt): a malformed Sources Size skips the artifact, not the whole sync

### DIFF
--- a/src/chantal/plugins/apt/sync.py
+++ b/src/chantal/plugins/apt/sync.py
@@ -1275,11 +1275,23 @@ class AptSyncPlugin:
             source_format = src.extra_fields.get("Format")
             for entry in src.checksums_sha256:
                 filename = entry["filename"]
+                # The size comes straight from the (untrusted) Sources stanza.
+                # A non-numeric value must skip the artifact, not raise and abort
+                # the whole sync (the binary Packages path is likewise tolerant).
+                raw_size = entry.get("size")
+                try:
+                    size = int(raw_size) if raw_size else 0
+                except (TypeError, ValueError):
+                    self.output.warning(
+                        f"Source artifact {filename} ({src.package} {src.version}) has a "
+                        f"non-numeric size {raw_size!r}; skipping it"
+                    )
+                    continue
                 artifacts.append(
                     {
                         "filename": filename,
                         "sha256": entry["checksum"],
-                        "size": int(entry["size"]) if entry.get("size") else 0,
+                        "size": size,
                         "md5": md5_by_name.get(filename),
                         "sha1": sha1_by_name.get(filename),
                         "directory": src.directory or "",

--- a/tests/test_apt_source_size.py
+++ b/tests/test_apt_source_size.py
@@ -1,0 +1,37 @@
+"""APT: a non-numeric Size in a Sources stanza must skip that artifact, not
+abort the whole sync."""
+
+from __future__ import annotations
+
+from chantal.core.config import AptConfig, RepositoryConfig
+from chantal.plugins.apt.models import SourcesMetadata
+from chantal.plugins.apt.sync import AptSyncPlugin
+
+
+def _syncer():
+    config = RepositoryConfig(
+        id="deb",
+        name="Deb",
+        type="apt",
+        feed="http://example.com/ubuntu",
+        apt=AptConfig(distribution="jammy", components=["main"], architectures=["amd64"]),
+    )
+    return AptSyncPlugin(storage=None, config=config)
+
+
+def test_non_numeric_source_size_is_skipped_not_raised():
+    src = SourcesMetadata(
+        package="demo",
+        version="1.0",
+        directory="pool/main/d/demo",
+        checksums_sha256=[
+            {"filename": "demo_1.0.dsc", "checksum": "a" * 64, "size": "123"},
+            {"filename": "demo_1.0.tar.gz", "checksum": "b" * 64, "size": "NOTANUMBER"},
+        ],
+    )
+
+    artifacts = _syncer()._flatten_source_artifacts([src])
+
+    names = {a["filename"] for a in artifacts}
+    assert names == {"demo_1.0.dsc"}  # the bad-size artifact is skipped, no raise
+    assert next(a for a in artifacts if a["filename"] == "demo_1.0.dsc")["size"] == 123


### PR DESCRIPTION
## Problem

`_flatten_source_artifacts` did `int(entry["size"])` **unguarded** (`sync.py:1282`), reached from `_sync_source_packages` **outside any try/except**. One non-numeric `Size` in a `Sources` stanza (only when `include_source_packages` is enabled) raised `ValueError` and **failed the entire sync** — discarding binary packages already downloaded earlier in the run. The binary `Packages` path is tolerant (skips the bad record); the source path was not.

## Fix

Parse the size defensively and skip the malformed artifact with a warning.

## Test

A stanza with one good and one non-numeric `size` yields only the good artifact (it raised without the fix).