### PR TITLE
fix(helm): tolerate a non-string digest in a mirror index entry

### DIFF
--- a/src/chantal/plugins/helm/sync.py
+++ b/src/chantal/plugins/helm/sync.py
@@ -31,8 +31,11 @@ def normalize_digest(digest: str | None) -> str | None:
 
     Helm ``index.yaml`` digests are bare hex, but some producers (including
     chantal's own generated index, historically) prefix them with ``sha256:``.
+    A malformed upstream index may parse ``digest:`` as a non-string (YAML reads
+    a bare numeric/bool as int/bool); treat anything non-string as absent so a
+    single bad entry can't crash the whole publish.
     """
-    if not digest:
+    if not digest or not isinstance(digest, str):
         return None
     return digest.split(":", 1)[1] if ":" in digest else digest
 

--- a/tests/test_helm_sync.py
+++ b/tests/test_helm_sync.py
@@ -656,3 +656,45 @@ class TestHelmIntegration:
 
         published = yaml.safe_load((target / "index.yaml").read_text())
         assert published["entries"]["demo"][0]["urls"] == ["demo-1.0.0.tgz"]
+
+    def test_mirror_index_tolerates_non_string_digest(self, temp_storage):
+        """A malformed entry whose digest YAML-parses to a non-string (int/bool)
+        must not crash the whole publish."""
+        # 12345 is parsed as an int by yaml.safe_load.
+        index = {
+            "apiVersion": "v1",
+            "entries": {
+                "demo": [
+                    {
+                        "name": "demo",
+                        "version": "1.0.0",
+                        "urls": ["demo-1.0.0.tgz"],
+                        "digest": 12345,
+                    }
+                ]
+            },
+        }
+        index_path = temp_storage.pool_path / "index.yaml"
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(yaml.safe_dump(index), encoding="utf-8")
+
+        chart = ContentItem(
+            content_type="helm",
+            name="demo",
+            version="1.0.0",
+            sha256="ab" * 32,
+            size_bytes=1,
+            pool_path="ab/ab/demo-1.0.0.tgz",
+            filename="demo-1.0.0.tgz",
+            content_metadata={},
+        )
+
+        publisher = HelmPublisher(storage=temp_storage)
+        target = temp_storage.published_path
+        target.mkdir(parents=True, exist_ok=True)
+        repo_config = RepositoryConfig(id="x", name="x", type="helm", feed="https://up.example.com")
+
+        # Must not raise; the entry falls back to a basename match.
+        publisher._publish_mirror_index(index_path, target, [chart], repo_config)
+        published = yaml.safe_load((target / "index.yaml").read_text())
+        assert published["entries"]["demo"][0]["urls"] == ["demo-1.0.0.tgz"]


### PR DESCRIPTION
## Problem

`normalize_digest` assumed a `str` (`":" in digest` / `digest.split(...)`). A malformed upstream `index.yaml` whose `digest:` parses to a **non-string** (YAML reads a bare numeric as `int`, `yes`/`true` as `bool`) made the per-entry call in `_publish_mirror_index` raise `TypeError` **outside** the malformed-index `try/except`, aborting the **entire repo publish** instead of skipping the one bad entry.

## Fix

Treat any non-string digest as absent (return `None`), so the entry falls back to the basename match like a digest-less one. Fixes the publish path; the sync path was already guarded by its per-chart try/except.

## Test

A mirror index entry with an int `digest` still publishes (it raised `TypeError` without the fix).