### PR TITLE
fix(apk): re-download when a package's content changes at the same version

### DIFF
--- a/src/chantal/plugins/apk/sync.py
+++ b/src/chantal/plugins/apk/sync.py
@@ -171,11 +171,21 @@ class ApkSyncer:
                     .all()
                 )
 
+                # Match on (name, version, arch) AND the upstream C: checksum.
+                # apk package identity is the control checksum, not name+version:
+                # if upstream replaces the bytes keeping the same version, the
+                # checksum differs and we must re-download rather than serve the
+                # stale package.
                 existing = None
+                stale = None
                 for candidate in candidates:
-                    if candidate.content_metadata.get("architecture") == metadata.architecture:
+                    if candidate.content_metadata.get("architecture") != metadata.architecture:
+                        continue
+                    if candidate.content_metadata.get("checksum") == metadata.checksum:
                         existing = candidate
-                        break
+                    else:
+                        stale = candidate
+                    break
 
                 if existing:
                     # Package already exists - link to repository if not already linked
@@ -188,6 +198,12 @@ class ApkSyncer:
                         stats["packages_skipped"] += 1
                     self.output.update_progress()
                     continue
+
+                if stale is not None and repository in stale.repositories:
+                    # Same version, different content: drop the superseded package
+                    # from this repository so the new bytes replace it (one entry
+                    # per name+version+arch in the published APKINDEX).
+                    stale.repositories.remove(repository)
 
                 # Download package
                 pkg_url = urljoin(base_url, filename)

--- a/tests/test_apk_sync_dedup.py
+++ b/tests/test_apk_sync_dedup.py
@@ -77,6 +77,46 @@ def test_duplicate_entries_in_one_sync_do_not_abort(session):
     assert len(items) == 1
 
 
+def test_same_version_content_replacement_redownloads(session):
+    """Upstream replacing a package's bytes while keeping the version (new C:)
+    must re-download and replace the stale package, not short-circuit it."""
+    repo = Repository(repo_id="alpine", name="Alpine", type="apk", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+    stale = ContentItem(
+        content_type="apk",
+        name="demo",
+        version="1.0-r0",
+        sha256="aa" * 32,
+        size_bytes=1,
+        pool_path="aa/aa/demo.apk",
+        filename="demo-1.0-r0.apk",
+        content_metadata={"architecture": "x86_64", "checksum": "Q1" + "A" * 27},
+    )
+    stale.repositories.append(repo)
+    session.add(stale)
+    session.commit()
+
+    config = _config()
+    syncer = ApkSyncer(storage=None, config=config)
+    new_entry = {**_entry(), "checksum": "Q1" + "B" * 27}  # same version, new content
+    with (
+        patch.object(syncer, "_fetch_apkindex", return_value=("", b"")),
+        patch.object(syncer, "_store_apkindex_file"),
+        patch.object(syncer, "_parse_apkindex", return_value=[new_entry]),
+        patch.object(
+            syncer, "_download_package", return_value=("cd/ef/demo.apk", "cd" * 32, 100, True)
+        ),
+    ):
+        stats = syncer.sync_repository(session, repo, config)
+
+    assert stats["packages_added"] == 1  # the new bytes were downloaded
+    apk_items = [i for i in repo.content_items if i.content_type == "apk"]
+    assert len(apk_items) == 1  # the stale package is unlinked, replaced
+    assert apk_items[0].sha256 == "cd" * 32
+    assert apk_items[0].content_metadata["checksum"] == "Q1" + "B" * 27
+
+
 def test_resync_links_instead_of_reinserting(session):
     repo = Repository(repo_id="alpine", name="Alpine", type="apk", feed="http://x", mode="MIRROR")
     session.add(repo)


### PR DESCRIPTION
## Problem

The pre-download dedup matched only `(name, version, arch)` and short-circuited (`continue`) **without comparing the upstream `C:` control checksum**. apk package identity is the **control checksum**, not name+version — so when upstream **replaced a package's bytes keeping the same version string** (a rebuild that didn't bump `-rN`), chantal kept serving the **stale** package and never re-downloaded.

## Fix

Require the `C:` checksum to match for the skip. When it differs (a content replacement), unlink the superseded package from this repository and fall through to download the new bytes — so the published APKINDEX keeps exactly one current entry per name+version+arch.

## Test

A same-version sync with a new `C:` re-downloads and replaces the stale package (it was skipped without the fix).