### PR TITLE
fix(storage): don't GC in-flight pool blobs (orphan grace window)

### DIFF
--- a/src/chantal/core/storage.py
+++ b/src/chantal/core/storage.py
@@ -12,6 +12,7 @@ import hashlib
 import os
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -282,19 +283,35 @@ class StorageManager:
 
         self.link_or_copy(source_path, target_path)
 
-    def get_orphaned_files(self, session: Session) -> list[Path]:
+    # A pool blob is written before the sync commits the DB row that references
+    # it, so a freshly-written unreferenced file is most likely in-flight, not a
+    # true orphan. Skip files modified within this window to avoid a concurrent
+    # `pool cleanup` deleting content a running sync is about to commit.
+    _ORPHAN_GRACE_SECONDS = 3600
+
+    def get_orphaned_files(
+        self, session: Session, grace_seconds: float | None = None
+    ) -> list[Path]:
         """Find files in pool that are not referenced in database.
 
         Checks both ContentItem (packages) and RepositoryFile (metadata/installer)
-        tables to find orphaned files in both pool subdirectories.
+        tables to find orphaned files in both pool subdirectories. Files modified
+        within ``grace_seconds`` (default :attr:`_ORPHAN_GRACE_SECONDS`) are
+        excluded so a concurrent in-progress sync's not-yet-committed blobs are
+        not mistaken for orphans.
 
         Args:
             session: Database session
+            grace_seconds: Skip files newer than this many seconds.
 
         Returns:
             List of orphaned file paths
         """
         from chantal.db.models import RepositoryFile
+
+        if grace_seconds is None:
+            grace_seconds = self._ORPHAN_GRACE_SECONDS
+        cutoff = time.time() - grace_seconds
 
         orphaned = []
 
@@ -312,21 +329,31 @@ class StorageManager:
                     if "_" in filename:
                         file_sha256 = filename.split("_", 1)[0]
                         if len(file_sha256) == 64 and file_sha256 not in db_sha256s:
+                            try:
+                                if pool_file.stat().st_mtime > cutoff:
+                                    # Recently written -> likely an in-flight sync.
+                                    continue
+                            except OSError:
+                                continue
                             orphaned.append(pool_file)
 
         return orphaned
 
-    def cleanup_orphaned_files(self, session: Session, dry_run: bool = True) -> tuple[int, int]:
+    def cleanup_orphaned_files(
+        self, session: Session, dry_run: bool = True, grace_seconds: float | None = None
+    ) -> tuple[int, int]:
         """Remove files from pool that are not referenced in database.
 
         Args:
             session: Database session
             dry_run: If True, only report what would be deleted
+            grace_seconds: Skip files newer than this many seconds (see
+                :meth:`get_orphaned_files`).
 
         Returns:
             Tuple of (files_removed, bytes_freed)
         """
-        orphaned_files = self.get_orphaned_files(session)
+        orphaned_files = self.get_orphaned_files(session, grace_seconds=grace_seconds)
 
         files_removed = 0
         bytes_freed = 0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -266,7 +266,7 @@ def test_get_orphaned_files(temp_storage, test_file, db_session):
     db_session.commit()
 
     # Should find no orphaned files
-    orphaned = temp_storage.get_orphaned_files(db_session)
+    orphaned = temp_storage.get_orphaned_files(db_session, grace_seconds=0)
     assert len(orphaned) == 0
 
     # Remove from database
@@ -274,7 +274,7 @@ def test_get_orphaned_files(temp_storage, test_file, db_session):
     db_session.commit()
 
     # Should find orphaned file now
-    orphaned = temp_storage.get_orphaned_files(db_session)
+    orphaned = temp_storage.get_orphaned_files(db_session, grace_seconds=0)
     assert len(orphaned) == 1
     assert orphaned[0].name.startswith(sha256)
 
@@ -285,7 +285,9 @@ def test_cleanup_orphaned_files_dry_run(temp_storage, test_file, db_session):
     sha256, pool_path, size = temp_storage.add_package(test_file, "test.txt", verify_checksum=True)
 
     # Run cleanup in dry-run mode
-    files_removed, bytes_freed = temp_storage.cleanup_orphaned_files(db_session, dry_run=True)
+    files_removed, bytes_freed = temp_storage.cleanup_orphaned_files(
+        db_session, dry_run=True, grace_seconds=0
+    )
 
     # Should report what would be removed
     assert files_removed == 1
@@ -302,7 +304,9 @@ def test_cleanup_orphaned_files_real(temp_storage, test_file, db_session):
     sha256, pool_path, size = temp_storage.add_package(test_file, "test.txt", verify_checksum=True)
 
     # Run cleanup for real
-    files_removed, bytes_freed = temp_storage.cleanup_orphaned_files(db_session, dry_run=False)
+    files_removed, bytes_freed = temp_storage.cleanup_orphaned_files(
+        db_session, dry_run=False, grace_seconds=0
+    )
 
     # Should have removed file
     assert files_removed == 1
@@ -426,7 +430,7 @@ def test_get_orphaned_files_with_repository_files(temp_storage, test_file, db_se
     db_session.commit()
 
     # Check for orphans - should be empty (file is referenced)
-    orphaned = temp_storage.get_orphaned_files(db_session)
+    orphaned = temp_storage.get_orphaned_files(db_session, grace_seconds=0)
     assert len(orphaned) == 0
 
     # Delete from DB
@@ -434,7 +438,7 @@ def test_get_orphaned_files_with_repository_files(temp_storage, test_file, db_se
     db_session.commit()
 
     # Now should be orphaned
-    orphaned = temp_storage.get_orphaned_files(db_session)
+    orphaned = temp_storage.get_orphaned_files(db_session, grace_seconds=0)
     assert len(orphaned) == 1
     assert orphaned[0] == temp_storage.pool_path / pool_path
 
@@ -457,7 +461,9 @@ def test_cleanup_orphaned_files_preserves_repository_files(temp_storage, test_fi
     db_session.commit()
 
     # Run cleanup
-    files_removed, bytes_freed = temp_storage.cleanup_orphaned_files(db_session, dry_run=False)
+    files_removed, bytes_freed = temp_storage.cleanup_orphaned_files(
+        db_session, dry_run=False, grace_seconds=0
+    )
 
     # Nothing should be removed (file is referenced)
     assert files_removed == 0
@@ -519,7 +525,7 @@ def test_mixed_content_and_files_cleanup(temp_storage, db_session):
         assert sha256_pkg != sha256_file
 
         # Both should be preserved
-        orphaned = temp_storage.get_orphaned_files(db_session)
+        orphaned = temp_storage.get_orphaned_files(db_session, grace_seconds=0)
         assert len(orphaned) == 0
 
         # Delete package from DB (but keep file)
@@ -527,7 +533,7 @@ def test_mixed_content_and_files_cleanup(temp_storage, db_session):
         db_session.commit()
 
         # Package file should be orphaned, but not metadata file
-        orphaned = temp_storage.get_orphaned_files(db_session)
+        orphaned = temp_storage.get_orphaned_files(db_session, grace_seconds=0)
         assert len(orphaned) == 1
         assert orphaned[0] == temp_storage.pool_path / pool_path_pkg
 

--- a/tests/test_storage_gc_grace.py
+++ b/tests/test_storage_gc_grace.py
@@ -1,0 +1,62 @@
+"""Pool GC must not delete an in-flight blob.
+
+A sync writes a pool blob before committing the ContentItem that references it,
+so a freshly-written unreferenced file is most likely an in-progress sync, not a
+true orphan. get_orphaned_files skips files newer than a grace window.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from chantal.core.config import StorageConfig
+from chantal.core.storage import StorageManager
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import Base
+
+
+@pytest.fixture
+def session(tmp_path):
+    dbm = DatabaseManager(f"sqlite:///{tmp_path / 'chantal.db'}")
+    Base.metadata.create_all(dbm.engine)
+    return dbm.get_session()
+
+
+@pytest.fixture
+def storage(tmp_path):
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    return StorageManager(
+        StorageConfig(
+            base_path=str(tmp_path), pool_path=str(pool), published_path=str(tmp_path / "pub")
+        )
+    )
+
+
+def test_recent_unreferenced_blob_is_not_orphaned(session, storage):
+    old = storage.pool_path / ("a" * 64 + "_old.bin")
+    old.write_bytes(b"old")
+    fresh = storage.pool_path / ("b" * 64 + "_fresh.bin")
+    fresh.write_bytes(b"fresh")
+    # Age the old blob beyond the grace window; the fresh one is just-written.
+    aged = time.time() - 7200
+    os.utime(old, (aged, aged))
+
+    names = {p.name for p in storage.get_orphaned_files(session)}
+    assert old.name in names  # genuinely old orphan -> collected
+    assert fresh.name not in names  # within grace -> skipped (possible in-flight)
+
+    # With no grace, both unreferenced blobs are orphans.
+    names0 = {p.name for p in storage.get_orphaned_files(session, grace_seconds=0)}
+    assert names0 == {old.name, fresh.name}
+
+
+def test_cleanup_respects_grace_window(session, storage):
+    fresh = storage.pool_path / ("c" * 64 + "_fresh.bin")
+    fresh.write_bytes(b"fresh")
+    removed, _ = storage.cleanup_orphaned_files(session, dry_run=False)
+    assert removed == 0  # the in-flight-looking blob is preserved
+    assert fresh.exists()


### PR DESCRIPTION
## Problem (data loss under concurrency)

A sync writes a pool blob (atomic `os.replace` into the content-addressed path) **before** committing the `ContentItem`/`RepositoryFile` row that references it. `get_orphaned_files` keyed purely on "sha256 not in any DB row", so a `pool cleanup` run **overlapping a sync** saw those not-yet-committed blobs as orphans and deleted them. The sync then committed rows pointing at **deleted files** — silent pool corruption, surfaced only later by `pool verify` as "missing files". (There is no locking between the two operations.)

## Fix

Skip files modified within a **grace window** (default 1 h) in `get_orphaned_files`/`cleanup_orphaned_files`, so a freshly-written unreferenced blob is treated as in-flight rather than orphaned. Callers may pass `grace_seconds` explicitly (`0` disables it).

## Tests

A recent unreferenced blob is preserved while an aged one is collected; the existing orphan-detection tests pass `grace_seconds=0` to exercise the detection logic directly.