### PR TITLE
fix(rpm): mirror all .treeinfo images and the [stage2] install.img

### DIFF
--- a/src/chantal/plugins/rpm/parsers.py
+++ b/src/chantal/plugins/rpm/parsers.py
@@ -447,17 +447,26 @@ def parse_treeinfo(content: str) -> list[dict[str, str | None]]:
                 checksum = value.split("sha256:")[1].strip()
                 checksums[key] = checksum
 
-    # Parse images section for current arch
-    arch = parser.get("general", "arch", fallback="x86_64")
-    images_section = f"images-{arch}"
-
-    if parser.has_section(images_section):
-        for file_type, file_path in parser.items(images_section):
-            # file_type: boot.iso, kernel, initrd, etc.
-            # file_path: images/boot.iso, images/pxeboot/vmlinuz
-
-            sha256 = checksums.get(file_path)
-
-            installer_files.append({"path": file_path, "file_type": file_type, "sha256": sha256})
+    # Collect installer files from every ``images-*`` section and ``[stage2]``.
+    # A .treeinfo lists boot images per arch (images-x86_64, images-xen, ...) and
+    # the installer runtime under [stage2] (mainimage/instimage = install.img).
+    # Republishing the .treeinfo verbatim while only mirroring the default arch's
+    # images leaves clients 404ing on install.img and other-arch images, so
+    # download everything the .treeinfo references. Dedup by path (an image can
+    # be listed in more than one section).
+    seen_paths: set[str] = set()
+    for section in parser.sections():
+        if section != "stage2" and not section.startswith("images-"):
+            continue
+        for file_type, file_path in parser.items(section):
+            # file_type: boot.iso, kernel, initrd, mainimage, ...
+            # file_path: images/boot.iso, images/pxeboot/vmlinuz, images/install.img
+            file_path = file_path.strip()
+            if not file_path or file_path in seen_paths:
+                continue
+            seen_paths.add(file_path)
+            installer_files.append(
+                {"path": file_path, "file_type": file_type, "sha256": checksums.get(file_path)}
+            )
 
     return installer_files

--- a/tests/test_rpm_sync.py
+++ b/tests/test_rpm_sync.py
@@ -94,14 +94,13 @@ boot.iso = images/boot-x86.iso
 
         installer_files = parsers.parse_treeinfo(treeinfo_content)
 
-        # Should only parse images-aarch64 section
-        assert len(installer_files) == 2
-
-        # Verify paths are from aarch64 section
+        # Every images-* section is mirrored (the published .treeinfo references
+        # all of them), not just the default arch.
+        assert len(installer_files) == 3
         paths = {f["path"] for f in installer_files}
         assert "images/boot.iso" in paths
         assert "images/pxeboot/vmlinuz" in paths
-        assert "images/boot-x86.iso" not in paths
+        assert "images/boot-x86.iso" in paths  # other-arch image also collected
 
     def test_parse_treeinfo_empty(self):
         """Test parsing empty .treeinfo file."""
@@ -168,14 +167,13 @@ mainimage = images/install.img
 
         installer_files = parsers.parse_treeinfo(treeinfo_content)
 
-        # Verify we got all 4 files from images-x86_64 section
-        assert len(installer_files) == 4
+        # The 4 images-x86_64 files plus the [stage2] install.img (instimage and
+        # mainimage both point at it, deduped to one).
+        assert len(installer_files) == 5
+        paths = {f["path"] for f in installer_files}
+        assert "images/install.img" in paths  # the installer stage2 is mirrored
 
-        # Verify file types
-        file_types = {f["file_type"] for f in installer_files}
-        assert file_types == {"boot.iso", "initrd", "kernel", "efiboot.img"}
-
-        # Verify all have checksums
-        for file_info in installer_files:
-            assert file_info["sha256"] is not None
-            assert len(file_info["sha256"]) == 64  # SHA256 hex length
+        # The boot images carry sha256 checksums from [checksums].
+        by_path = {f["path"]: f for f in installer_files}
+        assert by_path["images/boot.iso"]["sha256"] is not None
+        assert len(by_path["images/boot.iso"]["sha256"]) == 64


### PR DESCRIPTION
## Problem

`parse_treeinfo` only read `images-<default-arch>`, ignoring the **`[stage2]`** section (`mainimage`/`instimage` = `images/install.img`, the installer runtime) and any **other `images-*`** sections. But the `.treeinfo` is republished **verbatim**, so an install that fetches the installer stage2 or an other-arch image from the mirror got a **404** — `install.img` was never downloaded even though the published `.treeinfo` still references it. Installer/kickstart mirrors were silently incomplete.

## Fix

Collect installer files from **every `images-*` section and `[stage2]`**, deduped by path (an image can be listed under several sections; `instimage`/`mainimage` both point at `install.img`).

## Tests

Updated to the new behavior: a multi-arch `.treeinfo` mirrors every arch's images, and the real-CentOS fixture now also collects `images/install.img` from `[stage2]`.