### PR TITLE
fix(apk): keep the signed APKINDEX valid for long/non-ASCII key names

### DIFF
--- a/src/chantal/plugins/apk/signing.py
+++ b/src/chantal/plugins/apk/signing.py
@@ -103,11 +103,19 @@ class ApkSigner:
         """
         configured = self.config.public_key_name
         if configured and configured != "key.gpg":
-            return configured
-        base = default_base or self.config.key_name or self._default_name or "chantal"
-        # Keep the filename safe and apk-friendly.
-        base = "".join(c if c.isalnum() or c in "-._" else "-" for c in base)
-        return f"{base}.rsa.pub"
+            name = configured
+        else:
+            base = default_base or self.config.key_name or self._default_name or "chantal"
+            name = f"{base}.rsa.pub"
+        # The published filename is also embedded in the '.SIGN.RSA256.<name>'
+        # tar entry, so keep it ASCII + safe and short enough that the entry name
+        # (prefix + name) stays within USTAR's 100-byte limit - otherwise the
+        # signature segment can't be written as a single-header cut tar.
+        name = "".join(c if c.isascii() and (c.isalnum() or c in "-._") else "-" for c in name)
+        max_name = 100 - len(".SIGN.RSA256.")
+        if len(name) > max_name:
+            name = name[:max_name]
+        return name or "chantal.rsa.pub"
 
     def sign_index(self, unsigned_index: bytes) -> bytes:
         """Sign an unsigned ``APKINDEX.tar.gz`` byte string.
@@ -132,7 +140,12 @@ class ApkSigner:
         ``abuild-tar --cut``).
         """
         buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode="w") as tar:
+        # USTAR (not the default PAX): PAX prepends an extra ``@PaxHeader`` block
+        # whenever the entry name is long or non-ASCII, which would shift the real
+        # header out of the single-block cut window below and silently corrupt the
+        # signature segment. USTAR always emits exactly one 512-byte header, so
+        # the cut math holds; the name is kept short+ASCII in _resolve_public_name.
+        with tarfile.open(fileobj=buf, mode="w", format=tarfile.USTAR_FORMAT) as tar:
             info = tarfile.TarInfo(name)
             info.size = len(data)
             info.mtime = 0

--- a/tests/test_apk_signing.py
+++ b/tests/test_apk_signing.py
@@ -82,6 +82,30 @@ class TestApkSigner:
         signer = ApkSigner(config)
         assert signer.key_name == "alpine-mirror.rsa.pub"
 
+    def test_long_or_non_ascii_key_name_does_not_corrupt_signature(self):
+        """A long/non-ASCII public_key_name previously made tarfile emit a PAX
+        header that shifted the real header out of the cut window, silently
+        corrupting the signature segment into an unparseable APKINDEX."""
+        config = GpgConfig(generate_key=True, public_key_name="café-" + "x" * 200 + ".rsa.pub")
+        signer = ApkSigner(config)
+
+        # key_name is normalized to ASCII and bounded so the '.SIGN.RSA256.<name>'
+        # tar entry stays within USTAR's 100-byte single-header limit.
+        entry = f".SIGN.RSA256.{signer.key_name}"
+        assert entry.isascii()
+        assert len(entry) <= 100
+
+        unsigned = _unsigned_index()
+        signed = signer.sign_index(unsigned)
+        assert signed.endswith(unsigned)
+
+        # The signature segment is still a parseable cut tar holding the real
+        # entry, and the signature verifies (no corruption).
+        name, signature = _extract_signature(signed, unsigned)
+        assert name == entry
+        pub = load_pem_public_key(signer.export_public_key())
+        pub.verify(signature, unsigned, padding.PKCS1v15(), hashes.SHA256())
+
     def test_export_public_key_is_pem(self):
         signer = ApkSigner(GpgConfig(generate_key=True))
         pem = signer.export_public_key()


### PR DESCRIPTION
## Problem (silent index corruption)

`_cut_tar_gz` built the signature tar with tarfile's **default PAX** format, then kept only the first 512-byte header + data blocks (`buf[:_TAR_BLOCK + padded]`). But PAX **prepends an extra `@PaxHeader` block** whenever the entry name is **long (>100 bytes) or contains a non-ASCII byte** — so the cut window captured the PaxHeader blocks and **dropped the real header and the entire RSA signature**. The result is a silently malformed, unparseable signed `APKINDEX.tar.gz` that breaks the **whole repo** for apk clients (even `gunzip`/`tar` can't read it), with no error at publish time.

Reachable from ordinary configuration: a long or non-ASCII `public_key_name` (returned verbatim, no sanitization), or a long repo display name flowing into the derived `<base>.rsa.pub`.

## Fix

- Write the cut tar as **USTAR** () — always exactly one header block, so the single-header cut math holds.
- Normalize the published key name to **ASCII** and **bound its length** so the `.SIGN.RSA256.<name>` entry stays within USTAR's 100-byte limit (and remains apk-friendly).

## Test

Signs with a long, non-ASCII `public_key_name` and asserts the signature segment is a parseable cut tar whose entry name is ASCII/≤100 and whose signature still verifies (it was unparseable without the fix).