### PR TITLE
fix(apt): reject unsafe component/architecture to protect the signed Release

### DIFF
--- a/src/chantal/plugins/apt/publisher.py
+++ b/src/chantal/plugins/apt/publisher.py
@@ -7,6 +7,7 @@ This module implements publishing for APT repositories with Debian package metad
 """
 
 import hashlib
+import re
 import shutil
 from datetime import UTC, datetime, timedelta
 from pathlib import Path, PurePosixPath
@@ -26,6 +27,12 @@ _PACKAGES_VARIANTS = ("Packages", "Packages.gz", "Packages.xz", "Packages.zst", 
 
 # Sources index variants (the source-package analog of _PACKAGES_VARIANTS).
 _SOURCES_VARIANTS = ("Sources", "Sources.gz", "Sources.xz", "Sources.zst", "Sources.bz2")
+
+# A component/architecture is used as a directory name (binary-<arch>) and is
+# emitted into the GPG-signed Release. A real value is a plain token; reject
+# anything else (esp. embedded whitespace/newlines from an un-folded upstream
+# field) so it cannot inject a forged line into the signed Release.
+_SAFE_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.+_-]*$")
 
 
 class AptPublisher(PublisherPlugin):
@@ -246,6 +253,16 @@ class AptPublisher(PublisherPlugin):
             # Use `or` so an explicit None in the metadata still falls back.
             component = package.content_metadata.get("component") or "main"
             architecture = package.content_metadata.get("architecture") or "amd64"
+
+            # Reject a malformed component/architecture: these become directory
+            # names and Release fields, so an embedded newline (from an un-folded
+            # upstream Architecture: field) would inject into the signed Release.
+            if not _SAFE_TOKEN.match(architecture) or not _SAFE_TOKEN.match(component):
+                print(
+                    f"  ⚠ Skipping {package.name}: unsafe component/architecture "
+                    f"({component!r}/{architecture!r})"
+                )
+                continue
 
             if architecture == "source":
                 targets = ["source"]

--- a/tests/test_apt_publisher.py
+++ b/tests/test_apt_publisher.py
@@ -209,6 +209,34 @@ class TestPackagesFileGeneration:
         # Should contain a pool-relative filename (so it resolves for real apt)
         assert "Filename: pool/main/t/test-package/test-package_1.0-1_amd64.deb" in content
 
+    def test_group_drops_unsafe_architecture(self, temp_storage, apt_config):
+        """A package whose architecture carries an embedded newline (from an
+        un-folded upstream field) must be dropped, not used as a directory name
+        or injected into the signed Release."""
+        publisher = AptPublisher(storage=temp_storage, config=apt_config)
+
+        def pkg(name, sha, arch):
+            return ContentItem(
+                content_type="deb",
+                name=name,
+                version="1.0",
+                sha256=sha,
+                size_bytes=1,
+                pool_path=f"pool/{sha[:2]}/{name}.deb",
+                filename=f"{name}_1.0_amd64.deb",
+                content_metadata={"architecture": arch, "component": "main"},
+            )
+
+        good = pkg("good", "a" * 64, "amd64")
+        evil = pkg("evil", "b" * 64, "amd64\nValid-Until: Thu, 01 Jan 1970 00:00:00 UTC")
+
+        grouped = publisher._group_packages_by_component_arch([good, evil])
+
+        # Only the clean (component, arch) survives; the injected arch is gone.
+        assert set(grouped.keys()) == {("main", "amd64")}
+        names = {p.name for pkgs in grouped.values() for p in pkgs}
+        assert names == {"good"}
+
     def test_generate_packages_rejects_field_injection(
         self, db_session, temp_storage, apt_config, test_deb_file
     ):


### PR DESCRIPTION
## Problem (injection into the GPG-signed Release)

Round 3 fixed field injection in the regenerated `Packages`/`Sources` (`_fold_field_line`), but `_generate_release_file` still emits `Architectures:` and the `binary-<arch>` checksum-block paths from the **raw upstream architecture**. A crafted Packages `Architecture:` field with a continuation line — un-folded by the parser into an embedded newline — survives sync and filtering (there's no arch validation), becomes the **grouping key + a directory name**, and injects a forged line into the **chantal-GPG-signed Release** (e.g. truncating the `SHA256:` block so apt can't resolve indices, or forging a `Valid-Until:`). Same injection class, missed on the Release path.

## Fix

Validate `component` and `architecture` as plain tokens (`_SAFE_TOKEN`) at the grouping choke point (`_group_packages_by_component_arch`) and skip a package whose values aren't safe — so a malformed value never reaches a directory name or the Release.

## Test

A package with a newline-injected `architecture` is dropped from the grouping (it formed a forged group key without the fix).