### PR TITLE
fix(rpm): sign the regenerated repomd in mirror mode too

### DIFF
--- a/src/chantal/plugins/rpm/publisher.py
+++ b/src/chantal/plugins/rpm/publisher.py
@@ -206,12 +206,13 @@ class RpmPublisher(PublisherPlugin):
         # Generate repomd.xml with all metadata entries
         repomd_path = self._generate_repomd_xml(repodata_path, published_metadata)
 
-        # In filtered mode the regenerated repomd.xml invalidates the upstream
-        # repomd.xml.asc signature. Sign it ourselves when a GPG key is
-        # configured so clients can use repo_gpgcheck=1. Mirror mode keeps the
-        # upstream signature untouched. Packages are never re-signed: they
-        # retain their upstream signatures (verified via gpgcheck=1).
-        if mode == RepositoryMode.FILTERED and config is not None:
+        # repomd.xml is regenerated in EVERY mode (the primary is relocated and
+        # recompressed, with a fresh revision), so the upstream repomd.xml.asc
+        # never matches what we publish - mirror mode included. Sign it ourselves
+        # whenever a GPG key is configured so clients can use repo_gpgcheck=1 in
+        # mirror mode too. Packages are never re-signed: they retain their
+        # upstream signatures (verified via gpgcheck=1).
+        if config is not None:
             gpg_config = config.gpg
             if gpg_config is not None and gpg_config.enabled:
                 self._sign_repomd(repomd_path, target_path, gpg_config, config)

--- a/tests/test_rpm_gpg.py
+++ b/tests/test_rpm_gpg.py
@@ -215,13 +215,40 @@ class TestPublisherRpmGpgIntegration:
         assert (target / "repodata" / "repomd.xml").exists()
         assert not (target / "repodata" / "repomd.xml.asc").exists()
 
-    def test_mirror_mode_does_not_sign(self, db_session, temp_storage, tmp_path, gpg_home):
-        """Mirror mode preserves upstream signatures and does not re-sign."""
+    def test_mirror_mode_signs_regenerated_repomd(
+        self, db_session, temp_storage, tmp_path, gpg_home
+    ):
+        """Mirror mode also regenerates repomd.xml (primary is relocated and
+        recompressed), so the upstream signature no longer matches; with a gpg
+        config configured chantal signs the regenerated repomd so clients can use
+        repo_gpgcheck=1."""
         repo = _make_repo(db_session, temp_storage, tmp_path, RepositoryMode.MIRROR)
         config = _config(
             "mirror",
             GpgConfig(generate_key=True, gnupg_home=str(gpg_home), key_email="t@chantal.local"),
         )
+        publisher = RpmPublisher(storage=temp_storage)
+        target = tmp_path / "published" / "test-rpm-repo"
+
+        publisher.publish_repository(
+            session=db_session, repository=repo, config=config, target_path=target
+        )
+
+        repomd = target / "repodata" / "repomd.xml"
+        asc = target / "repodata" / "repomd.xml.asc"
+        assert repomd.exists()
+        assert asc.exists()
+        assert (target / "key.gpg").exists()
+
+        with GpgSigner(config.gpg) as verifier:
+            with open(asc, "rb") as sig:
+                verified = verifier.gpg.verify_file(sig, str(repomd))
+            assert verified.valid
+
+    def test_mirror_mode_without_gpg_is_unsigned(self, db_session, temp_storage, tmp_path):
+        """Mirror mode without a gpg config stays unsigned (backward compatible)."""
+        repo = _make_repo(db_session, temp_storage, tmp_path, RepositoryMode.MIRROR)
+        config = _config("mirror", None)
         publisher = RpmPublisher(storage=temp_storage)
         target = tmp_path / "published" / "test-rpm-repo"
 


### PR DESCRIPTION
## Problem

`repomd.xml` is regenerated in **every** mode — even mirror mode relocates each package `<location>` to the republished `Packages/` layout, recompresses `primary`, and stamps a fresh `<revision>`. So the upstream `repomd.xml.asc` never matches what chantal publishes. But GPG signing was gated to `mode == FILTERED`, so a **`mode: mirror` repo with `gpg.enabled`** published a regenerated, **unsigned** `repomd.xml` with no `.asc` — and a dnf client with `repo_gpgcheck=1` failed (`repomd.xml.asc not found`). The old comment claiming mirror "keeps the upstream signature untouched" was factually wrong.

## Fix

Sign the regenerated `repomd.xml` whenever a GPG key is configured, regardless of mode.

## Tests

- Mirror mode + gpg now emits a **verifying** `repomd.xml.asc` (+ published key). (This replaces the old test that asserted mirror does *not* sign.)
- Mirror mode without gpg stays unsigned (backward compatible).