### PR TITLE
fix(snapshot): correct diff arch handling and guard delete against view snapshots

### DIFF
--- a/src/chantal/cli/snapshot_commands.py
+++ b/src/chantal/cli/snapshot_commands.py
@@ -57,6 +57,20 @@ def _diff_package_sets(
     return added, removed, updated
 
 
+def _referencing_view_snapshots(session: Any, snapshot_id: int) -> list[ViewSnapshot]:
+    """Return view snapshots whose ``snapshot_ids`` include ``snapshot_id``.
+
+    ``ViewSnapshot.snapshot_ids`` is a plain JSON list of ``Snapshot.id`` with no
+    foreign key or cascade, so deleting a referenced snapshot would silently leave
+    a dangling reference that breaks the view snapshot when it is later published.
+    JSON-array containment is not portable across backends, so candidates are
+    filtered in Python.
+    """
+    return [
+        vs for vs in session.query(ViewSnapshot).all() if snapshot_id in (vs.snapshot_ids or [])
+    ]
+
+
 def create_snapshot_group(cli: click.Group) -> click.Group:
     """Create and return the snapshot command group.
 
@@ -371,6 +385,24 @@ def create_snapshot_group(cli: click.Group) -> click.Group:
                 click.echo(f"Error: Snapshot '{snapshot_name}' is currently published.", err=True)
                 click.echo(f"Published at: {snapshot.published_path}", err=True)
                 click.echo("Unpublish first or use --force to delete anyway.", err=True)
+                ctx.exit(1)
+
+            # Check if referenced by any view snapshot (no FK/cascade on snapshot_ids,
+            # so an unguarded delete would leave a dangling reference that breaks the
+            # view snapshot when it is published).
+            referencing = _referencing_view_snapshots(session, snapshot.id)
+            if referencing and not force:
+                click.echo(
+                    f"Error: Snapshot '{snapshot_name}' is referenced by "
+                    f"{len(referencing)} view snapshot(s):",
+                    err=True,
+                )
+                for vs in referencing:
+                    click.echo(f"  - view '{vs.view.name}' snapshot '{vs.name}'", err=True)
+                click.echo(
+                    "Delete the view snapshot(s) first or use --force to delete anyway.",
+                    err=True,
+                )
                 ctx.exit(1)
 
             click.echo(f"Deleting snapshot: {snapshot_name}")

--- a/src/chantal/cli/snapshot_commands.py
+++ b/src/chantal/cli/snapshot_commands.py
@@ -11,10 +11,50 @@ import click
 
 from chantal.core.config import GlobalConfig
 from chantal.db.connection import DatabaseManager
-from chantal.db.models import Repository, Snapshot, View, ViewSnapshot
+from chantal.db.models import ContentItem, Repository, Snapshot, View, ViewSnapshot
 
 # Click context settings to enable -h as alias for --help
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+def _package_ident(pkg: ContentItem) -> tuple[str, str]:
+    """Identity for snapshot-diff grouping: (name, arch).
+
+    Grouping by name alone collapses every multi-arch package
+    (``glibc.x86_64`` + ``glibc.i686``) and multi-version package, producing
+    spurious or missed updates. ``arch`` lives under ``arch`` (rpm) or
+    ``architecture`` (deb/apk); helm charts have none (-> "").
+    """
+    md = pkg.content_metadata or {}
+    return (pkg.name, md.get("arch") or md.get("architecture") or "")
+
+
+def _diff_package_sets(
+    packages1: dict[str, ContentItem], packages2: dict[str, ContentItem]
+) -> tuple[list[ContentItem], list[ContentItem], list[tuple[ContentItem, ContentItem]]]:
+    """Classify two sha256-keyed package sets into (added, removed, updated).
+
+    A package is *updated* when the same ``(name, arch)`` exists in both sets
+    with different content (sha256); such pairs are excluded from added/removed.
+    """
+    added_sha256s = set(packages2) - set(packages1)
+    removed_sha256s = set(packages1) - set(packages2)
+
+    by_ident1 = {_package_ident(pkg): pkg for pkg in packages1.values()}
+    by_ident2 = {_package_ident(pkg): pkg for pkg in packages2.values()}
+
+    updated: list[tuple[ContentItem, ContentItem]] = []
+    for ident in by_ident1.keys() & by_ident2.keys():
+        pkg1, pkg2 = by_ident1[ident], by_ident2[ident]
+        if pkg1.sha256 != pkg2.sha256:
+            updated.append((pkg1, pkg2))
+            added_sha256s.discard(pkg2.sha256)
+            removed_sha256s.discard(pkg1.sha256)
+
+    added = sorted((packages2[s] for s in added_sha256s), key=lambda p: p.name)
+    removed = sorted((packages1[s] for s in removed_sha256s), key=lambda p: p.name)
+    updated.sort(key=lambda p: p[0].name)
+    return added, removed, updated
 
 
 def create_snapshot_group(cli: click.Group) -> click.Group:
@@ -212,38 +252,8 @@ def create_snapshot_group(cli: click.Group) -> click.Group:
                 packages2 = {pkg.sha256: pkg for pkg in snap2.content_items}
                 comparison_name = snapshot2
 
-            # Calculate differences
-            added_sha256s = set(packages2.keys()) - set(packages1.keys())
-            removed_sha256s = set(packages1.keys()) - set(packages2.keys())
-
-            # Find updated packages (same name, different version)
-            # Group packages by name for easier comparison
-            packages1_by_name = {}
-            for pkg in packages1.values():
-                packages1_by_name[pkg.name] = pkg
-
-            packages2_by_name = {}
-            for pkg in packages2.values():
-                packages2_by_name[pkg.name] = pkg
-
-            # Find packages with same name but different SHA256 (= different version)
-            updated = []
-            for name in packages1_by_name.keys() & packages2_by_name.keys():
-                pkg1 = packages1_by_name[name]
-                pkg2 = packages2_by_name[name]
-                if pkg1.sha256 != pkg2.sha256:
-                    updated.append((pkg1, pkg2))
-                    # Remove from added/removed since they're updates
-                    added_sha256s.discard(pkg2.sha256)
-                    removed_sha256s.discard(pkg1.sha256)
-
-            added = [packages2[sha] for sha in added_sha256s]
-            removed = [packages1[sha] for sha in removed_sha256s]
-
-            # Sort for consistent output
-            added.sort(key=lambda p: p.name)
-            removed.sort(key=lambda p: p.name)
-            updated.sort(key=lambda p: p[0].name)
+            # Calculate differences (added / removed / updated).
+            added, removed, updated = _diff_package_sets(packages1, packages2)
 
             # Output
             if output_format == "json":

--- a/tests/test_snapshot_delete.py
+++ b/tests/test_snapshot_delete.py
@@ -1,0 +1,88 @@
+"""snapshot delete must refuse to orphan a view snapshot.
+
+``ViewSnapshot.snapshot_ids`` is a plain JSON list of ``Snapshot.id`` with no
+foreign key or cascade. Deleting a referenced snapshot would silently leave a
+dangling reference that breaks the view snapshot when it is published, so the
+delete command must refuse (unless ``--force``).
+"""
+
+from __future__ import annotations
+
+import yaml
+from click.testing import CliRunner
+
+from chantal.cli.main import cli
+from chantal.db.connection import DatabaseManager
+from chantal.db.models import Base, Repository, Snapshot, View, ViewSnapshot
+
+
+def _config(tmp_path, db_url):
+    cfg = {
+        "database": {"url": db_url},
+        "storage": {
+            "base_path": str(tmp_path / "data"),
+            "pool_path": str(tmp_path / "data" / "pool"),
+            "published_path": str(tmp_path / "published"),
+        },
+        "repositories": [{"id": "repo", "type": "rpm", "feed": "http://x"}],
+    }
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return str(p)
+
+
+def _seed(db_url):
+    """A repo with one snapshot referenced by a view snapshot."""
+    dbm = DatabaseManager(db_url)
+    Base.metadata.create_all(dbm.engine)
+    session = dbm.get_session()
+    repo = Repository(repo_id="repo", name="R", type="rpm", feed="http://x", mode="MIRROR")
+    session.add(repo)
+    session.flush()
+    snap = Snapshot(repository_id=repo.id, name="2026-01-01")
+    session.add(snap)
+    session.flush()
+    view = View(name="prod", repo_type="rpm")
+    session.add(view)
+    session.flush()
+    vs = ViewSnapshot(view_id=view.id, name="release-1", snapshot_ids=[snap.id])
+    session.add(vs)
+    session.commit()
+    snap_id = snap.id
+    session.close()
+    return snap_id
+
+
+def test_delete_refuses_when_referenced_by_view_snapshot(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    snap_id = _seed(db_url)
+    cfg = _config(tmp_path, db_url)
+
+    result = CliRunner().invoke(
+        cli, ["--config", cfg, "snapshot", "delete", "--repo-id", "repo", "2026-01-01"]
+    )
+
+    # Refused, with a helpful message naming the referencing view snapshot...
+    assert result.exit_code != 0
+    assert "referenced by" in result.output
+    assert "release-1" in result.output
+    # ...and the snapshot is still present (no dangling reference created).
+    session = DatabaseManager(db_url).get_session()
+    assert session.query(Snapshot).filter_by(id=snap_id).first() is not None
+    session.close()
+
+
+def test_force_deletes_referenced_snapshot(tmp_path):
+    db_url = f"sqlite:///{tmp_path / 'chantal.db'}"
+    snap_id = _seed(db_url)
+    cfg = _config(tmp_path, db_url)
+
+    result = CliRunner().invoke(
+        cli,
+        ["--config", cfg, "snapshot", "delete", "--repo-id", "repo", "2026-01-01", "--force"],
+    )
+
+    assert result.exit_code == 0
+    session = DatabaseManager(db_url).get_session()
+    assert session.query(Snapshot).filter_by(id=snap_id).first() is None
+    session.close()

--- a/tests/test_snapshot_diff.py
+++ b/tests/test_snapshot_diff.py
@@ -1,0 +1,53 @@
+"""snapshot diff must distinguish architectures, not collapse by name.
+
+Grouping by name alone reports a per-arch update as a spurious add+remove and
+can miss/duplicate updates on multi-arch (and multi-version) repositories.
+"""
+
+from __future__ import annotations
+
+from chantal.cli.snapshot_commands import _diff_package_sets
+from chantal.db.models import ContentItem
+
+
+def _pkg(name: str, arch: str, sha: str) -> ContentItem:
+    return ContentItem(
+        content_type="rpm",
+        name=name,
+        version="1.0",
+        sha256=sha,
+        size_bytes=1,
+        pool_path=f"{sha[:2]}/{sha[2:4]}/{name}.rpm",
+        filename=f"{name}.rpm",
+        content_metadata={"arch": arch},
+    )
+
+
+def test_diff_distinguishes_arches():
+    a, b, c = "a" * 64, "b" * 64, "c" * 64
+    # x86_64 changed (a -> c); i686 unchanged (b in both).
+    snap1 = {a: _pkg("foo", "x86_64", a), b: _pkg("foo", "i686", b)}
+    snap2 = {c: _pkg("foo", "x86_64", c), b: _pkg("foo", "i686", b)}
+
+    added, removed, updated = _diff_package_sets(snap1, snap2)
+
+    # Name-only grouping would leak the x86_64 change into added+removed; per-arch
+    # grouping reports it as a single update and the i686 as unchanged.
+    assert added == []
+    assert removed == []
+    assert len(updated) == 1
+    old, new = updated[0]
+    assert old.content_metadata["arch"] == "x86_64"
+    assert old.sha256 == a and new.sha256 == c
+
+
+def test_diff_added_and_removed():
+    a, b = "a" * 64, "b" * 64
+    snap1 = {a: _pkg("foo", "x86_64", a)}
+    snap2 = {b: _pkg("bar", "x86_64", b)}
+
+    added, removed, updated = _diff_package_sets(snap1, snap2)
+
+    assert [p.name for p in added] == ["bar"]
+    assert [p.name for p in removed] == ["foo"]
+    assert updated == []


### PR DESCRIPTION
Two related correctness fixes in the snapshot CLI.

## 1. Diff by `(name, arch)`, not name alone

`chantal snapshot diff` grouped packages by name alone. On multi-arch repositories this collapses distinct architectures (e.g. `foo.x86_64` and `foo.i686`) into one entry, so a per-arch update is misreported as a spurious **add + remove**, and a real update on one arch can be hidden by an unchanged package of the same name on another arch.

Fix: group by `(name, arch)`, reading `content_metadata['arch']` (rpm) or `['architecture']` (deb/apk). Logic extracted into `_diff_package_sets` / `_package_ident` helpers.

Test `test_snapshot_diff.py::test_diff_distinguishes_arches`: under the old grouping yields added=1/removed=1/updated=0; asserts added==[]/removed==[]/updated==1, so it fails without the fix.

## 2. Refuse delete when referenced by a view snapshot

`ViewSnapshot.snapshot_ids` is a plain JSON list of `Snapshot.id` with **no foreign key or cascade**. Deleting a referenced snapshot silently left a dangling reference that breaks the view snapshot when it is published.

Fix: `snapshot delete` now scans for any view snapshot referencing the target and refuses with a message naming the offending view snapshot(s), unless `--force` is given (mirroring the existing `is_published` guard).

Test `test_snapshot_delete.py`: without the guard the delete returns exit 0 and orphans the view snapshot; the test asserts the delete is refused and the snapshot survives, plus that `--force` still deletes.